### PR TITLE
title supposed to show iViewer: image name

### DIFF
--- a/src/app/header.js
+++ b/src/app/header.js
@@ -94,13 +94,13 @@ export class Header extends EventSubscriber {
      */
      onImageConfigChange(params = {}) {
          let conf = this.context.getImageConfig(params.config_id);
+
          this.setTitle(
              conf && conf.image_info && conf.image_info.image_name ?
                 conf.image_info.image_name : null);
-         if (conf === null) return;
 
-         this.image_info =
-             this.context.getImageConfig(params.config_id).image_info;
+         if (conf === null) return;
+         this.image_info = conf.image_info;
 
          if (!this.image_info.has_scalebar) {
              this.context.show_scalebar = false;

--- a/src/app/header.js
+++ b/src/app/header.js
@@ -5,6 +5,7 @@ require('../css/images/close.gif');
 import {inject,customElement} from 'aurelia-framework';
 import Context from './context';
 import Misc from '../utils/misc';
+import {APP_NAME} from '../utils/constants';
 import {
     IMAGE_CONFIG_UPDATE,
     IMAGE_VIEWER_SCALEBAR,
@@ -92,7 +93,12 @@ export class Header extends EventSubscriber {
      * @param {Object} params the event notification parameters
      */
      onImageConfigChange(params = {}) {
-         if (this.context.getImageConfig(params.config_id) === null) return;
+         let conf = this.context.getImageConfig(params.config_id);
+         this.setTitle(
+             conf && conf.image_info && conf.image_info.image_name ?
+                conf.image_info.image_name : null);
+         if (conf === null) return;
+
          this.image_info =
              this.context.getImageConfig(params.config_id).image_info;
 
@@ -178,6 +184,22 @@ export class Header extends EventSubscriber {
                         {config_id : ctx.id, split : makeSplit});
           }
       }
+
+    /**
+    * Will set the title of the window
+    *
+    * @param {string} title the title
+    * @param {boolean} use_app_prefix if true we prefix with the app name
+    * @memberof Header
+    */
+    setTitle(title = null, use_app_prefix = true) {
+        if (typeof use_app_prefix !== 'boolean') use_app_prefix = true;
+        let actTitle = use_app_prefix ? APP_NAME : '';
+        if (typeof title === 'string')
+        actTitle =
+            (actTitle.length > 0 ? actTitle + ": " : actTitle) + title;
+        document.title = actTitle;
+    }
 
     /**
      * Overridden aurelia lifecycle method:

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -16,7 +16,7 @@
              'IMAGE_ID' : 208443};
       </script>
 
-      <title>Viewer NG</title>
+      <title>iViewer</title>
   </head>
 
   <body class="container-fluid"></body>

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
         {% endfor %}
       </script>
 
-      <title>Viewer NG</title>
+      <title>iViewer</title>
   </head>
 
   <body class="container-fluid">

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -55,6 +55,13 @@ export default class ImageInfo {
     author = null;
 
     /**
+     * the imageName in the json response
+     * @memberof ImageInfo
+     * @type {string}
+     */
+    image_name = null;
+
+    /**
      * a flag for whether we are allowed to save the settings
      * @memberof ImageInfo
      * @type {boolean}
@@ -267,6 +274,8 @@ export default class ImageInfo {
         this.can_save_settings = response.perms.canAnnotate;
         if (typeof response.meta.imageAuthor === 'string')
             this.author = response.meta.imageAuthor;
+        if (typeof response.meta.imageName === 'string')
+            this.image_name = response.meta.imageName;
         this.sanityCheckInitialValues();
 
         // signal that we are ready and

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,12 @@
 import {noView} from 'aurelia-framework';
 
 /**
+ * the app name
+ * @type {string}
+ */
+export const APP_NAME = 'iViewer';
+
+/**
  * the possible request params that we accept
  * @type {Object}
  */


### PR DESCRIPTION
Analog to the present web viewer the title now reflects the image name of the image viewer, prefixed with "iViewer".

![image](https://cloud.githubusercontent.com/assets/1559229/21007464/b1b8369a-bd88-11e6-98b9-bc8c35a5a564.png)
