### PR TITLE
Fix path

### DIFF
--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -35,7 +35,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-VERSION = '0.0.1'
+VERSION = '0.0.7'
 
 
 cmdclass = {}
@@ -50,7 +50,7 @@ class RunProd(Command):
         pass
 
     def run(self):
-        if not os.path.isdir('omero-iviewer/static'):
+        if not os.path.isdir('omero_iviewer/static'):
             self.spawn(['npm', 'run', 'prod'])
 
 
@@ -60,8 +60,7 @@ cmdclass['run_prod'] = RunProd
 class Sdist(setuptools.command.sdist.sdist):
 
     def run(self):
-        print os.path.isdir('omero-iviewer/static')
-        if not os.path.isdir('omero-iviewer/static'):
+        if not os.path.isdir('omero_iviewer/static'):
             self.run_command('run_prod')
         setuptools.command.sdist.sdist.run(self)
 
@@ -72,7 +71,7 @@ cmdclass['sdist'] = Sdist
 class Install(setuptools.command.install.install):
 
     def run(self):
-        if not os.path.isdir('omero-iviewer/static'):
+        if not os.path.isdir('omero_iviewer/static'):
             self.run_command('run_prod')
         setuptools.command.install.install.run(self)
 


### PR DESCRIPTION
Fix the path to the folder to check during build process

test 1:
 * delete the ``plugin/omero_iviewer/static``
 * Run ``python setup.py sdist`` from the plugin directory
 * This should run the full build
 * Run it again. It should not build

test 2:
Install from testpypi
``pip install --upgrade -i https://testpypi.python.org/pypi omero-iviewer``
This should install and not build anything (the version is 0.0.7 on testpypi, this is not important)


