### PR TITLE
style improvements

### DIFF
--- a/src/app/header.html
+++ b/src/app/header.html
@@ -11,31 +11,30 @@
             </div>
         </div>
 
-        <div class="checkbox col-xs-6">
+        <div class="header-content col-xs-9">
             <button
-                disabled="disabled" class="btn-xs split_channels disabled-color"
+                disabled="disabled"
+                class="btn btn-default btn-sm split_channels disabled-color"
                 click.delegate="toggleSplitChannels()"
+                style="line-height: 20px;margin-bottom:5px"
                 value="normal">
                 Split Channels
             </button>
 
-            <label class="has_scalebar"><input type="checkbox"
-               checked.bind="context.show_scalebar"
-              change.delegate="toggleScalebar()">Show Scalebar</label>
-              <span>&nbsp;</span>
+            <label class="has_scalebar">
+                <input type="checkbox"
+                checked.bind="context.show_scalebar"
+                change.delegate="toggleScalebar()">&nbsp;Show Scalebar
+            </label>
 
             <label class="${image_info === null ||
                  image_info.projection === 'split' ? 'disabled-color' : ''}">
                  <input type="checkbox"
                         disabled.bind="image_info === null ||
                             image_info.projection === 'split'"
-                    class="${image_info === null ||
-                        image_info.projection === 'split' ? 'disabled-color' : ''}"
                checked.bind="context.show_regions"
-              change.delegate="toggleRegions()">Show ROIs</label>
+              change.delegate="toggleRegions()">&nbsp;Show ROIs</label>
 
         </div>
-
-        <div class="col-xs-3">&nbsp;</div>
     </nav>
 </template>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -64,9 +64,6 @@ a.ui-button:active,
 .ui-icon-triangle-1-s,.ui-icon-triangle-1-n {
     height: 100%;
 }
-.full-width {
-    width: 100%;
-}
 /** JQUERY UI adjustments END **/
 
 /** SPECTRUM colorpicker adjustments START **/
@@ -78,11 +75,11 @@ a.ui-button:active,
 }
 .color-range-spectrum-container {
     position: relative!important;
-    width: 176px;
+    width: 195px;
     height: 220px;
     right: 100px;
     top: 12px!important;
-    left: -150px!important;
+    left: -180px!important;
 }
 .shape-fill-color-replacer .sp-preview {
     margin-left: 2px;
@@ -99,12 +96,26 @@ a.ui-button:active,
 }
 .color-spectrum-container {
     position: absolute!important;
-    width: 186px;
+    width: 195px;
     height: 270px;
     top: 100px!important;
     left: 10px!important;
     line-height: 30px;
 }
+.color-spectrum-container .sp-picker-container {
+    padding: 4px;
+    width: 184px;
+}
+.color-spectrum-container .sp-input-container {
+    width: 135px;
+}
+.color-spectrum-container .sp-thumb {
+    width: 42px;
+}
+.color-spectrum-container span {
+    width: 21px;
+}
+
 .color-spectrum-container span {
     background-image: none;
 }
@@ -116,9 +127,20 @@ a.ui-button:active,
 /** SPECTRUM colorpicker adjustments END **/
 
 .disabled-color {
-    color: #c0c0c0!important;
+    cursor:not-allowed;
+    filter:alpha(opacity=65);
+    -webkit-box-shadow:none;
+    box-shadow:none;
+    opacity:.65;
 }
-
+.header-content {
+    height: 40px;
+}
+.header-content label {
+    margin-left: 5px;
+    line-height: 40px;
+    font-weight: normal;
+}
 .link-url {
     height: 40px;
 }
@@ -282,8 +304,8 @@ thumbnail-slider img {
 .right-hand-panel .row {
     min-width: 350px;
     max-width: 800px;
-    line-height: 30px;
     height: 30px;
+    margin-bottom: 2px;
     margin-left: 2px;
     margin-right: 0px;
 }
@@ -330,10 +352,10 @@ thumbnail-slider img {
     background: #f8f8f8;
     border: 1px solid #000;
     display: none;
-    position: absolute;
+    position: relative;
     z-index: 1000;
-    top: 32px;
-    right: 5px;
+    top: 12px;
+    left: -230px;
     max-height: 250px;
     overflow-y: auto;
     width: 250px;
@@ -361,7 +383,15 @@ thumbnail-slider img {
     line-height: 13px;
     font-size: 13px;
 }
-
+.luts-color-picker {
+    margin-bottom: 5px;
+}
+.luts-color-picker .sp-replacer {
+    width: 145px;
+}
+.luts-color-picker .sp-preview {
+    width: 115px;
+}
 .channel-mode {
     margin-top: 2px;
     width: 100%;
@@ -599,14 +629,8 @@ thead, tbody {
     background-color: transparent;
 }
 
-.shapes-edit .edit-button {
-    line-height: 25px;
-    height: 28px;
-    width: 30px;
-    margin-left: 2px;
-}
 .shapes-edit .dropdown-menu {
-    left: -130px;
+    left: -55px;
 }
 .shapes-persistence div {
     float: left;
@@ -615,34 +639,44 @@ thead, tbody {
 .shape-fill-color, .shape-stroke-color {
     float: left;
     height: 32px;
-    margin-bottom: 2px;
-    margin-left: 2px;
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
 .shape-stroke-width, .shape-font-size {
+    margin-right: 5px;
     float: left;
     padding-top: 2px;
 }
 
 .shape-stroke-width .ui-spinner {
-    min-width: 30px;
-    max-width: 30px;
+    min-width: 50px;
+    max-width: 50px;
     line-height: 28px;
     height: 28px;
 }
 .shape-font-size .ui-spinner {
-    min-width: 38px;
-    max-width: 38px;
+    min-width: 50px;
+    max-width: 50px;
     line-height: 28px;
     height: 28px;
 }
 .shape-font-size span {
     max-width: 38px;
 }
-
+.shapes-edit {
+    line-height: 30px;
+    margin: 5px;
+}
+.shape-edit-button {
+    width: 100px;
+    margin-left: 5px;
+}
 .shape-edit-comment {
-    min-width: 110px;
-    width: 30%;
+    margin-left: 5px;
+    margin-right: 5px;
+    min-width: 100px;
+    width: 75%;
     float: left;
 }
 .shape-edit-comment input {
@@ -652,10 +686,12 @@ thead, tbody {
 }
 
 .arrow-button .dropdown-menu {
-    left: -20px;
+    left: -5px;
     min-width: 20px;
 }
-
+.regions-drawing-mode {
+    line-height: 30px;
+}
 .drawing-mode {
     float: left;
     margin-left: 2px;
@@ -681,7 +717,7 @@ thead, tbody {
 .regions-propagation-options input {
     float: left;
     height: 28px;
-    line-height: 28px;
+    line-height: 30px;
 }
 
 .regions-propagation-options .aligned-text-input {

--- a/src/regions/regions-drawing-mode.html
+++ b/src/regions/regions-drawing-mode.html
@@ -3,14 +3,16 @@
     <div style="min-width: 200px;">
         <span class="collapsible-regions-header">Drawing Mode & Propagation</span>
         <div click.delegate="toggleRegionsDrawingMode()"
-            class="regions-drawing-mode-toggler collapse-up"></div>
+            class="regions-drawing-mode-toggler collapse-up"
+            style="margin-right: 5px;">
+        </div>
     </div>
     <hr />
     <div class="regions-drawing-mode">
         <div class="drawing-mode">
             <input class='propagate-mode'
                 click.delegate="onDrawingModeChange(true,$event.target.checked)"
-                type="checkbox" />
+                type="checkbox" style="margin-top: 10px"/>
             <span>&nbsp;Propagate</span>
         </div>
         <div class="row regions-propagation-options">
@@ -70,7 +72,7 @@
             </div>
         </div>
         <div class="drawing-mode"><input class='viewed-mode'
-            checked="checked"
+            checked="checked" style="margin-top: 10px"
             click.delegate="onDrawingModeChange(false,$event.target.checked)"
                 type="checkbox" />
                 <span>&nbsp;Attach to viewed Z and T</span>

--- a/src/regions/regions-drawing.html
+++ b/src/regions/regions-drawing.html
@@ -3,6 +3,6 @@
         <div repeat.for="shape of supported_shapes"
             class="draw-icons draw-${shape}-icon
                 ${shape_to_be_drawn === shape ? 'draw-active' : 'draw-inactive'}"
-            click.delegate="onDrawShape($index)"/>
+            click.delegate="onDrawShape($index)" style="margin: 10px;"/>
     </div>
 </template>

--- a/src/regions/regions-edit.html
+++ b/src/regions/regions-edit.html
@@ -3,10 +3,10 @@
             <div class="shape-fill-color"><input class="spectrum-input"/></div>
             <div class="shape-stroke-color"><input class="spectrum-input"/></div>
             <div class="shape-stroke-width"><input /></div>
-            <div class="shape-edit-comment"><input value="Comment"/></div>
-            <div class="shape-font-size"><input /></div>
+
             <div class="dropdown rois-dropdown arrow-button">
-                <button type="button" class="btn-xs dropdown-toggle disabled-color"
+                <button type="button"
+                    class="btn btn-default btn-sm dropdown-toggle disabled-color"
                     disabled="disabled"
                 data-toggle="dropdown">&lt;-&gt;</button>
                 <ul class="dropdown-menu">
@@ -16,7 +16,8 @@
             </div>
 
             <div class="dropdown rois-dropdown">
-                <button type="button" class="btn-xs dropdown-toggle edit-button"
+                <button type="button"
+                    class="btn btn-default btn-sm dropdown-toggle shape-edit-button"
                 data-toggle="dropdown">Edit
                 </button>
                 <ul class="dropdown-menu">
@@ -31,6 +32,10 @@
                     <li click.delegate="setEditMode(true)"><a href="#">Modify</a></li>
                 </ul>
             </div>
+        </div>
+        <div class="row shapes-edit">
+            <div class="shape-edit-comment"><input value="Comment"/></div>
+            <div class="shape-font-size"><input /></div>
         </div>
     </div>
 </template>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -3,7 +3,9 @@
     <div style="min-width: 110px;">
         <span class="collapsible-regions-header">Shape List</span>
         <div click.delegate="toggleRegionsTable()"
-            class="regions-list-toggler collapse-up"></div>
+            class="regions-list-toggler collapse-up"
+            style="margin-right: 5px;">
+        </div>
     </div>
     <hr />
     <div class="row regions-list">

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -8,17 +8,15 @@
         regions_info !== null && regions_info.data !== null">
 
         <div class="row shapes-persistence" style="padding-top: 2px">
-            <div>
-                <button type="button" class="btn-xs"
+            <div class="btn-group" style="margin: 5px;">
+                <button type="button" class="btn btn-default btn-xs"
                     click.delegate="saveShapes()">Save
                 </button>
                 <button type="button"
                     disabled="${regions_info.history &&
                         regions_info.history.history.length > 0 &&
                          regions_info.history.historyPointer >= 0 ? '' : 'disabled'}"
-                    class="btn-xs  ${regions_info.history &&
-                        regions_info.history.history.length > 0 &&
-                        regions_info.history.historyPointer >= 0 ? '' : 'disabled-color'}"
+                    class="btn btn-default btn-xs"
                     click.delegate="undoHistory()">Undo
                 </button>
                 <button type="button"
@@ -27,17 +25,13 @@
                          regions_info.history.historyPointer <
                          regions_info.history.history.length-1 ?
                           '' :'disabled'}"
-                    class="btn-xs  ${regions_info.history &&
-                            regions_info.history.history.length > 0 &&
-                            regions_info.history.historyPointer <
-                            regions_info.history.history.length-1 ?
-                                '' : 'disabled-color'}"
+                    class="btn btn-default btn-xs"
                     click.delegate="redoHistory()">Redo
                 </button>
             </div>
 
-            <div class="dropdown rois-dropdown" style="margin-left: 5px;">
-                <button type="button" class="btn-xs dropdown-toggle"
+            <div class="dropdown rois-dropdown" style="margin: 5px;">
+                <button type="button" class="btn btn-default btn-xs dropdown-toggle"
                         data-toggle="dropdown">Delete
                 </button>
                 <ul class="dropdown-menu">
@@ -45,12 +39,12 @@
                                     regions_info.selected_shapes.length !== 0"
                         click.delegate="deleteShapes()"><a href="#">Delete</a></li>
                     <li click.delegate="deleteShapes(true)"><a href="#">Delete All</a></li>
-                    <!--li click.delegate="deleteShapes(true, true)"><a href="#">Undo All Deletes</a></li-->
                 </ul>
             </div>
 
             <div class="checkbox checkbox-settings" style="line-height: 20px;">
-                <label><input style="line-height: 20px;" type="checkbox"
+                <label>
+                    <input style="line-height: 20px;" type="checkbox"
                     change.delegate="showComments($event.target.checked)">
                     Show Comments
                 </label>

--- a/src/settings/channel-range.html
+++ b/src/settings/channel-range.html
@@ -28,7 +28,9 @@
                 </div>
             </div>
             <hr/>
-            <div>&nbsp;Pick Color:&nbsp;<input class="spectrum-input"/></div>
+            <div class="luts-color-picker">&nbsp;Pick Color:&nbsp;
+                <input class="spectrum-input" style="width:160px"/>
+            </div>
         </div>
     </div>
 </template>

--- a/src/settings/channel-settings.html
+++ b/src/settings/channel-settings.html
@@ -2,7 +2,7 @@
         <require from="./channel-range"></require>
 
         <div repeat.for="channel of image_config.image_info.channels"
-            class="full-width row">
+            class="row" style="float: left;">
 
             <button type="button"
                 title="${channel.label}"

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -2,45 +2,34 @@
     <require from="../utils/converters"></require>
     <require from="./channel-settings"></require>
 
-    <div class="btn-group" style="margin: 5px">
+    <div class="btn-group save-settings" style="margin: 5px">
         <button type="button"
             disabled="${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings &&
                 image_config.history.length > 0 && image_config.historyPointer >= 0 ?
                 '': 'disabled'}"
-            class="btn btn-default btn btn-default btn-xs ${image_config && image_config.image_info &&
-                image_config.image_info.can_save_settings &&
-                image_config.history.length > 0 && image_config.historyPointer >= 0 ?
-                '' : 'disabled-color'}"
+            class="btn btn-default btn-xs"
             click.delegate="saveImageSettings()">Save
         </button>
         <button type="button"
             disabled="${image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings ? '': 'disabled'}"
-            class="btn btn-default btn-xs  ${image_config && image_config.image_info &&
-                image_config.image_info.can_save_settings ? '' : 'disabled-color'}"
+            class="btn btn-default btn-xs"
             click.delegate="saveImageSettingsToAll()">Save to All
         </button>
     </div>
 
-    <div class="btn-group" style="margin: 5px">
+    <div class="btn-group history" style="margin: 5px">
         <button type="button" click.delegate="undo()"
             disabled="${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer >= 0 ? '' : 'disabled'}"
-            class="btn btn-default btn-xs  ${image_config && image_config.history.length > 0 &&
-                image_config.historyPointer >= 0 ? '' : 'disabled-color'}">Undo</button>
+            class="btn btn-default btn-xs">Undo</button>
         <button type="button" click.delegate="redo()"
             disabled="${image_config && image_config.history.length > 0 &&
                 image_config.historyPointer < image_config.history.length-1 ? '' :'disabled'}"
-            class="btn btn-default btn-xs  ${image_config && image_config.history.length > 0 &&
-                image_config.historyPointer < image_config.history.length-1 ?
-                 '' : 'disabled-color'}">Redo</button>
+            class="btn btn-default btn-xs">Redo</button>
         <button type="button" click.delegate="copy()" class="btn btn-default btn-xs">Copy</button>
-        <button type="button"
-            class="btn btn-default btn-xs  ${image_config && image_config.image_info &&
-                image_config.image_info.copied_img_rdef &&
-                image_config.image_info.copied_img_rdef.imageId ===
-                image_config.image_info.image_id ? '' : 'disabled-color'}"
+        <button type="button" class="btn btn-default btn-xs"
             disabled="${image_config && image_config.image_info &&
                 image_config.image_info.copied_img_rdef &&
                 image_config.image_info.copied_img_rdef.imageId ===
@@ -57,19 +46,17 @@
                Grayscale
            </label>
         </div>
-        <div class="col-xs-6
-                    ${image_config && image_config.image_info &&
-                        image_config.image_info.has_histogram
-                            ? '' : 'disabled-color'}">
-            <input type="checkbox"
-                class="${image_config && image_config.image_info &&
+        <div class="col-xs-6">
+            <label  class="${image_config && image_config.image_info &&
                     image_config.image_info.has_histogram
-                        ? '' : 'disabled-color'}"
+                        ? '' : 'disabled-color'}">
+            <input type="checkbox"
                 disabled="${image_config && image_config.image_info &&
                     image_config.image_info.has_histogram
-                        ? '' : 'disabled-color'}"
+                        ? '' : 'disabled'}"
                 change.delegate="toggleHistogram($event.target.checked)" />
-            &nbsp;Show Histogram
+            Show Histogram
+            </label>
         </div>
     </div>
 
@@ -78,7 +65,7 @@
     </div>
 
     <div class="row" style="height: 100%">
-        <channel-settings class="full-width" config_id.bind="config_id"></channel-settings>
+        <channel-settings config_id.bind="config_id"></channel-settings>
     </div>
 
     <div class="row">


### PR DESCRIPTION
This is a follow up for https://github.com/ome/omero-iviewer/pull/9.

It uses bootstrap styling for the buttons in the regions tab of the right hand panel, refactors some styling in the header and fixes a problem that slipped in with the previous PR. 

For future reviewing and comparison, this is what it looked like before:

![old_style](https://cloud.githubusercontent.com/assets/1559229/21268513/6f6b7c2a-c3af-11e6-8720-14b77287a912.png)

Note: to be able to get to the roi tab, you'll have to check "Show ROIs" in the header section of the page.