### PR TITLE
open with parent

### DIFF
--- a/src/openwith.js
+++ b/src/openwith.js
@@ -1,3 +1,20 @@
 OME.setOpenWithUrlProvider("omero_iviewer", function(selected, url) {
-    return url + selected[0].id + "/";
+	// Add image Id to url
+	url += selected[0].id + "/";
+
+	// We try to traverse the jstree, to find parent of selected image
+	if ($ && $.jstree) {
+		try {
+			var inst = $.jstree.reference('#dataTree');
+			var parent = OME.getTreeImageContainerBestGuess(selected[0].id);
+			if (parent && parent.data) {
+				if (parent.type === 'dataset' || parent.type === 'tag') {
+					url += '?' + parent.type + '=' + parent.data.id;
+				}
+			}
+		} catch(err) {
+			console.log(err);
+		}
+	}
+    return url;
 });


### PR DESCRIPTION
To allow the viewer to know the container (dataset or tag) that the image was in when opened,
we try to traverse the jsTree in the openwith.js to get the selected image's parent.

Then we can add ?dataset=1 or ?tag=2 to the iviewer url.
The viewer could then show thumbnails from this container, even if the image is in multiple Datasets.

The Javascript code tests for presence of jsTree, since this may not be present (E.g. when used in OMERO.figure). Also uses try/catch to be safe (E.g. won't fail if global ```OME.getTreeImageContainerBestGuess``` is not found or causes exception).

We have previously discussed this strategy with @chris-allan for use with path-viewer.

To test:
 - Open with > OMERO.iviewer
 - Url should include ```?dataset=<datasetId> or ?tag=<tagId>```

:NB this will conflict with #5 until that is merged etc.