### PR TITLE
left-hand thumbnail panel empty when opened image belongs to multiple datasets

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -240,10 +240,11 @@ export default class Context {
      * the same image to be used in multiple ImageConfigs.
      *
      * @memberof Context
-     * @param {number} image_id the image id of the server
+     * @param {number} image_id the image id
+     * @param {number} dataset_id an optional dataset_id
      * @return {ImageConfig} an ImageConfig object
      */
-    addImageConfig(image_id) {
+    addImageConfig(image_id, dataset_id) {
         if (typeof image_id !== 'number' || image_id < 0)
             return null;
 
@@ -252,7 +253,7 @@ export default class Context {
             for (let [id, conf] of this.image_configs)
                 this.removeImageConfig(id,conf)
 
-        let image_config = new ImageConfig(this, image_id);
+        let image_config = new ImageConfig(this, image_id, dataset_id);
         // store the image config in the map and make it the selected one
         this.image_configs.set(image_config.id, image_config);
         this.selectConfig(image_config.id);

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -95,7 +95,50 @@ export default class Context {
         if (typeof eventbus instanceof EventAggregator)
             throw "Invalid EventAggregator given!"
 
-        let server = optParams[REQUEST_PARAMS.SERVER];
+        // process request params and assign members
+        this.processServerParameter(optParams);
+        this.readPrefixedURIs(optParams);
+        this.eventbus = eventbus;
+        this.initParams = optParams;
+
+        // we set the initial image as the default (if given)
+        let initial_dataset_id =
+            parseInt(
+                this.getInitialRequestParam(REQUEST_PARAMS.DATASET_ID));
+        let initial_image_config =
+            this.addImageConfig(initial_image_id, initial_dataset_id);
+        this.selected_config = initial_image_config.id;
+
+        // set up key listener
+        this.establishKeyDownListener();
+
+        if (this.hasHTML5HistoryFeatures()) {
+            window.onpopstate = (e) => {
+                if (e.state === null) window.history.go(0);
+                this.addImageConfig(e.state.image_id, e.state.dataset_id);
+            };
+        }
+    }
+
+    /**
+     * Checks for history features introduced with HTML5
+     *
+     * @memberof Context
+     */
+    hasHTML5HistoryFeatures() {
+        return window.history &&
+            typeof window.history.pushState === 'function' &&
+            typeof window.onpopstate !== 'undefined';
+    }
+
+    /**
+     * Processes and sanitizes some of the server param
+     *
+     * @param {Object} params the handed in parameters
+     * @memberof Context
+     */
+    processServerParameter(params) {
+        let server = params[REQUEST_PARAMS.SERVER];
         if (typeof server !== 'string' || server.length === 0) server = "";
         else {
             // check for localhost and if we need to prefix for requests
@@ -110,23 +153,13 @@ export default class Context {
                 server = "http://" + server;
         }
         this.server = server;
-        delete optParams[REQUEST_PARAMS.SERVER];
-
-        this.readPrefixedURIs(optParams);
-
-        this.eventbus = eventbus;
-        this.initParams = optParams;
-
-        // we set the initial image as the default (if given)
-        let initial_image_config = this.addImageConfig(initial_image_id);
-        this.selected_config = initial_image_config.id;
-        // set up key listener
-        this.establishKeyDownListener();
+        delete params[REQUEST_PARAMS.SERVER];
     }
 
     /**
      * Reads the list of uris that we need
      *
+     * @param {Object} params the handed in parameters
      * @memberof Context
      */
     readPrefixedURIs(params) {
@@ -229,6 +262,20 @@ export default class Context {
     removeKeyListener(key) {
         if (typeof key !== 'number') return;
         this.key_listeners.delete(key);
+    }
+
+    rememberImageConfigChange(image_id, dataset_id) {
+        if (!this.hasHTML5HistoryFeatures()) return;
+
+        let old_image_id =
+            this.getSelectedImageConfig().image_info.image_id;
+        let oldPath = window.location.pathname;
+        let newPath =
+            oldPath.replace(old_image_id, image_id);
+        if (typeof dataset_id === 'number')
+            newPath += '?dataset_id=' + dataset_id;
+        window.history.pushState(
+            {image_id: image_id, dataset_id: dataset_id},"",newPath);
     }
 
     /**

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -106,7 +106,9 @@ export default class Context {
             parseInt(
                 this.getInitialRequestParam(REQUEST_PARAMS.DATASET_ID));
         let initial_image_config =
-            this.addImageConfig(initial_image_id, initial_dataset_id);
+            this.addImageConfig(initial_image_id,
+                typeof initial_dataset_id === 'number' &&
+                !isNaN(initial_dataset_id) ? initial_dataset_id : null);
         this.selected_config = initial_image_config.id;
 
         // set up key listener

--- a/src/app/header.js
+++ b/src/app/header.js
@@ -132,7 +132,9 @@ export class Header extends EventSubscriber {
       * @memberof Header
       */
      displayLink() {
-         if (this.context.getSelectedImageConfig() === null) return;
+         let selConf = this.context.getSelectedImageConfig();
+         if (selConf === null) return;
+
          let callback = ((settings) => {
              let url =
                 Misc.assembleImageLink(
@@ -140,6 +142,10 @@ export class Header extends EventSubscriber {
                     this.context.getPrefixedURI(WEBCLIENT),
                     this.image_info.image_id,
                     settings);
+                // let's add the dataset id if we have one
+                if (typeof selConf.image_info.dataset_id === 'number')
+                    url += "&dataset_id=" + selConf.image_info.dataset_id;
+
                 // show link and register close button
                 $('.link-url button').blur();
                 let linkDiv = $('.link-url div');

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -173,6 +173,7 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {number} image_id the image id for the clicked thumbnail
      */
     onClick(image_id) {
+        this.context.rememberImageConfigChange(image_id, this.dataset_id);
         this.context.addImageConfig(image_id, this.dataset_id);
     }
 

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -173,7 +173,7 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {number} image_id the image id for the clicked thumbnail
      */
     onClick(image_id) {
-        this.context.addImageConfig(image_id);
+        this.context.addImageConfig(image_id, this.dataset_id);
     }
 
     /**

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -47,13 +47,14 @@ export default class ImageConfig extends History {
      * @constructor
      * @param {Context} context the application context
      * @param {number} image_id the image id to be queried
+     * @param {number} dataset_id an optional dataset_id
      */
-    constructor(context, image_id) {
+    constructor(context, image_id, dataset_id) {
         super(); // for history
         // for now this should suffice, especially given js 1 threaded nature
         this.id = new Date().getTime();
         // go create the data objects for an image and its associated region
-        this.image_info = new ImageInfo(context, this.id, image_id);
+        this.image_info = new ImageInfo(context, this.id, image_id, dataset_id);
         this.regions_info = new RegionsInfo(this.image_info)
     }
 

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -187,15 +187,20 @@ export default class ImageInfo {
             dataType : dataType,
             cache : false,
             success : (response) => {
-                // remember any associated dataset id
-                if (typeof response.meta === 'object' &&
-                        typeof response.meta.datasetId === 'number')
-                    this.dataset_id = response.meta.datasetId;
-                else this.dataset_id = null;
-
-                // delegate to break up code
+                // reset existing dataset id
+                this.dataset_id = null;
+                // read initial request params
                 this.initializeImageInfo(response);
 
+                // check for a dataset id
+                if (typeof this.dataset_id !== 'number') {
+                    if (typeof response.meta === 'object' &&
+                            typeof response.meta.datasetId === 'number')
+                        this.dataset_id = response.meta.datasetId;
+                    else this.dataset_id = null;
+                    // TODO: fall back on other strategy for image in multiple ds
+                }
+                
                 // fire off the request for the imported data,
                 // can't hurt to have handy when we need it
                 this.requestImportedData();
@@ -236,6 +241,12 @@ export default class ImageInfo {
      */
     initializeImageInfo(response) {
         // we might have some requested defaults
+        let initialDatasetId =
+            parseInt(
+                this.context.getInitialRequestParam(REQUEST_PARAMS.DATASET));
+        if (typeof initialDatasetId === 'number' &&
+                !isNaN(initialDatasetId) && initialDatasetId >= 0)
+            this.dataset_id = initialDatasetId;
         let initialTime =
             this.context.getInitialRequestParam(REQUEST_PARAMS.TIME);
         let initialPlane =

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -197,16 +197,13 @@ export default class ImageInfo {
                     if (typeof response.meta === 'object' &&
                             typeof response.meta.datasetId === 'number')
                         this.dataset_id = response.meta.datasetId;
-                    else this.dataset_id = null;
-                    // TODO: fall back on other strategy for image in multiple ds
                 }
-                
+
                 // fire off the request for the imported data,
                 // can't hurt to have handy when we need it
                 this.requestImportedData();
                 // fetch copied img RDef
                 this.requestImgRDef();
-
                 // notify everyone that we are ready
                 if (this.context)
                     this.context.publish(
@@ -243,7 +240,7 @@ export default class ImageInfo {
         // we might have some requested defaults
         let initialDatasetId =
             parseInt(
-                this.context.getInitialRequestParam(REQUEST_PARAMS.DATASET));
+                this.context.getInitialRequestParam(REQUEST_PARAMS.DATASET_ID));
         if (typeof initialDatasetId === 'number' &&
                 !isNaN(initialDatasetId) && initialDatasetId >= 0)
             this.dataset_id = initialDatasetId;

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -130,11 +130,13 @@ export default class ImageInfo {
      * @param {Context} context the application context
      * @param {number} config_id the config id we belong to
      * @param {number} image_id the image id to be queried
+     * @param {number} dataset_id an optional dataset_id
      */
-    constructor(context, config_id, image_id) {
+    constructor(context, config_id, image_id, dataset_id) {
         this.context = context;
         this.config_id = config_id;
         this.image_id = image_id;
+        if (typeof dataset_id === 'number') this.dataset_id = dataset_id;
     }
 
     /**
@@ -187,8 +189,6 @@ export default class ImageInfo {
             dataType : dataType,
             cache : false,
             success : (response) => {
-                // reset existing dataset id
-                this.dataset_id = null;
                 // read initial request params
                 this.initializeImageInfo(response);
 

--- a/src/openwith.js
+++ b/src/openwith.js
@@ -1,4 +1,4 @@
-OME.setOpenWithUrlProvider("OMERO.iviewer", function(selected, url) {
+OME.setOpenWithUrlProvider("omero_iviewer", function(selected, url) {
 	// Add image Id to url
 	url += selected[0].id + "/";
 

--- a/src/openwith.js
+++ b/src/openwith.js
@@ -9,7 +9,7 @@ OME.setOpenWithUrlProvider("omero_iviewer", function(selected, url) {
 			var parent = OME.getTreeImageContainerBestGuess(selected[0].id);
 			if (parent && parent.data) {
 				if (parent.type === 'dataset')
-					url += '?dataset_id=' + parent.data.id;
+					url += '?' + parent.type + '=' + parent.data.id
 			}
 		} catch(err) {
 			console.log(err);

--- a/src/openwith.js
+++ b/src/openwith.js
@@ -1,3 +1,19 @@
-OME.setOpenWithUrlProvider("omero_iviewer", function(selected, url) {
-    return url + selected[0].id + "/";
+OME.setOpenWithUrlProvider("OMERO.iviewer", function(selected, url) {
+	// Add image Id to url
+	url += selected[0].id + "/";
+
+	// We try to traverse the jstree, to find parent of selected image
+	if ($ && $.jstree) {
+		try {
+			var inst = $.jstree.reference('#dataTree');
+			var parent = OME.getTreeImageContainerBestGuess(selected[0].id);
+			if (parent && parent.data) {
+				if (parent.type === 'dataset')
+					url += '?dataset_id=' + parent.data.id;
+			}
+		} catch(err) {
+			console.log(err);
+		}
+	}
+    return url;
 });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -40,7 +40,7 @@ export const WEBCLIENT = "WEBCLIENT";
  * @type {Object}
  */
 export const REQUEST_PARAMS = {
-    DATASET : 'DATASET',
+    DATASET_ID : 'DATASET_ID',
     SERVER : 'SERVER',
     IMAGE_ID : 'IMAGE_ID',
     CHANNELS : 'C',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -40,6 +40,7 @@ export const WEBCLIENT = "WEBCLIENT";
  * @type {Object}
  */
 export const REQUEST_PARAMS = {
+    DATASET : 'DATASET',
     SERVER : 'SERVER',
     IMAGE_ID : 'IMAGE_ID',
     CHANNELS : 'C',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -40,7 +40,7 @@ export const WEBCLIENT = "WEBCLIENT";
  * @type {Object}
  */
 export const REQUEST_PARAMS = {
-    DATASET_ID : 'DATASET_ID',
+    DATASET_ID : 'DATASET',
     SERVER : 'SERVER',
     IMAGE_ID : 'IMAGE_ID',
     CHANNELS : 'C',


### PR DESCRIPTION
I changed the description of this PR to narrow down its scope and avoid confusion:

It was noted in trello ( https://trello.com/c/HYnRRhE8/243-review-first-round ) that an image that was opened with the iviewer AND belongs to more than 1 dataset does not show the thumbnails of the other images which is due to the dataset ids not being supplied in the imgData when there are multiple.

It has become apparent to me that this is not an easy thing to remedy since in the case of multiple datasets one needs to know which of the image/dataset combination in the tree was clicked on, not to mention multiple selections as @jburel points outs in his comment below.

Therefore the only way for this to work is to steal the idea in https://github.com/ome/omero-iviewer/pull/7 and use open_with.


TEST: cowfish.openmicroscopy.org/webtrial/

Use an image that belongs to 2 datasets, or link an image to another. Then right-click on the image in the tree and open with iviewer. The iviewer window should show a left hand panel that displays the images from the dataset that was the parent of the opened image. Make sure you repeat this procedure for the other dataset/parent.