### PR TITLE
let user enter channel start/end values outside of min/max but inside of range limits

### DIFF
--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -468,6 +468,7 @@ export default class ImageInfo {
         let start_min,start_max,end_min,end_max,start_val,end_val;
         let c = this.channels[index];
         switch(mode) {
+            case CHANNEL_SETTINGS_MODE.IMPORTED:
             case CHANNEL_SETTINGS_MODE.MIN_MAX:
                 start_min = c.window.min;
                 start_max = c.window.end-1;
@@ -484,23 +485,9 @@ export default class ImageInfo {
                 start_max = c.window.end-1;
                 end_min = c.window.start+1;
                 end_max = this.range[1];
-                start_val = this.initial_values ?
-                     c.window.start : this.range[0];
-                end_val =
-                    this.initial_values ?
-                         c.window.end : this.range[1];
+                start_val = this.range[0];
+                end_val = this.range[1];
                 break;
-
-            case CHANNEL_SETTINGS_MODE.IMPORTED:
-            default:
-               let ch =
-                   this.context.getSelectedImageConfig().image_info.imported_settings.c;
-                start_min = ch[index].window.min;
-                start_max = ch[index].window.end-1;
-                end_min = ch[index].window.start+1;
-                end_max = ch[index].window.max;
-                start_val = ch[index].window.start;
-                end_val = ch[index].window.end;
         }
 
         return {
@@ -511,24 +498,5 @@ export default class ImageInfo {
             start_val: start_val,
             end_val: end_val
         }
-    }
-
-    /**
-     * Helper to determine if the present channel data might need the full range
-     * mode to be displayed, i.e. start/end are outsided of min/max
-     *
-     * @return {Object|null} returns object with the respective min,max properties or null
-     * @memberof ChannelRange
-     */
-    needsFullRange() {
-        let ret = false;
-
-        if (!Misc.isArray(this.channels)) return false;
-
-        this.channels.map((c) => {
-            if (c.window.start < c.window.min || c.window.end > c.window.max)
-                ret = true;});
-
-        return ret;
     }
 }

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -308,8 +308,7 @@ export default class ChannelRange  {
 
                 // we want to update the histogram on slide so we
                 // need a separate event. we throttle so that
-                // we send only the lastest slider value within a 100ms
-                // window.
+                // we send only the last slider value within a 100ms window.
                 this.lastDelayedTimeout = new Date().getTime();
                 let delayedUpdate = (() => {
                     if (new Date().getTime() < this.lastDelayedTimeout)

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -236,9 +236,9 @@ export default class ChannelRange  {
      detached() {
          // tear down jquery elements
          try {
-             $(this.element).find(".channel-start").off("input");
+             $(this.element).find(".channel-start").off("blur");
              $(this.element).find(".channel-start").spinner("destroy");
-             $(this.element).find(".channel-end").off("input");
+             $(this.element).find(".channel-end").off("blur");
              $(this.element).find(".channel-end").spinner("destroy");
              $(this.element).find(".channel-slider").slider("destroy");
              $(this.element).find(".spectrum-input").spectrum("destroy");
@@ -265,8 +265,12 @@ export default class ChannelRange  {
          // channel start
          $(this.element).find(".channel-start").spinner(
              {min: minMaxRange.start_min, max: minMaxRange.start_max});
-         $(this.element).find(".channel-start").on("input spinstop",
-            (event, ui) => this.onRangeChange(event.target.value, true));
+         $(this.element).find(".channel-start").on("blur spinstop",
+            (event) => {
+                if (typeof event.keyCode !== 'number' ||
+                    event.keyCode === 13)
+                        this.onRangeChange(event.target.value, true);
+        });
         $(this.element).find(".channel-start").spinner(
             "value", minMaxValues.start_val);
 
@@ -329,8 +333,12 @@ export default class ChannelRange  {
         //channel end
         $(this.element).find(".channel-end").spinner(
             {min: minMaxRange.end_min, max: minMaxRange.end_max});
-        $(this.element).find(".channel-end").on("input spinstop",
-            (event) => this.onRangeChange(event.target.value));
+        $(this.element).find(".channel-end").on("blur spinstop",
+            (event) => {
+                if (typeof event.keyCode !== 'number' ||
+                    event.keyCode === 13)
+                        this.onRangeChange(event.target.value)
+        });
        $(this.element).find(".channel-end").spinner(
            "value",minMaxValues.end_val);
 

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -495,33 +495,34 @@ export default class ChannelRange  {
         let sliderMin = is_start ? minMaxValues.start_min : minMaxValues.end_min;
         let sliderMax = is_start ? minMaxValues.start_max : minMaxValues.end_max;
 
-         // clamp
-         let exceededBounds = false;
-         if (value < min) {
-             value = min;
-             exceededBounds = true;
-         }
-         if (value > max) {
-             value = max;
-             exceededBounds = true;
-         }
-         // set new start/end
-         if (!exceededBounds) {
-             let otherClazz = is_start ? '.channel-end' : '.channel-start';
-              $(this.element).children("span").css(
-                  "border-color", "rgb(170,170,170)");
-              if ((is_start && value === this.channel.window.start) ||
+        // clamp
+        let exceededBounds = false;
+        if (value < min) {
+            value = min;
+            exceededBounds = true;
+        }
+        if (value > max) {
+            value = max;
+            exceededBounds = true;
+        }
+        // set new start/end
+        if (!exceededBounds) {
+            let otherClazz = is_start ? '.channel-end' : '.channel-start';
+            $(this.element).children("span").css(
+                "border-color", "rgb(170,170,170)");
+            if ((is_start && value === this.channel.window.start) ||
                 (!is_start && value === this.channel.window.end)) return;
 
-             if (is_start) this.channel.window.start = value;
-             else this.channel.window.end = value;
+            if (is_start) this.channel.window.start = value;
+            else this.channel.window.end = value;
 
-             try {
-                 $(this.element).find(clazz).spinner("value", value);
-                 $(this.element).find(".channel-slider").slider(
-                     "option", "values",
-                     [this.channel.window.start, this.channel.window.end]);
-                 if (is_start) {
+            try {
+                $(this.element).find(clazz).spinner("value", value);
+                $(this.element).find(".channel-slider").slider(
+                    "option", "values",
+                    [this.channel.window.start, this.channel.window.end]);
+
+                if (is_start) {
                     $(this.element).find(otherClazz).spinner("option", "min", value+1);
                     $(this.element).find(".channel-slider").slider(
                         "option", "min", value < sliderMin ? value : sliderMin);
@@ -536,9 +537,10 @@ export default class ChannelRange  {
                         ['image_info', 'channels', '' + this.index,
                         'window', is_start ? 'start' : 'end'],
                         old_val : oldValue, new_val: value, type : "number"});
-             } catch (ignored) {}
-         } else $(this.element).find(clazz).parent().css("border-color", "rgb(255,0,0)");
-     }
+                    } catch (ignored) {}
+        } else $(this.element).find(clazz).parent().css(
+            "border-color", "rgb(255,0,0)");
+    }
 
     /**
      * Overridden aurelia lifecycle method:

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -293,6 +293,12 @@ export default class ChannelRange  {
             }, slide: (event,ui) => {
                 if (ui.values[0] >= ui.values[1]) return false;
 
+                // adjust value in input fields instantly
+                $(this.element).find(".channel-start").spinner(
+                    "value", ui.values[0]);
+                $(this.element).find(".channel-end").spinner(
+                    "value", ui.values[1]);
+
                 let imgConf = this.context.getSelectedImageConfig();
                 if (!imgConf.image_info.has_histogram) return true;
 

--- a/src/settings/channel-settings.js
+++ b/src/settings/channel-settings.js
@@ -115,12 +115,7 @@ export default class ChannelSettings extends EventSubscriber {
         if (this.image_config === null ||
                 this.image_config.image_info === null) return;
 
-        // we select the mode based on the channel range values
-        // if they are outside min/max, we need the full range view
-        if (this.image_config.image_info.needsFullRange())
-            this.mode = CHANNEL_SETTINGS_MODE.FULL_RANGE;
-        else
-            this.mode = CHANNEL_SETTINGS_MODE.MIN_MAX;
+        this.mode = CHANNEL_SETTINGS_MODE.MIN_MAX;
     }
 
     /**


### PR DESCRIPTION
Before this PR iViewer, when in min/max "mode", start/end values for channels outside of the set min/max were not allowed. To go below/above one had to switch to "full range" with the slider spanning the entire range.

To exhibit behavior like in the present web viewer as well as figure these restrictions were removed.


TEST:

Deployed on cowfish, e.g: https://cowfish.openmicroscopy.org/webtrial/omero_iviewer/9442/?dataset_id=1457 (user-1) 

Choose an appropriate test image, ideally with a larger range (16 bit say), and some smaller min/max -values. By default iViewer is in min/max 'mode'.

You should now be able to enter start/end values for the respective channels that are outside the original min/max (but still within the full range limits). Check that the range slider adjusts correspondingly after expanding the range and using it gives sensible values within the range. Likewise if the range is compacted the slider adjusts, yet it should not get "smaller" than the min/max that's set.