### PR TITLE
argb -> rgba

### DIFF
--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -235,12 +235,9 @@ ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
  * @return {number|null} returns the color/alpha info encoded in a signed integer
  */
 ome.ol3.utils.Conversion.convertColorToSignedInteger = function(color, alpha) {
-	if (typeof(alpha) !== 'number') {// check optional alpha argument
-		try {
-			alpha = parseInt(alpha);
-		} catch(notANumber) {
-			alpha = 1.0;
-		}
+    if (typeof(alpha) !== 'number') {
+		alpha = parseInt(alpha);
+		if (isNaN(alpha)) alpha = 1.0;
 	}
 
 	if (typeof(color) == 'string') { // delegate to appropriate conversion
@@ -262,8 +259,8 @@ ome.ol3.utils.Conversion.convertColorToSignedInteger = function(color, alpha) {
         decimalOnly <= 0.5 ?
             Math.floor(decimalMultiplied) : Math.ceil(decimalMultiplied);
 
-    return ((alpha << 24) |
-                (color['red'] << 16) | (color['green'] << 8) | color['blue']);
+    return ((color['red'] << 24) | (color['green'] << 16) | (color['blue'] << 8)
+            | alpha);
 }
 
 /**

--- a/ol3-viewer/test/unit/utils/conversion.js
+++ b/ol3-viewer/test/unit/utils/conversion.js
@@ -6,65 +6,65 @@ describe("Conversion", function() {
 		it('convertRgbaColorFormatToObject', function() {
 			var colorObject =
 				ome.ol3.utils.Conversion.convertRgbaColorFormatToObject("rgba(255,128,0,0.75)");
-			assert(colorObject.red === 255);
-			assert(colorObject.green === 128);
-			assert(colorObject.blue === 0);
-			assert(colorObject.alpha === 0.75);
+			assert.equal(colorObject.red,255);
+			assert.equal(colorObject.green,128);
+			assert.equal(colorObject.blue, 0);
+			assert.equal(colorObject.alpha,0.75);
 
 			colorObject =
 				ome.ol3.utils.Conversion.convertRgbaColorFormatToObject("rgb(0,128,255)", 0.11);
-			assert(colorObject.red === 0);
-			assert(colorObject.green === 128);
-			assert(colorObject.blue === 255);
-			assert(colorObject.alpha === 0.11);
+			assert.equal(colorObject.red,0);
+			assert.equal(colorObject.green,128);
+			assert.equal(colorObject.blue,255);
+			assert.equal(colorObject.alpha,0.11);
 		});
 
 		it('convertHexColorFormatToObject', function() {
 			var colorObject =
 				ome.ol3.utils.Conversion.convertHexColorFormatToObject("#FF8000", 0.5);
-			assert(colorObject.red === 255);
-			assert(colorObject.green === 128);
-			assert(colorObject.blue === 0);
-			assert(colorObject.alpha === 0.5);
+			assert.equal(colorObject.red,255);
+			assert.equal(colorObject.green,128);
+			assert.equal(colorObject.blue,0);
+			assert.equal(colorObject.alpha,0.5);
 
 			colorObject =
 				ome.ol3.utils.Conversion.convertHexColorFormatToObject("#0080FF", 0.11);
-			assert(colorObject.red === 0);
-			assert(colorObject.green === 128);
-			assert(colorObject.blue === 255);
-			assert(colorObject.alpha === 0.11);
+			assert.equal(colorObject.red,0);
+			assert.equal(colorObject.green,128);
+			assert.equal(colorObject.blue,255);
+			assert.equal(colorObject.alpha,0.11);
 		});
 
 		it('convertColorObjectToHex', function() {
 			var hexColor =
 				ome.ol3.utils.Conversion.convertColorObjectToHex(
 					{red : 255, green : 128, blue: 0, alpha: 0.9});
-			assert(hexColor === "#ff8000");
+			assert.equal(hexColor, "#ff8000");
 		});
 
 		it('convertColorObjectToRgba', function() {
 			var rgbColor =
 				ome.ol3.utils.Conversion.convertColorObjectToRgba(
 					{red : 255, green : 128, blue: 0});
-			assert(rgbColor === "rgba(255,128,0,1)");
+			assert.equal(rgbColor,"rgba(255,128,0,1)");
 			rgbColor =
 				ome.ol3.utils.Conversion.convertColorObjectToRgba(
 					{red : 0, green : 128, blue: 255, alpha: 0.321 });
-			assert(rgbColor === "rgba(0,128,255,0.321)");
+			assert.equal(rgbColor,"rgba(0,128,255,0.321)");
 		});
 
 		it('convertColorToSignedInteger', function() {
 			var signedInteger =
 				ome.ol3.utils.Conversion.convertColorToSignedInteger(
-					{red : 255, green : 128, blue: 0, alpha: 1});
-			assert(signedInteger === -32768);
+					{red : 0, green : 255, blue: 0, alpha: 0.5});
+            assert.equal(signedInteger,16711807);
 			signedInteger =
 				ome.ol3.utils.Conversion.convertColorToSignedInteger(
-					"#0080FF", 0.0196);
-			assert(signedInteger === 83919103);
+					"#0000FF", 0.0196);
+			assert.equal(signedInteger,65285);
 			signedInteger =
-				ome.ol3.utils.Conversion.convertColorToSignedInteger("rgba(255,255,0, 0.7)");
-			assert(signedInteger === -1291845888);
+				ome.ol3.utils.Conversion.convertColorToSignedInteger("rgba(255,112,122,0.7)");
+			assert.equal(signedInteger,-9405774);
 		});
 
 		var pointFeature = new ol.Feature({
@@ -75,11 +75,11 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.pointToJsonObject(
 					pointFeature.getGeometry(),255);
-			assert(jsonObject['@id'] === 255);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'],255);
+			assert.equal(jsonObject['@type'],
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Point");
-			assert(jsonObject['X'] === 10);
-			assert(jsonObject['Y'] === 10);
+			assert.equal(jsonObject['X'],10);
+			assert.equal(jsonObject['Y'],10);
 		});
 
 		var ellipseFeature = new ol.Feature({
@@ -90,13 +90,13 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.ellipseToJsonObject(
 					ellipseFeature.getGeometry(),333);
-			assert(jsonObject['@id'] === 333);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 333);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse");
-			assert(jsonObject['X'] === 100);
-			assert(jsonObject['Y'] === 100);
-			assert(jsonObject['RadiusX'] === 20);
-			assert(jsonObject['RadiusY'] === 40);
+			assert.equal(jsonObject['X'] , 100);
+			assert.equal(jsonObject['Y'] , 100);
+			assert.equal(jsonObject['RadiusX'] , 20);
+			assert.equal(jsonObject['RadiusY'] , 40);
 		});
 
 		var rectangleFeature = new ol.Feature({
@@ -107,13 +107,13 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.rectangleToJsonObject(
 					rectangleFeature.getGeometry(),123);
-			assert(jsonObject['@id'] === 123);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 123);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-			assert(jsonObject['X'] === 33);
-			assert(jsonObject['Y'] === 77);
-			assert(jsonObject['Width'] === 20);
-			assert(jsonObject['Height'] === 40);
+			assert.equal(jsonObject['X'] , 33);
+			assert.equal(jsonObject['Y'] , 77);
+			assert.equal(jsonObject['Width'] , 20);
+			assert.equal(jsonObject['Height'] , 40);
 		});
 
 		var lineFeature = new ol.Feature({
@@ -124,13 +124,13 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.lineToJsonObject(
 					lineFeature.getGeometry(),673);
-			assert(jsonObject['@id'] === 673);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 673);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Line");
-			assert(jsonObject['X1'] === 0);
-			assert(jsonObject['Y1'] === 0);
-			assert(jsonObject['X2'] === 10);
-			assert(jsonObject['Y2'] === 10);
+			assert.equal(jsonObject['X1'] , 0);
+			assert.equal(jsonObject['Y1'] , 0);
+			assert.equal(jsonObject['X2'] , 10);
+			assert.equal(jsonObject['Y2'] , 10);
 		});
 
 		var polylineFeature = new ol.Feature({
@@ -141,10 +141,10 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.polylineToJsonObject(
 					polylineFeature.getGeometry(),342);
-			assert(jsonObject['@id'] === 342);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 342);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline");
-			assert(jsonObject['Points'] === '0,0 10,10 0,100');
+			assert.equal(jsonObject['Points'] , '0,0 10,10 0,100');
 		});
 
 		var labelFeature = new ol.Feature({
@@ -155,11 +155,11 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.labelToJsonObject(
 					labelFeature.getGeometry(),99);
-			assert(jsonObject['@id'] === 99);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 99);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-			assert(jsonObject['X'] === 500);
-			assert(jsonObject['Y'] === 66);
+			assert.equal(jsonObject['X'] , 500);
+			assert.equal(jsonObject['Y'] , 66);
 		});
 
 		var polygonFeature = new ol.Feature({
@@ -171,10 +171,10 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.polygonToJsonObject(
 					polygonFeature.getGeometry(),4332);
-			assert(jsonObject['@id'] === 4332);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 4332);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon");
-			assert(jsonObject['Points'] === '0,0 10,10 0,100 0,0');
+			assert.equal(jsonObject['Points'] , '0,0 10,10 0,100 0,0');
 		});
 
 		labelFeature.setStyle(new ol.style.Style({
@@ -201,21 +201,21 @@ describe("Conversion", function() {
 					labelFeature.getGeometry(),6);
 			ome.ol3.utils.Conversion.integrateStyleIntoJsonObject(
 				labelFeature, jsonObject);
-			assert(jsonObject['@id'] === 6);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'] , 6);
+			assert.equal(jsonObject['@type'] ,
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-			assert(jsonObject['X'] === 500);
-			assert(jsonObject['Y'] === 66);
-			assert(jsonObject['Text'] === "unit test");
-			assert(jsonObject['StrokeColor'] === -1291845888);
-			assert(jsonObject['StrokeWidth']['@type'] === 'TBD#LengthI');
-			assert(jsonObject['StrokeWidth']['Unit'] === 'PIXEL');
-			assert(jsonObject['StrokeWidth']['Value'] === 2);
-			assert(jsonObject['FontFamily'] === 'arial');
-			assert(jsonObject['FontStyle'] === 'bold');
-			assert(jsonObject['FontSize']['@type'] === 'TBD#LengthI');
-			assert(jsonObject['FontSize']['Unit'] === 'PIXEL');
-			assert(jsonObject['FontSize']['Value'] === 666);
+			assert.equal(jsonObject['X'] , 500);
+			assert.equal(jsonObject['Y'] , 66);
+			assert.equal(jsonObject['Text'] , "unit test");
+			assert.equal(jsonObject['StrokeColor'], -65358);
+			assert.equal(jsonObject['StrokeWidth']['@type'] , 'TBD#LengthI');
+			assert.equal(jsonObject['StrokeWidth']['Unit'] , 'PIXEL');
+			assert.equal(jsonObject['StrokeWidth']['Value'] , 2);
+			assert.equal(jsonObject['FontFamily'] , 'arial');
+			assert.equal(jsonObject['FontStyle'] , 'bold');
+			assert.equal(jsonObject['FontSize']['@type'] , 'TBD#LengthI');
+			assert.equal(jsonObject['FontSize']['Unit'] , 'PIXEL');
+			assert.equal(jsonObject['FontSize']['Value'] , 666);
 		});
 
 		it('integrateStyleAndMiscIntoJsonObject2', function() {
@@ -227,20 +227,20 @@ describe("Conversion", function() {
 			ome.ol3.utils.Conversion.integrateMiscInfoIntoJsonObject(
 				rectangleFeature, jsonObject);
 
-			assert(jsonObject['@id'] === 3);
-			assert(jsonObject['@type'] ===
+			assert.equal(jsonObject['@id'], 3);
+			assert.equal(jsonObject['@type'],
 			 	"http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-			assert(jsonObject['X'] === 33);
-			assert(jsonObject['Y'] === 77);
-			assert(jsonObject['Width'] === 20);
-			assert(jsonObject['Height'] === 40);
-			assert(jsonObject['FillColor'] === -32768);
-			assert(jsonObject['StrokeWidth']['@type'] === 'TBD#LengthI');
-			assert(jsonObject['StrokeWidth']['Unit'] === 'PIXEL');
-			assert(jsonObject['StrokeWidth']['Value'] === 1);
-			assert(jsonObject['TheC'] === 1);
-			assert(jsonObject['TheT'] === 7);
-			assert(jsonObject['TheZ'] === 3);
+			assert.equal(jsonObject['X'],33);
+			assert.equal(jsonObject['Y'],77);
+			assert.equal(jsonObject['Width'],20);
+			assert.equal(jsonObject['Height'],40);
+			assert.equal(jsonObject['FillColor'],-8388353);
+			assert.equal(jsonObject['StrokeWidth']['@type'],'TBD#LengthI');
+			assert.equal(jsonObject['StrokeWidth']['Unit'],'PIXEL');
+			assert.equal(jsonObject['StrokeWidth']['Value'],1);
+			assert.equal(jsonObject['TheC'],1);
+			assert.equal(jsonObject['TheT'],7);
+			assert.equal(jsonObject['TheZ'],3);
 
 			// now set the old style and evaluate again
 			rectangleFeature['oldStrokeStyle'] = {};
@@ -250,10 +250,10 @@ describe("Conversion", function() {
 				rectangleFeature.getStyle().getStroke().getWidth();
 			ome.ol3.utils.Conversion.integrateStyleIntoJsonObject(
 			rectangleFeature, jsonObject);
-			assert(jsonObject['StrokeColor'] === -1291845888);
-			assert(jsonObject['StrokeWidth']['@type'] === 'TBD#LengthI');
-			assert(jsonObject['StrokeWidth']['Unit'] === 'PIXEL');
-			assert(jsonObject['StrokeWidth']['Value'] === 5);
+			assert.equal(jsonObject['StrokeColor'],-65358);
+			assert.equal(jsonObject['StrokeWidth']['@type'],'TBD#LengthI');
+			assert.equal(jsonObject['StrokeWidth']['Unit'],'PIXEL');
+			assert.equal(jsonObject['StrokeWidth']['Value'],5);
 		});
 
 		it('toJsonObject', function() {
@@ -274,36 +274,36 @@ describe("Conversion", function() {
 			var jsonObject =
 				ome.ol3.utils.Conversion.toJsonObject(features);
 
-			assert(jsonObject['count'] === 3);
-			assert(jsonObject['rois']['1']['@type'] ===
+            assert.equal(jsonObject['count'],3);
+			assert.equal(jsonObject['rois']['1']['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-			assert(jsonObject['rois']['1']['shapes'][0]['@id'] === 1);
-			assert(jsonObject['rois']['1']['shapes'][0]['@type'] ===
+			assert.equal(jsonObject['rois']['1']['shapes'][0]['@id'],1);
+			assert.equal(jsonObject['rois']['1']['shapes'][0]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-			assert(jsonObject['rois']['-1']['@type'] ===
+			assert.equal(jsonObject['rois']['-1']['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-			assert(jsonObject['rois']['-1']['shapes'][0]['@type'] ===
+			assert.equal(jsonObject['rois']['-1']['shapes'][0]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-			assert(jsonObject['rois']['-1']['shapes'][1]['@type'] ===
+			assert.equal(jsonObject['rois']['-1']['shapes'][1]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Point");
 
 			// test variation: each shape gets its own roi
 			var jsonObject =
 				ome.ol3.utils.Conversion.toJsonObject(features, true);
 
-			assert(jsonObject['count'] === 3);
-			assert(jsonObject['rois']['1']['@type'] ===
+			assert.equal(jsonObject['count'], 3);
+			assert.equal(jsonObject['rois']['1']['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-			assert(jsonObject['rois']['1']['shapes'][0]['@id'] === 1);
-			assert(jsonObject['rois']['1']['shapes'][0]['@type'] ===
+			assert.equal(jsonObject['rois']['1']['shapes'][0]['@id'],1);
+			assert.equal(jsonObject['rois']['1']['shapes'][0]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-			assert(jsonObject['rois']['-1']['@type'] ===
+			assert.equal(jsonObject['rois']['-1']['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-			assert(jsonObject['rois']['-1']['shapes'][0]['@type'] ===
+			assert.equal(jsonObject['rois']['-1']['shapes'][0]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-			assert(jsonObject['rois']['-2']['@type'] ===
+			assert.equal(jsonObject['rois']['-2']['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-			assert(jsonObject['rois']['-2']['shapes'][0]['@type'] ===
+			assert.equal(jsonObject['rois']['-2']['shapes'][0]['@type'],
 				"http://www.openmicroscopy.org/Schemas/OME/2016-06#Point");
 		});
 });

--- a/ol3-viewer/test/unit/utils/regions.js
+++ b/ol3-viewer/test/unit/utils/regions.js
@@ -110,9 +110,7 @@ describe("Regions", function() {
 			assert.instanceOf(features[f], ol.Feature);
 			var geom = features[f].getGeometry();
 			assert.instanceOf(geom, ol.geom.Polygon);
-			assert(ol.extent.containsExtent(
-				[0,-1000,1000,0],
-				geom.getExtent()));
+			assert(ol.extent.containsExtent([0,-1000,1000,0], geom.getExtent()));
 		}
 	});
 

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -108,18 +108,17 @@ export class Converters {
     static signedIntegerColorToHexAndAlpha(signed_integer) {
         if (typeof signed_integer !== 'number') return null;
 
+        // prepare integer to be converted to hex for easier dissection
         if (signed_integer < 0) signed_integer = signed_integer >>> 0;
         let intAsHex = signed_integer.toString(16);
-        // we have to have rgb at a minimum
-        if (intAsHex.length < 6) return;
+        // pad with zeros to have 8 digits
+        intAsHex = ("00" + intAsHex).slice(-8);
 
-        // finally convert padding appropriately if we don't have 8 positions
-        if (intAsHex.length === 6) intAsHex = "11" + intAsHex; // no alpha => 1 default
-        else intAsHex = ("00" + intAsHex).slice(-8); // pad zeros to fill up (if needed)
-        let alpha = parseInt(intAsHex.substring(0,2), 16) / 255;
+        // we expect RGBA
         let hex = "#";
-        for (let i=2;i<intAsHex.length;i+=2)
+        for (let i=0;i<intAsHex.length-2;i+=2)
             hex += intAsHex.substr(i, 2);
+        let alpha = parseInt(intAsHex.substring(6,8), 16) / 255;
 
         return [hex, alpha];
     }
@@ -172,7 +171,7 @@ export class Converters {
             if (p === 'FontSize') value = shape[p].Value;
             // transform
             if (p === 'Transform')
-                value = "matrix(" + 
+                value = "matrix(" +
                     shape[p].A00 + " " + shape[p].A10 + " " +
                     shape[p].A01 + " " + shape[p].A11 + " " +
                     shape[p].A02 + " " + shape[p].A12 + ")";


### PR DESCRIPTION
This PR follows suit with https://github.com/openmicroscopy/openmicroscopy/pull/4948 and https://github.com/openmicroscopy/openmicroscopy/pull/4995 which got merged more recently.

Instead of using ARGB color encoding we want to use RGBA.

Along with the corresponding changes for the js-unit tests, I adjusted the assert syntax in those tests.

Test: While there are js-unit tests (see run below) and you can rerun them locally, the best way to test this is on cowfish, against the present web viewer and against insight.

![image](https://cloud.githubusercontent.com/assets/1559229/22271610/23f03adc-e2e1-11e6-856b-ceded9e863b5.png)
