### PR TITLE
Channel Settings: add colors to selection before luts list

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -360,6 +360,10 @@ thumbnail-slider img {
     overflow-y: auto;
     width: 250px;
 }
+.luts-title {
+    text-align: center;
+    font-weight: bold;
+}
 .luts-close {
     position: absolute;
     top: 2px;

--- a/src/settings/channel-range.html
+++ b/src/settings/channel-range.html
@@ -7,10 +7,11 @@
             click.delegate="showLuts()"/>
         <div class="luts">
             <img class="luts-close" src="../css/images/close.gif"/>
-            <div>Lookup Tables</div>
+            <div class="luts-title">Colors &amp; Lookup Tables</div>
             <hr/>
             <div
-                class="${channel.reverseIntensity === null ? 'disabled-color' : ''}">
+                class="${channel.reverseIntensity === null ? 'disabled-color' : ''}"
+                style="margin-left: 2px;">
                 <input type="checkbox"
                 disabled.bind="channel.reverseIntensity === null"
                 class="${channel.reverseIntensity === null ? 'disabled-color' : ''}"

--- a/src/settings/channel-range.html
+++ b/src/settings/channel-range.html
@@ -19,6 +19,34 @@
                 &nbsp;Reverse Intensity
             </div>
             <hr/>
+            <div class="luts-preview luts-item" style="background-color: #FF0000"
+                click.delegate="chooseLut('#FF0000')">
+                <div class="luts-name">red</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #00FF00"
+                click.delegate="chooseLut('#00FF00')">
+                <div class="luts-name">green</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #0000FF"
+                click.delegate="chooseLut('#0000FF')">
+                <div class="luts-name">blue</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #FFFFFF"
+                click.delegate="chooseLut('#FFFFFF')">
+                <div class="luts-name">white</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #FFFF00"
+                click.delegate="chooseLut('#FFFF00')">
+                <div class="luts-name">yellow</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #FF00FF"
+                click.delegate="chooseLut('#FF00FF')">
+                <div class="luts-name">magenta</div>
+            </div>
+            <div class="luts-preview luts-item" style="background-color: #00FFFF"
+                click.delegate="chooseLut('#00FFFF')">
+                <div class="luts-name">cyan</div>
+            </div>
             <div class="luts-item" repeat.for="[id, lut] of luts"
                 click.delegate="chooseLut(id)">
                 <div class="luts-preview" css="background-image:


### PR DESCRIPTION
When selecting a color or lookup for a channel, the list that shows did so far only comprise the lookup entries, as well as an opion to open the color picker.

To be in synch with the standard web viewer, the colors red, green, blue, white, yellow, magenta, cyan have been added to the selection list prior to the luts entries.

![luts](https://cloud.githubusercontent.com/assets/1559229/21386947/b12f6e18-c775-11e6-92d2-addfe4b73cb8.png)
