### PR TITLE
open_with fix

### DIFF
--- a/src/openwith.js
+++ b/src/openwith.js
@@ -1,3 +1,3 @@
-OME.setOpenWithUrlProvider("omero_iviewer", function(selected, url) {
+OME.setOpenWithUrlProvider("OMERO.iviewer", function(selected, url) {
     return url + selected[0].id + "/";
 });


### PR DESCRIPTION
This fixes the "Open with" that was broken due to the changing of Label in Open_with menu.

To test:
 - setup open_with (if not done already) as described on https://github.com/ome/omero-iviewer/tree/master/plugin/omero_iviewer (uses label "OMERO.iviewer"), restart web etc.
 - Right-click menu in Tree, Open_with > OMERO.iviewer  should open iviewer in a new window with the selected image.
cc @waxenegger 