### PR TITLE
refactor jsdocs generation, fixing error and warnings for iviewer docs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,19 +14,15 @@
     <property name="node_modules" value="${basedir}/node_modules" />
     <property name="ol.js" value="${node_modules}/openlayers" />
     <property name="mocha-phantomjs" value="${node_modules}/mocha-phantomjs/bin/mocha-phantomjs" />
-    <property name="jsdoc.js" value="${basedir}/node_modules/jsdoc/jsdoc.js" />
 
     <property name="src" value="${basedir}/${ant.project.name}/src" />
     <property name="build.dir" value="${basedir}/build" />
     <property name="test.build.dir" value="${basedir}/test/build" />
     <property name="plugin.dir.static" value="${basedir}/plugin/${ant.project.name}/static/${ant.project.name}" />
 
-    <property name="dist.name"
-            value="${build.dir}/ol3-viewer.js" />
-    <property name="debug.name"
-            value="${build.dir}/ol3-viewer-debug.js" />
-    <property name="test.name"
-            value="${test.build.dir}/ol3-viewer-test.js" />
+    <property name="dist.name" value="${build.dir}/ol3-viewer.js" />
+    <property name="debug.name" value="${build.dir}/ol3-viewer-debug.js" />
+    <property name="test.name" value="${test.build.dir}/ol3-viewer-test.js" />
 
     <property name="outputwrapper" value="
         (function (root, factory) {
@@ -157,14 +153,6 @@
 
     <target name="copy-to-lib">
         <copy file="${dist.name}" todir="libs" overwrite="true"/>
-    </target>
-
-    <target name="docs" depends="init" description="generates jsdocs">
-        <delete dir="${build.dir}/docs" />
-        <mkdir dir="${build.dir}/docs" />
-        <exec executable="${jsdoc.js}">
-          <arg line="-r ${src} -d ${build.dir}/docs -p --verbose" />
-        </exec>
     </target>
 
     <target name="init">

--- a/esdoc-index.html
+++ b/esdoc-index.html
@@ -1,0 +1,5 @@
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0;URL='file/src/main.js.html'" />
+    </head>
+</html>

--- a/esdoc.json
+++ b/esdoc.json
@@ -1,6 +1,7 @@
 {
   "source": "./src",
-  "destination": "./build/docs",
+  "destination": "./build/docs/iviewer",
+  "index": "./esdoc-index.html",
   "plugins": [
     {"name": "esdoc-es7-plugin"}
   ]

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# fetch dependencies
+echo ""
+echo "-----------------------------------"
+echo "Fetching Documentation Libraries..."
+echo "-----------------------------------"
+echo ""
+npm install jsdoc esdoc@0.4.8 esdoc-es7-plugin
+
+# clean any docs that might have existed before and recreate the dir
+rm -rf ./build/docs
+mkdir ./build/docs
+
+# generate docs from source for both ol3viewer and iviewer
+echo ""
+echo "--------------------------------"
+echo "Running jsdocs for ol3-viewer..."
+echo "--------------------------------"
+echo ""
+./node_modules/.bin/jsdoc -r ./ol3-viewer -d ./build/docs/ol3-viewer -p --verbose
+echo ""
+echo "----------------------------"
+echo "Running esdoc for iviewer..."
+echo "----------------------------"
+echo ""
+./node_modules/.bin/esdoc -c esdoc.json

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1230,7 +1230,7 @@ ome.ol3.Viewer.prototype.getId = function() {
  * Returns the (possibly prefixed) uri for a resource
  *
  * @param {string} resource the resource name
- * @return {string\null} the prefixed URI or null (if not found)
+ * @return {string|null} the prefixed URI or null (if not found)
  */
 ome.ol3.Viewer.prototype.getPrefixedURI = function(resource) {
     if (typeof this.prefixed_uris_[resource] !== 'string') return null;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "./ol3_viewer_prepare.sh DEV && webpack-dev-server --config webpack.dev.config.js --hot --inline --progress --devtool eval",
     "debug": "./ol3_viewer_prepare.sh DEV && ./prepare_build.sh && webpack --config webpack.prod.config.js --progress --devtool source-map && ./deploy_build.sh",
     "prod": "./ol3_viewer_prepare.sh && ./prepare_build.sh && webpack -p --config webpack.prod.config.js --progress && ./deploy_build.sh",
-    "docs": "./node_modules/.bin/esdoc -c esdoc.json"
+    "docs": "./generate_docs.sh"
   },
   "dependencies": {
     "aurelia-bootstrapper-webpack": "^1.0.0",
@@ -48,8 +48,6 @@
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1",
-    "esdoc": ">=0.4.8",
-    "esdoc-es7-plugin": ">=0.0.3"
+    "webpack-dev-server": "^1.14.1"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ if (!is_dev_server) {
 /**
  * IViewer bootstrap function
  * @function
- * @param {Object} aurelia the aurealia instance
+ * @param {Object} aurelia the aurelia instance
  */
 bootstrap(function(aurelia) {
   aurelia.use

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,11 @@ if (!is_dev_server) {
     __webpack_public_path__ = prefix + '/static/' + PLUGIN_NAME + '/';
 }
 
+/**
+ * IViewer bootstrap function
+ * @function
+ * @param {Object} aurelia the aurealia instance
+ */
 bootstrap(function(aurelia) {
   aurelia.use
     .standardConfiguration()

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -427,8 +427,8 @@ export default class ImageInfo {
      * response
      *
      * @memberof ImageInfo
-     * @param {Array.<Object>} an array of existing channels (from response)
-     * @param {Array.<Object>} an array of initial settings per channel
+     * @param {Array.<Object>} channels the existing channels (response)
+     * @param {Array.<Object>} initialChannels initial channel settings (request)
      * @return {Array.<Object>} an array of mixed-in channel objects
      */
     initAndMixChannelsWithInitialSettings(channels, initialChannels) {

--- a/src/model/regions_history.js
+++ b/src/model/regions_history.js
@@ -226,6 +226,7 @@ export default class RegionsHistory {
      * @param {Object} shape a shape definition
      * @param {Array.<string>} props the properties of the shape to be affected
      * @param {Array.<?>} vals the values that the properties should take on
+     * @param {function} post_update_handler a callback after update
      * @memberof History
      */
     affectHistoryPropertyChange(shape, props, vals, post_update_handler) {

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -244,8 +244,8 @@ export default class RegionsInfo extends EventSubscriber {
      * @memberof RegionsInfo
      * @param {Array.<string>} properties an array of property names
      * @param {number|string|Array|boolean|Object} values the values to filter for
-     * @param {Array.<ids>|null} an optional array of ids of the form: roi:shape-id
-     * @return {Array.<ids>} an array of ids for shapes that satisfy the filter
+     * @param {Array.<string>|null} ids an optional array of ids of the form: roi:shape-id
+     * @return {Array.<string>} an array of ids that satisfy the filter
      */
     unsophisticatedShapeFilter(properties=[], values=[], ids=null) {
         let ret = [];

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -112,7 +112,7 @@ export default class RegionsList {
     /**
      * Establishes and tears down the handlers for column resize
      *
-     * @param {Object} the th cell that is being resized
+     * @param {Object} cell the cell that is being resized
      * @memberof RegionsList
      */
     enableColumnResize(cell) {

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -347,7 +347,6 @@ export default class ChannelRange  {
      * channel color change handler
      *
      * @param {number} value the new value
-     * @param {boolean} is_start was start of range or not
      * @memberof ChannelRange
      */
      onColorChange(value) {

--- a/src/settings/histogram.js
+++ b/src/settings/histogram.js
@@ -248,6 +248,8 @@ export default class Histogram extends EventSubscriber {
     /**
      * Plots the lines only
      * @param {number} channel the active channel index
+     * @param {number} start a start value
+     * @param {number} end an end value
      * @memberof Histogram
      */
     plotHistogramLines(channel, start, end) {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -156,10 +156,10 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Shows and hides the histogram
-    *
-    * @memberof Settings
-    */
+     * Shows and hides the histogram
+     *
+     * @memberof Settings
+     */
     toggleHistogram(checked) {
         if (this.histogram) {
             this.histogram.toggleHistogramVisibilty(checked);
@@ -167,10 +167,10 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * on model change handler
-    *
-    * @memberof Settings
-    */
+     * on model change handler
+     *
+     * @memberof Settings
+     */
     onModelChange(flag) {
         // add history record
         this.image_config.addHistory({
@@ -181,10 +181,10 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Persists the rendering settings
-    *
-    * @memberof Settings
-    */
+     * Persists the rendering settings
+     *
+     * @memberof Settings
+     */
     saveImageSettings() {
         $('.save-settings').children('button').blur();
         if (Misc.useJsonp(this.context.server)) {
@@ -227,20 +227,20 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Tries to persists the rendering settings to all images in the dataset
-    *
-    * @memberof Settings
-    */
+     * Tries to persists the rendering settings to all images in the dataset
+     *
+     * @memberof Settings
+     */
     saveImageSettingsToAll() {
         // we only delegate
         this.copy(true);
     }
 
     /**
-    * Undoes the last change
-    *
-    * @memberof Settings
-    */
+     * Undoes the last change
+     *
+     * @memberof Settings
+     */
     undo() {
         if (this.image_config) {
             this.image_config.undoHistory();
@@ -249,10 +249,10 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Redoes the last change
-    *
-    * @memberof Settings
-    */
+     * Redoes the last change
+     *
+     * @memberof Settings
+     */
     redo() {
         if (this.image_config) {
             this.image_config.redoHistory();
@@ -261,12 +261,12 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Copies the rendering settings
-    *
-    * @param {boolean} to_all if true settings will be applied to all,
-    *  otherwise only the present one
-    * @memberof Settings
-    */
+     * Copies the rendering settings
+     *
+     * @param {boolean} toAll if true settings will be applied to all,
+     *                        otherwise only the present one
+     * @memberof Settings
+     */
     copy(toAll=false) {
         let dataType = Misc.useJsonp(this.context.server) ? 'jsonp' : 'json';
 
@@ -332,12 +332,12 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Applies the rendering settings, keeping a history of the old settings
-    *
-    * @param {Object} rdef the rendering defintion
-    * @param {boolean} for_pasting true if rdef supplied it for pasting of settings, false otherwise
-    * @memberof Settings
-    */
+     * Applies the rendering settings, keeping a history of the old settings
+     *
+     * @param {Object} rdef the rendering defintion
+     * @param {boolean} for_pasting true if rdef supplied it for pasting of settings, false otherwise
+     * @memberof Settings
+     */
     applyRenderingSettings(rdef, for_pasting=true) {
         if (rdef === null) return;
 
@@ -448,11 +448,11 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-    * Applies user settings from rdefs[index]
-    *
-    * @param {number} index the index in the rdefs array
-    * @memberof Settings
-    */
+     * Applies user settings from rdefs[index]
+     *
+     * @param {number} index the index in the rdefs array
+     * @memberof Settings
+     */
     applyUserSetting(index) {
         this.applyRenderingSettings(this.rdefs[index], false);
     }

--- a/src/utils/regions.js
+++ b/src/utils/regions.js
@@ -74,7 +74,8 @@ export class Utils {
      * @param {Array.<?>} values the respective values for the properties
      * @param {History?} history an optional History instance
      * @param {number?} hist_id an optional history id
-     * @return {function} a function which takes a shape as an input or null
+     * @param {function} post_update_handler an optional callback after update
+     * @return {function} the update callback
      * @static
      */
      static createUpdateHandler(

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -200,7 +200,8 @@ export default class Ui {
     /**
      * Shows a bootstrap modal message box
      *
-     * @param {string} title the title of the dialog
+     * @param {string} message the title of the dialog
+     * @param {boolean} ok_button true will display an ok button, false won't
      * @static
      */
     static showModalMessage(message, ok_button) {

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -163,9 +163,8 @@ export default class Ui {
     }
 
     /**
-     * Collapse
+     * Adjusts the sidebars in case of window resize
      *
-     * @param {boolean} left flag if left sidebar
      * @static
      */
     static adjustSideBarsOnWindowResize() {


### PR DESCRIPTION
The jsdoc generation was broken for the iViewer bits of the project because of a version incompatibility.

Furthermore warnings for jsdoc comments were fixed.

The generation of the jdocs in HTML format is now handled by the script _generate_docs.sh_ which can also be called like this: `npm run docs`.

The previous ant target has been removed since it was only responsible for the ol3viewer bit.

TEST: 

Clone the project locally (either from https://github.com/waxenegger/omero-iviewer using the branch 'docs_fixes' or https://github.com/ome/omero-iviewer fetching the PR), cd to the root and run  `npm run docs`. This is going to create the documentation in PROJECT_ROOT/build/docs.

Use a browser to open file:///PROJECT_ROOT/build/docs/ and there should be 2 directories. Check that they contain the documentation, they both have an _index.html_ and you can continue browsing from there:

![image](https://cloud.githubusercontent.com/assets/1559229/22680427/a4463994-ed53-11e6-957e-705611f2ccd7.png)

![image](https://cloud.githubusercontent.com/assets/1559229/22680460/d5788a94-ed53-11e6-9ba3-12339bc8ccf7.png)

![image](https://cloud.githubusercontent.com/assets/1559229/22680437/b88427f4-ed53-11e6-90a2-12a1e0fdc063.png)
