### PR TITLE
Right panel styling

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -64,6 +64,9 @@ a.ui-button:active,
 .ui-icon-triangle-1-s,.ui-icon-triangle-1-n {
     height: 100%;
 }
+.full-width {
+    width: 100%;
+}
 /** JQUERY UI adjustments END **/
 
 /** SPECTRUM colorpicker adjustments START **/
@@ -283,11 +286,6 @@ thumbnail-slider img {
     height: 30px;
     margin-left: 2px;
     margin-right: 0px;
-}
-
-.right-hand-panel * {
-    padding-left: 0px;
-    padding-right: 0px;
 }
 
 .left-hand-panel-hidden {

--- a/src/settings/channel-settings.html
+++ b/src/settings/channel-settings.html
@@ -2,7 +2,7 @@
         <require from="./channel-range"></require>
 
         <div repeat.for="channel of image_config.image_info.channels"
-            class="col-xs-12 row">
+            class="full-width row">
 
             <button type="button"
                 title="${channel.label}"

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -2,7 +2,7 @@
     <require from="../utils/converters"></require>
     <require from="./channel-settings"></require>
 
-    <div class="row save-settings">
+    <div class="btn-group" style="margin: 5px">
         <button type="button"
             disabled="${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings &&
@@ -23,7 +23,7 @@
         </button>
     </div>
 
-    <div class="row history">
+    <div class="btn-group" style="margin: 5px">
         <button type="button" click.delegate="undo()"
             disabled="${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer >= 0 ? '' : 'disabled'}"

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -8,7 +8,7 @@
                 image_config.image_info.can_save_settings &&
                 image_config.history.length > 0 && image_config.historyPointer >= 0 ?
                 '': 'disabled'}"
-            class="btn-xs ${image_config && image_config.image_info &&
+            class="btn btn-default btn btn-default btn-xs ${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings &&
                 image_config.history.length > 0 && image_config.historyPointer >= 0 ?
                 '' : 'disabled-color'}"
@@ -17,7 +17,7 @@
         <button type="button"
             disabled="${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings ? '': 'disabled'}"
-            class="btn-xs  ${image_config && image_config.image_info &&
+            class="btn btn-default btn-xs  ${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings ? '' : 'disabled-color'}"
             click.delegate="saveImageSettingsToAll()">Save to All
         </button>
@@ -27,17 +27,17 @@
         <button type="button" click.delegate="undo()"
             disabled="${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer >= 0 ? '' : 'disabled'}"
-            class="btn-xs  ${image_config && image_config.history.length > 0 &&
+            class="btn btn-default btn-xs  ${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer >= 0 ? '' : 'disabled-color'}">Undo</button>
         <button type="button" click.delegate="redo()"
             disabled="${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer < image_config.history.length-1 ? '' :'disabled'}"
-            class="btn-xs  ${image_config && image_config.history.length > 0 &&
+            class="btn btn-default btn-xs  ${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer < image_config.history.length-1 ?
                  '' : 'disabled-color'}">Redo</button>
-        <button type="button" click.delegate="copy()" class="btn-xs">Copy</button>
+        <button type="button" click.delegate="copy()" class="btn btn-default btn-xs">Copy</button>
         <button type="button"
-            class="btn-xs  ${image_config && image_config.image_info &&
+            class="btn btn-default btn-xs  ${image_config && image_config.image_info &&
                 image_config.image_info.copied_img_rdef &&
                 image_config.image_info.copied_img_rdef.imageId ===
                 image_config.image_info.image_id ? '' : 'disabled-color'}"
@@ -78,7 +78,7 @@
     </div>
 
     <div class="row" style="height: 100%">
-        <channel-settings class="col-xs-12" config_id.bind="config_id"></channel-settings>
+        <channel-settings class="full-width" config_id.bind="config_id"></channel-settings>
     </div>
 
     <div class="row">


### PR DESCRIPTION
Looking to improve the invisible text in disabled buttons on right panel.
Used more bootstrap styles.
Also put the buttons into a ```btn-group``` container.

Original panel width:
![screen shot 2016-12-09 at 13 51 56](https://cloud.githubusercontent.com/assets/900055/21051155/cc7a3df0-be16-11e6-83c3-b75eef8d5e7a.png)


Narrow panel (wraps to new row):
![screen shot 2016-12-09 at 12 37 56](https://cloud.githubusercontent.com/assets/900055/21049441/bdeaa91e-be0c-11e6-991e-81cfafbedd6c.png)

Without the ```btn-group``` (after first commit only):
![screen shot 2016-12-09 at 12 24 27](https://cloud.githubusercontent.com/assets/900055/21049458/d8baf820-be0c-11e6-8778-ae0e3906188e.png)

cc @waxenegger 