### PR TITLE
version bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "OMERO.iviewer",
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.config.js --hot --inline --progress --devtool eval",

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,9 @@
   </head>
 
   <body class="container-fluid">
-      <script type="text/javascript" src="{% static 'omero_iviewer/bundle1.0.0.js' %}"></script>
+      <script type="text/javascript"
+              src="{% static 'omero_iviewer/bundle.js' %}">
+      </script>
   </body>
 
 </html>

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, 'build'),
-    filename: 'bundle' + pkg.version + '.js',
+    filename: 'bundle.js',
     publicPath: '/static/omero_iviewer/'
   },
   plugins: [


### PR DESCRIPTION
The built js referenced in the html is at the moment hard-coded (incl. a version name based on package.info) which can break things with version bumping.

Given that releases happen via pypi and code is tagged appropriately with each release, the need to have yet another version to maintain within the java script is obsolete. 

Therefore the version in package info was set to 0.0.0 and the webpack config does not include any version number in the built js file name.
