### PR TITLE
use ajax setup to avoid redundancy

### DIFF
--- a/ol3-viewer/src/ome/ol3/utils/Net.js
+++ b/ol3-viewer/src/ome/ol3/utils/Net.js
@@ -326,7 +326,9 @@ ome.ol3.utils.Net.sendSameOrigin = function(
 	// assemble the url from server and uri info
 	var url = server['full'] === "" &&  uri['relative'] ? uri['full'] :
 		server['full'] + "/" + uri['full'];
-	if (uri['query'] === "") url += "/"; // to avoid redirects
+    var timestamp = '_=' + new Date().getTime();
+	if (uri['query'] === "") url += "/?" + timestamp; // to avoid redirects
+    else url += "&" + timestamp;
 	xhr.open(method, url, true);
 
 	for (var h in headers) // add headers (if there)

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -101,6 +101,18 @@ export default class Context {
         this.eventbus = eventbus;
         this.initParams = optParams;
 
+        // set global ajax request properties
+        $.ajaxSetup({
+            cache: false,
+            dataType : Misc.useJsonp(this.server) ? "jsonp" : "json",
+            beforeSend: (xhr, settings) => {
+                if (!Misc.useJsonp(this.server) &&
+                    !(/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)))
+                    xhr.setRequestHeader("X-CSRFToken",
+                        Misc.getCookie('csrftoken'));
+            }
+        });
+
         // we set the initial image as the default (if given)
         let initial_dataset_id =
             parseInt(
@@ -113,7 +125,7 @@ export default class Context {
 
         // set up key listener
         this.establishKeyDownListener();
-
+        // url navigation
         if (this.hasHTML5HistoryFeatures()) {
             window.onpopstate = (e) => {
                 if (e.state === null) window.history.go(0);

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -107,7 +107,6 @@ export default class ThumbnailSlider extends EventSubscriber {
 
         $.ajax(
             {url : url,
-            dataType : "jsonp",
             success : (response) => {
                 // we want an array
                 if (!Misc.isArray(response)) return;

--- a/src/main.js
+++ b/src/main.js
@@ -38,13 +38,5 @@ bootstrap(function(aurelia) {
     if (is_dev_server) ctx.tweakForDevServer();
     aurelia.container.registerInstance(Context,ctx);
 
-    $.ajaxSetup({
-        beforeSend: (xhr, settings) => {
-            if (!Misc.useJsonp(ctx.server) &&
-                !(/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)))
-                xhr.setRequestHeader("X-CSRFToken", Misc.getCookie('csrftoken'));
-        }
-    });
-
     aurelia.start().then(() => aurelia.setRoot('app/index', document.body));
 });

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -114,8 +114,6 @@ export default class ImageConfig extends History {
         let uri_prefix =  this.image_info.context.getPrefixedURI(WEBGATEWAY);
         $.ajax(
             {url : server + uri_prefix + "/luts/",
-            dataType : Misc.useJsonp(server) ? "jsonp" : "json",
-            cache : false,
             success : (response) => {
                 if (typeof response !== 'object' || response === null ||
                     !Misc.isArray(response.luts)) return;

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -177,17 +177,10 @@ export default class ImageInfo {
      * @memberof ImageInfo
      */
     requestData() {
-        let dataType = "json";
-        if (Misc.useJsonp(this.context.server)) dataType += "p";
-
-        let url =
-            this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
-            "/imgData/" + this.image_id + '/';
-
-        $.ajax(
-            {url : url,
-            dataType : dataType,
-            cache : false,
+        $.ajax({
+            url :
+                this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
+                "/imgData/" + this.image_id + '/',
             success : (response) => {
                 // read initial request params
                 this.initializeImageInfo(response);
@@ -342,10 +335,7 @@ export default class ImageInfo {
             }
         $.ajax({
             url : this.context.server +
-                    this.context.getPrefixedURI(WEBGATEWAY) +
-                        "/getImgRDef/",
-            dataType : Misc.useJsonp(this.context.server) ? 'jsonp' : 'json',
-            cache : false,
+                  this.context.getPrefixedURI(WEBGATEWAY) + "/getImgRDef/",
             success : (response) => {
                 if (typeof response !== 'object' || response === null ||
                     typeof response.rdef !== 'object' ||
@@ -372,17 +362,10 @@ export default class ImageInfo {
             return;
         }
 
-        let dataType = "json";
-        if (Misc.useJsonp(this.context.server)) dataType += "p";
-
-        let url =
-            this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
-            "/imgData/" + this.image_id + '/?getDefaults=true';
-
-        $.ajax(
-            {url : url,
-            dataType : dataType,
-            cache : false,
+        $.ajax({
+            url :
+                this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
+                "/imgData/" + this.image_id + '/?getDefaults=true',
             success : (response) => {
                 if (typeof response !== 'object' || response === null ||
                     !Misc.isArray(response.channels) ||

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -188,18 +188,11 @@ export default class RegionsInfo extends EventSubscriber {
         // reset history
         this.history.resetHistory();
 
-        // assmeble url
-        let url =
-            this.image_info.context.server +
-                this.image_info.context.getPrefixedURI(WEBGATEWAY) +
-                    "/get_rois_json/" + this.image_info.image_id + '/';
-        let dataType = "json";
-        if (Misc.useJsonp(this.image_info.context.server)) dataType += "p";
-
-        $.ajax(
-            {url : url,
-            dataType : dataType,
-            cache : false,
+        // send request
+        $.ajax({
+            url : this.image_info.context.server +
+                  this.image_info.context.getPrefixedURI(WEBGATEWAY) +
+                  "/get_rois_json/" + this.image_info.image_id + '/',
             success : (response) => {
                 // we want an array
                 if (!Misc.isArray(response)) return;

--- a/src/settings/histogram.js
+++ b/src/settings/histogram.js
@@ -320,8 +320,6 @@ export default class Histogram extends EventSubscriber {
 
         // fire off ajax request
         $.ajax({url : url,
-            dataType : Misc.useJsonp(server) ? 'jsonp' : 'json',
-            cache : false,
             success : (response) => {
                 // for error and non array data (which is what we want)
                 // we return null and the handler will respond accordingly

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -118,8 +118,6 @@ export default class Settings extends EventSubscriber {
             url : this.context.server +
                     this.context.getPrefixedURI(WEBGATEWAY) +
                         "/get_image_rdefs_json/" + img_id,
-            dataType : Misc.useJsonp(this.context.server) ? 'jsonp' : 'json',
-            cache : false,
             success : (response) => {
                 if (!Misc.isArray(response.rdefs)) return;
 
@@ -298,21 +296,16 @@ export default class Settings extends EventSubscriber {
         let params = {
             url : url,
             method: toAll ? 'POST' : 'GET',
-            cache: false,
             error : (error) => {}
         };
 
-        if (!toAll) {
-            params.dataType = dataType;
-            params.success =
-                (response) => imgInf.requestImgRDef();
-        }else {
+        if (toAll) {
             params.data={
+                dataType: 'json',
                 toids: imgInf.dataset_id,
                 to_type: 'dataset',
                 imageId: imgInf.image_id
             };
-            params.dataType = "json";
             params.success =
                 (response) => {
                     let thumbIds = [imgInf.image_id];
@@ -327,7 +320,8 @@ export default class Settings extends EventSubscriber {
                                 { config_id : this.config_id, ids: thumbIds}));
                     this.requestAllRenderingDefs(action);
                 }
-        }
+        } else params.success =
+            (response) => imgInf.requestImgRDef();
         $.ajax(params);
     }
 

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -266,9 +266,7 @@ export default class Settings extends EventSubscriber {
     * @memberof Settings
     */
     copy(toAll=false) {
-        let dataType = Misc.useJsonp(this.context.server) ? 'jsonp' : 'json';
-
-        if (toAll && dataType === 'jsonp') {
+        if (toAll && Misc.useJsonp(this.context.server)) {
             alert("Saving to All will not work cross-domain!");
             return;
         }


### PR DESCRIPTION
in the spirit of https://github.com/openmicroscopy/openmicroscopy/pull/5091 this PR makes use of the global ajax setup to eliminate cache: false and dataType: json/p.


TEST: test on cowfish.openmicroscopy.org/webtrial/webclient/, any user.

Open image with iviewer, then hit F12 in your favorite browser and navigate to the network tab to view the traffic. In fact it's best to reload/refresh the page straight away so that you get the initial requests as well. The only requests that matter are the ajax requests. So, in the chrome dev tools you can reduce the list by filtering for XHR (see screenshot). Make sure all those requests have the timestamp appended.

![image](https://cloud.githubusercontent.com/assets/1559229/22960164/7608e380-f387-11e6-83d4-b75c69cf0540.png)
