### PR TITLE
bugfix: undo of the deletion of newly drawn shapes

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1457,7 +1457,9 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
     if (ome.ol3.utils.Misc.isArray(ids) && ids.length > 0 && this.regions_.idIndex_) {
         col = new ol.Collection();
         for (var id in ids)
-            if (this.regions_.idIndex_[ids[id]] instanceof ol.Feature)
+            if (this.regions_.idIndex_[ids[id]] instanceof ol.Feature &&
+                    this.regions_.idIndex_[ids[id]]['state'] !==
+                        ome.ol3.REGIONS_STATE.REMOVED)
                 col.push(this.regions_.idIndex_[ids[id]]);
     }
 

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -745,22 +745,6 @@ ome.ol3.source.Regions.prototype.setProperty =
                     eventProperty = "rollback";
             }
 
-            // in the case where we are deleting a newly added shape
-            // we remove it altogether
-            if (property === 'state' &&
-                    value === ome.ol3.REGIONS_STATE.REMOVED &&
-                (presentState === ome.ol3.REGIONS_STATE.ADDED ||
-                    (presentState === ome.ol3.REGIONS_STATE.MODIFIED &&
-                        typeof this.idIndex_[s]["old_state"] === 'number' &&
-                        this.idIndex_[s]["old_state"]  ===
-                            ome.ol3.REGIONS_STATE.ADDED))) {
-                    this.removeFeature(this.idIndex_[s]);
-                    changedFeatures.push(s);
-                    changedProperties.push("deleted");
-                    changedValues.push(true);
-                    continue;
-            }
-
             // set new value
             this.idIndex_[s][property] =
                 (property === 'state' && value === ome.ol3.REGIONS_STATE.ROLLBACK) ?

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -694,7 +694,7 @@ ome.ol3.utils.Conversion.toJsonObject = function(
 
         // we don't want newly added but immediately deleted shapes
         if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED &&
-                shapeId < 0) continue;
+                roiId < 0) continue;
 
 		// now that we have the roi and shape id we check whether we have them in
 		// our associative array already or we need to create it yet

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -174,9 +174,6 @@ export default class RegionsInfo extends EventSubscriber {
             let i = this.selected_shapes.indexOf(id);
             if (i !== -1) this.selected_shapes.splice(i, 1);
         }
-        // for deleted shapes that were new, we remove them instantly
-        if (property === 'deleted' && value &&
-                typeof shape.is_new !== 'undefined') this.data.delete(id);
     }
 
     /**
@@ -467,23 +464,13 @@ export class History {
                 let generate = undo ? rec.old_vals : rec.new_vals;
                 if (generate) { // we recreate them
                     rec.diffs.map((shape) => {
-                        let isNew =
-                            typeof shape.is_new === 'boolean' && shape.is_new;
-                        if (!isNew && shape.deleted)
-                            imgInfo.context.publish(
-                                REGIONS_SET_PROPERTY,
-                                    {config_id : imgInfo.config_id,
-                                        property: 'state',
-                                        shapes : [shape.shape_id],
-                                        value: 'undo'});
-                        else
-                            imgInfo.context.publish(
-                                REGIONS_GENERATE_SHAPES,
+                        imgInfo.context.publish(
+                            REGIONS_SET_PROPERTY,
                                 {config_id : imgInfo.config_id,
-                                 shapes : [shape], number : 1, random : false,
-                                 theDims : [{z: shape.theZ, t: shape.theT}],
-                                 add_history : false})
-                         });
+                                    property: 'state',
+                                    shapes : [shape.shape_id],
+                                    value: 'undo'});
+                    });
                 } else { // we delete them
                     let ids = [];
                     rec.diffs.map((shape) => ids.push(shape.shape_id));

--- a/src/regions/regions-drawing-mode.js
+++ b/src/regions/regions-drawing-mode.js
@@ -147,26 +147,26 @@ export default class RegionsDrawingMode {
      */
     propagateSelectedShapes() {
         let hist_id = this.regions_info.history.getHistoryId();
-        let roi_id = this.regions_info.getNewRegionsId();
-        // we loop over all selected shapes and propagate them individually
-        // since they could be in different t/z so that the propagation won't
-        // be the same for each of them
-        this.regions_info.selected_shapes.map(
-            (id) => {
-                let shape =
-                    Object.assign({}, this.regions_info.data.get(id));
-                // collect dimensions for propagation
-                let theDims =
-                    Utils.getDimensionsForPropagation(
-                        this.regions_info, shape.theZ, shape.theT);
-                if (theDims.length > 0)
-                    this.context.publish(
-                        REGIONS_GENERATE_SHAPES,
-                        {config_id : this.regions_info.image_info.config_id,
-                            shapes : [shape],
-                            number : theDims.length, random : false,
-                            roi_id: roi_id, hist_id: hist_id,
-                            theDims : theDims, propagated: true});
-            });
+         let roi_id = this.regions_info.getNewRegionsId();
+         // we loop over all selected shapes and propagate them individually
+         // since they could be in different t/z so that the propagation won't
+         // be the same for each of them
+         this.regions_info.selected_shapes.map(
+             (id) => {
+                 let shape =
+                     Object.assign({}, this.regions_info.data.get(id));
+                 // collect dimensions for propagation
+                 let theDims =
+                     Utils.getDimensionsForPropagation(
+                         this.regions_info, shape.theZ, shape.theT);
+                 if (theDims.length > 0)
+                     this.context.publish(
+                         REGIONS_GENERATE_SHAPES,
+                         {config_id : this.regions_info.image_info.config_id,
+                             shapes : [shape],
+                             number : theDims.length, random : false,
+                             roi_id: roi_id, hist_id: hist_id,
+                             theDims : theDims, propagated: true});
+             });
     }
 }

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -24,6 +24,7 @@
         <table class="regions-table">
             <tbody>
                 <tr repeat.for="[id, shape] of regions_info.data"
+                    show.bind="!(shape.deleted && shape.is_new)"
                     id="${'roi-' + id}"
                     css="${shape.selected ?
                             'background-color: #d0d0ff;' : ''}

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -354,23 +354,25 @@ export default class Ol3Viewer extends EventSubscriber {
           params.shapes.map(
               (def) => {
                   try {
-                      let deepCopy = Object.assign({},def);
-                      // we are modified so let's update the definition
-                      // before we generate from it
-                      if (deepCopy.modified) {
-                          let upToDateDef =
-                            this.viewer.getShapeDefinition(deepCopy.shape_id);
-                          if (upToDateDef)
-                            deepCopy =
-                                Converters.makeShapeBackwardsCompatible(upToDateDef);
-                      }
-                      // for any generated shape we don't want an id
-                      // it will receive its own, new id
-                      if (params.propagated) delete deepCopy['shape_id'];
-                      deepCopy['roi_id'] = params.roi_id;
-                      this.viewer.generateShapes(deepCopy,
-                          params.number, params.random, extent, theDims,
-                          params.add_history, params.hist_id);
+                      if (!def.deleted) {
+                          let deepCopy = Object.assign({},def);
+                          // we are modified so let's update the definition
+                          // before we generate from it
+                          if (deepCopy.modified) {
+                              let upToDateDef =
+                                this.viewer.getShapeDefinition(deepCopy.shape_id);
+                              if (upToDateDef)
+                                deepCopy =
+                                    Converters.makeShapeBackwardsCompatible(upToDateDef);
+                          }
+                          // for any generated shape we don't want an id
+                          // it will receive its own, new id
+                          if (params.propagated) delete deepCopy['shape_id'];
+                          deepCopy['roi_id'] = params.roi_id;
+                          this.viewer.generateShapes(deepCopy,
+                              params.number, params.random, extent, theDims,
+                              params.add_history, params.hist_id);
+                    };
                   } catch(ignored) {}});
       }
 


### PR DESCRIPTION
see: https://trello.com/c/HYnRRhE8/243-review-first-round

The deletion of newly drawn shapes was handled slightly differently which lead to a bug in the undo functionality (part of history). In particular a newly created shape that was modified (spatially/geometry/style) and then deleted would be recreated in its initial state on clicking "undo" (as opposed to its most recent/modified state before deletion).

Test: Create a new shape and modify it by moving it or manipulating its vertices/edges (right panel edit dropdown menu offers switch between translate/modify) and changing its fill/stroke color for instance. Then delete it via the delete button in the right hand panel (you could use either delete selected or all, doesn't matter). After clicking the undo button, everything should go back to the state before deletion and  you should be able to undo the individual changes as well