### PR TITLE
enable copy & paste of rnd settings for compatible images

### DIFF
--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -321,6 +321,17 @@ export default class ImageInfo {
      * @memberof ImageInfo
      */
     requestImgRDef(callback = null) {
+        if (callback === null)
+            callback = (rdef) => {
+                if (rdef === null || typeof rdef.c !== 'string') return;
+                let channels = Misc.parseChannelParameters(rdef.c);
+                // we only allow copy and paste with same number of channels
+                // and compatible range
+                if (!Misc.isArray(channels) ||
+                        channels.length != this.channels.length ||
+                        rdef.pixel_range != this.range.join(":"))
+                            this.copied_img_rdef = null;
+            }
         $.ajax({
             url : this.context.server +
                     this.context.getPrefixedURI(WEBGATEWAY) +
@@ -330,9 +341,7 @@ export default class ImageInfo {
             success : (response) => {
                 if (typeof response !== 'object' || response === null ||
                     typeof response.rdef !== 'object' ||
-                    response.rdef === null ||
-                    typeof response.rdef.imageId !== 'number' ||
-                    response.rdef.imageId !== this.image_id)
+                    response.rdef === null)
                         this.copied_img_rdef = null;
                 else this.copied_img_rdef = response.rdef;
                 if (typeof callback === 'function')

--- a/src/settings/channel-settings.js
+++ b/src/settings/channel-settings.js
@@ -260,6 +260,9 @@ export default class ChannelSettings extends EventSubscriber {
                     new_val: impImgData.c[index].color,
                     type: 'string'});
             // log reverse intensity
+            //(taking into account that it might not be supported)
+            if (typeof impImgData.c[index].reverseIntensity === 'undefined')
+                impImgData.c[index].reverseIntensity = null;
             if (chan.reverseIntensity !== impImgData.c[index].reverseIntensity)
                history.push({
                    prop: ['image_info', 'channels', '' + index, 'reverseIntensity'],

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -31,9 +31,7 @@
         <button type="button" click.delegate="copy()" class="btn btn-default btn-xs">Copy</button>
         <button type="button" class="btn btn-default btn-xs"
             disabled="${image_config && image_config.image_info &&
-                image_config.image_info.copied_img_rdef &&
-                image_config.image_info.copied_img_rdef.imageId ===
-                image_config.image_info.image_id ? '' : 'disabled'}"
+                image_config.image_info.copied_img_rdef ? '' : 'disabled'}"
             click.delegate="paste()">Paste</button>
     </div>
 

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -4,16 +4,15 @@
 
     <div class="btn-group save-settings" style="margin: 5px">
         <button type="button"
-            disabled="${image_config && image_config.image_info &&
+            disabled.bind="!(image_config && image_config.image_info &&
                 image_config.image_info.can_save_settings &&
-                image_config.history.length > 0 && image_config.historyPointer >= 0 ?
-                '': 'disabled'}"
+                image_config.history.length > 0 && image_config.historyPointer >= 0)"
             class="btn btn-default btn-xs"
             click.delegate="saveImageSettings()">Save
         </button>
         <button type="button"
-            disabled="${image_config && image_config.image_info &&
-                image_config.image_info.can_save_settings ? '': 'disabled'}"
+            disabled.bind="!(image_config && image_config.image_info &&
+                image_config.image_info.can_save_settings)"
             class="btn btn-default btn-xs"
             click.delegate="saveImageSettingsToAll()">Save to All
         </button>
@@ -21,17 +20,17 @@
 
     <div class="btn-group history" style="margin: 5px">
         <button type="button" click.delegate="undo()"
-            disabled="${image_config && image_config.history.length > 0 &&
-                image_config.historyPointer >= 0 ? '' : 'disabled'}"
+            disabled.bind="!(image_config && image_config.history.length > 0 &&
+                image_config.historyPointer >= 0)"
             class="btn btn-default btn-xs">Undo</button>
         <button type="button" click.delegate="redo()"
-            disabled="${image_config && image_config.history.length > 0 &&
-                image_config.historyPointer < image_config.history.length-1 ? '' :'disabled'}"
+            disabled.bind="!(image_config && image_config.history.length > 0 &&
+                image_config.historyPointer < image_config.history.length-1)"
             class="btn btn-default btn-xs">Redo</button>
         <button type="button" click.delegate="copy()" class="btn btn-default btn-xs">Copy</button>
         <button type="button" class="btn btn-default btn-xs"
-            disabled="${image_config && image_config.image_info &&
-                image_config.image_info.copied_img_rdef ? '' : 'disabled'}"
+            disabled.bind="!(image_config && image_config.image_info &&
+                image_config.image_info.copied_img_rdef)"
             click.delegate="paste()">Paste</button>
     </div>
 
@@ -45,13 +44,11 @@
            </label>
         </div>
         <div class="col-xs-6">
-            <label  class="${image_config && image_config.image_info &&
-                    image_config.image_info.has_histogram
-                        ? '' : 'disabled-color'}">
+            <label class="${image_config && image_config.image_info &&
+                    image_config.image_info.has_histogram ? '' : 'disabled-color'}">
             <input type="checkbox"
-                disabled="${image_config && image_config.image_info &&
-                    image_config.image_info.has_histogram
-                        ? '' : 'disabled'}"
+                disabled.bind="!(image_config && image_config.image_info &&
+                    image_config.image_info.has_histogram)"
                 change.delegate="toggleHistogram($event.target.checked)" />
             Show Histogram
             </label>

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -288,7 +288,10 @@ export default class Settings extends EventSubscriber {
         imgInf.channels.map(
             (c) =>
                 url+= (i !== 0 ? ',' : '') + (!c.active ? '-' : '') + (++i) +
-                 "|" + c.window.start + ":" + c.window.end + "$" + c.color);
+                 "|" + c.window.start + ":" + c.window.end +
+                    (typeof c.reverseIntensity === 'boolean' ?
+                        (c.reverseIntensity ? 'r' : '-r') : '') +
+                 "$" + c.color);
 
         // save to all differs from copy in that it is a POST with data
         // instead of a JSON(P) GET, as well as the success handler
@@ -407,6 +410,19 @@ export default class Settings extends EventSubscriber {
                        new_val: newColor,
                        type: 'string'});
                     actChannel.color = copiedChannel.color;
+                }
+                if (typeof copiedChannel.reverseIntensity === 'undefined')
+                    copiedChannel.reverseIntensity = null;
+                if (actChannel.reverseIntensity !==
+                        copiedChannel.reverseIntensity) {
+                            history.push({
+                                prop: ['image_info',
+                                    'channels', '' + i, 'reverseIntensity'],
+                                old_val : actChannel.reverseIntensity,
+                                new_val: copiedChannel.reverseIntensity,
+                                type: 'boolean'});
+                    actChannel.reverseIntensity =
+                        copiedChannel.reverseIntensity;
                 }
             };
         if (history.length > 0) {


### PR DESCRIPTION
According to https://trello.com/c/HYnRRhE8/243-review-first-round the pasting of copied rendering settings should not be restricted to the same image only but instead to compatible ones whereby compatible is defined to be equal number of channels and data type/range.

This PR aims to remove that restriction, including reverse intensity into the copy & pasting as well.



Test: 

Choose a dataset that has compatible images (i.e. same number of channels + pixel range) and you should be able to paste after you have done a copy on one of the.