### PR TITLE
allow modify and translate at the same time

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -697,9 +697,11 @@ ome.ol3.Viewer.prototype.addRegions = function(options) {
 	// add a vector layer with the regions
 	if (this.regions_) {
 		this.viewer_.addLayer(new ol.layer.Vector({source : this.regions_}));
-		// enable roi selection by default
+		// enable roi selection by default,
+        // as well as modify and translate
 		this.regions_.setModes(
             [ome.ol3.REGIONS_MODE['SELECT'],
+             ome.ol3.REGIONS_MODE['MODIFY'],
              ome.ol3.REGIONS_MODE['TRANSLATE']]);
 
 		this.onViewRotationListener =

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -56,474 +56,475 @@ goog.require('ol.Map');
  * @param {Object.<string, *>=} options additional properties (optional)
  */
 ome.ol3.Viewer = function(id, options) {
-	goog.base(this);
+    goog.base(this);
 
-	var opts = options || {};
-
-	/**
-	 * the image id
-	 *
-	 * @type {number}
-	 * @private
-	 */
-	this.id_ = id || -1;
-	try {
-		this.id_ = parseInt(this.id_);
-	} catch(not_a_number) {
-		id = -1;
-	}
+    var opts = options || {};
 
     /**
-	 * are we in the split view
-	 *
-	 * @type {boolean}
-	 * @private
-	 */
+     * the image id
+     *
+     * @type {number}
+     * @private
+     */
+    this.id_ = id || -1;
+    try {
+        this.id_ = parseInt(this.id_);
+    } catch(not_a_number) {
+        id = -1;
+    }
+
+    /**
+     * are we in the split view
+     *
+     * @type {boolean}
+     * @private
+     */
     this.split_ = false;
 
-	/**
-	 * an omero server address given as a fully qualified address
-	 * https://some_host:[some_port]
-	 *
-	 * if not supplied we use relative to what our location is which is the best
-	 * solution for same origin anyhow.
-	 *
-	 * after input sanitization we end up with a server info object
-	 *
-	 * @type {Object}
-	 * @private
-	 */
-	this.server_ = ome.ol3.utils.Net.checkAndSanitizeServerAddress(opts['server'] || "");
+    /**
+     * an omero server address given as a fully qualified address
+     * https://some_host:[some_port]
+     *
+     * if not supplied we use relative to what our location is which is the best
+     * solution for same origin anyhow.
+     *
+     * after input sanitization we end up with a server info object
+     *
+     * @type {Object}
+     * @private
+     */
+    this.server_ = ome.ol3.utils.Net.checkAndSanitizeServerAddress(opts['server'] || "");
 
     /**
-	 * some initial values/parameters for channel, model and projection (optional)
-	 *
-	 * @type {Object}
-	 * @private
-	 */
-	this.initParams_ = opts['initParams'] || {};
+     * some initial values/parameters for channel, model and projection (optional)
+     *
+     * @type {Object}
+     * @private
+     */
+    this.initParams_ = opts['initParams'] || {};
 
     /**
-	 * a list of (possibly prefixed) uris for lookup
-	 * @type {Object}
-	 * @private
-	 */
-	this.prefixed_uris_ = {};
+     * a list of (possibly prefixed) uris for lookup
+     * @type {Object}
+     * @private
+     */
+    this.prefixed_uris_ = {};
     this.readPrefixedUris(this.initParams_);
 
     /**
-	 * because of async wait until map has been instatiated, an addRegions call
+     * because of async wait until map has been instatiated, an addRegions call
      * might not be able to execute successfully. this flag tells us so that
      * we can make one once the map initialization has finished
-	 * @type {boolean}
-	 * @private
-	 */
-	 this.tried_regions = false;
+     * @type {boolean}
+     * @private
+     */
+     this.tried_regions = false;
 
-	/**
-	 * a flag that's only relevant if the server is not same orgin.
-	 * then we have to go different ways to redirect the user to the server login.
-	 * this flag reminds us if we've done so or still need to do so, i.e. if we
-	 * have a supposed session or not.
-	 *
-	 * @type {boolean}
-	 * @private
-	 */
-	 this.haveMadeCrossOriginLogin_ =
-	 	ome.ol3.utils.Net.isSameOrigin(this.server_) ? true : false;
-	if (!this.haveMadeCrossOriginLogin_ &&
-		window['location']['href'].indexOf("haveMadeCrossOriginLogin_") !== -1)
-		this.haveMadeCrossOriginLogin_ = true;
+    /**
+     * a flag that's only relevant if the server is not same orgin.
+     * then we have to go different ways to redirect the user to the server login.
+     * this flag reminds us if we've done so or still need to do so, i.e. if we
+     * have a supposed session or not.
+     *
+     * @type {boolean}
+     * @private
+     */
+     this.haveMadeCrossOriginLogin_ =
+         ome.ol3.utils.Net.isSameOrigin(this.server_) ? true : false;
+    if (!this.haveMadeCrossOriginLogin_ &&
+        window['location']['href'].indexOf("haveMadeCrossOriginLogin_") !== -1)
+        this.haveMadeCrossOriginLogin_ = true;
 
-	/**
-	 * the id of the element serving as the container for the viewer
-	 * @type {string}
-	 * @private
-	 */
-	this.container_ = "ome_viewer";
-	if (typeof(opts['container']) === 'string')
-		this.container_ = opts['container'];
+    /**
+     * the id of the element serving as the container for the viewer
+     * @type {string}
+     * @private
+     */
+    this.container_ = "ome_viewer";
+    if (typeof(opts['container']) === 'string')
+        this.container_ = opts['container'];
 
-	/**
-	 * the associated image information
-	 * as retrieved from the omero server
-	 * @type {Object}
-	 * @private
-	 */
-	 this.image_info_ = null;
+    /**
+     * the associated image information
+     * as retrieved from the omero server
+     * @type {Object}
+     * @private
+     */
+    this.image_info_ = null;
 
-	 /**
- 	 * the associated OmeroRegions object
- 	 * @type {ome.ol3.source.Regions}
- 	 * @private
- 	 */
- 	 this.regions_ = null;
+    /**
+     * the associated OmeroRegions object
+     * @type {ome.ol3.source.Regions}
+     * @private
+     */
+    this.regions_ = null;
 
-	 /**
- 	 * the 'viewer state', i.e. the controls and interactions that were added
- 	 * the items in the map have the following layout
-	 * <pre>
-	 *  "key" : { type : "interaction/control", ref : reference_to_instance}
-	 * </pre>
-	 *
-	 * IMPORTANT:
-	 * <ul>
-	 * <li>The key has to be the same as in {@link ome.ol3.AVAILABLE_VIEWER_INTERACTIONS} or
-	 * {@link ome.ol3.AVAILABLE_VIEWER_CONTROLS}</li>
-	 * <li>The type has to be: 'interaction' or 'control'</li>
-	 * <li>The reference has to exist so that the component can be individually unregistered</li>
-	 * </ul>
-	 *
- 	 * @type {Object}
- 	 * @private
- 	 */
-	 this.viewerState_ = {};
+    /**
+     * the 'viewer state', i.e. the controls and interactions that were added
+     * the items in the map have the following layout
+     * <pre>
+     *  "key" : { type : "interaction/control", ref : reference_to_instance}
+     * </pre>
+     *
+     * IMPORTANT:
+     * <ul>
+     * <li>The key has to be the same as in {@link ome.ol3.AVAILABLE_VIEWER_INTERACTIONS} or
+     * {@link ome.ol3.AVAILABLE_VIEWER_CONTROLS}</li>
+     * <li>The type has to be: 'interaction' or 'control'</li>
+     * <li>The reference has to exist so that the component can be individually unregistered</li>
+     * </ul>
+     *
+     * @type {Object}
+     * @private
+     */
+    this.viewerState_ = {};
 
-	/**
-	 * the viewer (ol.Map) instance
-	 *
-	 * @type {ol.Map}
-	 * @private
-	 */
-	 this.viewer_ = null;
+    /**
+     * the viewer (ol.Map) instance
+     *
+     * @type {ol.Map}
+     * @private
+     */
+    this.viewer_ = null;
 
-	 /**
- 	 * an EventBus instance
- 	 *
- 	 * @type {EventBus}
- 	 * @private
- 	 */
- 	 this.eventbus_ =
+    /**
+     * an EventBus instance
+     *
+     * @type {EventBus}
+     * @private
+     */
+    this.eventbus_ =
         typeof opts['eventbus'] === 'object' &&
         typeof  opts['eventbus']['publish'] === 'function' ?
         opts['eventbus'] : null;
 
-	/**
- 	 * The initialization function performs the following steps:
-	 * 1. Request image data as json
-	 * 2. Store the image data internally
-	 * 3. Build open layer objects needed for map creation
-	 * 4. Instantiate the Viewer(ol.Map) and store it interally
-	 *
-	 * Note: steps 2-4 are done asynchroniously after the image data
-	 * 			has been received.
- 	 *
- 	 * @function
-	 * @param {Object} scope the java script context
-	 * @param {?function} postSuccessHook an optional post success handler
+    /**
+     * The initialization function performs the following steps:
+     * 1. Request image data as json
+     * 2. Store the image data internally
+     * 3. Build open layer objects needed for map creation
+     * 4. Instantiate the Viewer(ol.Map) and store it interally
+     *
+     * Note: steps 2-4 are done asynchroniously after the image data
+     *       has been received.
+     *
+     * @function
+     * @param {Object} scope the java script context
+     * @param {?function} postSuccessHook an optional post success handler
      * @param {?function} initHook an optional initialization handler
- 	 * @private
- 	 */
- 	 this.initialize_ = function(scope, postSuccessHook, initHook) {
-		 // can happen if we instantitate the viewer without id
-		 if (scope.id_ < 0) return;
+     * @private
+     */
+    this.initialize_ = function(scope, postSuccessHook, initHook) {
+        // can happen if we instantitate the viewer without id
+        if (scope.id_ < 0) return;
 
-			// the success handler builds the open layers map
-			var success = function(data) {
-				if (typeof(data) === 'string') {
-					try {
-						data = JSON.parse(data);
-					} catch(parseError) {
-						console.error("Failed to parse json response!");
-					}
-				}
-				if (typeof(data) !== 'object') {
-						console.error("Image Request did not receive proper response!");
-						return;
-				 }
-				 // store response internally to be able to work with it later
-				 scope.image_info_ = data;
-
-				 if (typeof(scope.image_info_['size']) === 'undefined') {
-						console.error("Image Info does not contain size info!");
-						return;
-				}
-
-                // we might need to run some initialization handler after we have
-                // received the json respone.
-                if (typeof initHook === 'function') initHook.call(scope);
-
-				/*
-				 * get dimensions of image: width,height, z, t and c sizes,
-				 * as well as zoom levels for pyramids
-				 * for openlayers we gotta prepare the resolutions
-				 * as 1 / res and reverse the order
-				 */
-				var zoomLevelScaling = null;
-				var dims = scope.image_info_['size'];
-				if (scope.image_info_['zoomLevelScaling']) {
-					var tmp = [];
-					for (var r in scope.image_info_['zoomLevelScaling'])
-						tmp.push(1 / scope.image_info_['zoomLevelScaling'][r]);
-					zoomLevelScaling = tmp.reverse();
-				}
-				var zoom= zoomLevelScaling ? zoomLevelScaling.length : -1;
-
-                // we have to check the initial projection so that we can adjust
-                // the view potentially to cater for split view in the code below
-                var initialProjection =
-                    scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.PROJECTION);
-                initialProjection =
-                   initialProjection !== null ? initialProjection.toLowerCase() :
-                       scope.image_info_['rdefs']['projection']
-                if (initialProjection !== 'normal' &&
-                   initialProjection !== 'intmax' && initialProjection !== 'split')
-                   initialProjection = 'normal';
-               if (initialProjection === 'split')
-                   scope.split_ = true;
-
-               // in the same spirit we need the model so that in the split channel
-               // case we get the proper dimensions from the json
-               var initialModel =
-                    scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.MODEL);
-                initialModel =
-                   initialModel !== null ? initialModel :
-                       scope.image_info_['rdefs']['model']
-                var lowerCaseModel = initialModel.toLowerCase()[0];
-                switch (lowerCaseModel) {
-                    case 'c': initialModel = 'color'; break;
-                    case 'g': initialModel = 'greyscale'; break;
-                    default: initialModel = 'color';
-                };
-
-               // should we be in the split view mode, we need to trick ol3
-               // and set the dims and tile sizes accordingly to essentially
-               // request 1 tile with the dimensions of the entire image extent
-               if (scope.split_) {
-                   var tmpDims =
-                        scope.image_info_['split_channel'][initialModel[0]];
-                    if (typeof tmpDims === 'object' && tmpDims) {
-                        dims['width'] = tmpDims['width'];
-                        dims['height'] = tmpDims['height'];
-                        scope.image_info_['tile_size'] =
-                            {"width" : dims['width'], "height" : dims['height']};
-                    }
-                    initialProjection = "split";
-               }
-
-				// determine the center
-				var imgCenter = [dims['width'] / 2, -dims['height'] / 2];
-                // pixel size
-                var pixelSize =
-                    typeof scope.image_info_['pixel_size'] === "object" &&
-                    typeof scope.image_info_['pixel_size']['x'] === "number" ?
-                        scope.image_info_['pixel_size']['x'] : null;
-
-				// instantiate a pixel projection for omero data
-				var proj = new ol.proj.Projection({
-					 code: 'OMERO',
-					 units: 'pixels',
-					 extent: [0, 0, dims['width'], dims['height']],
-                     metersPerUnit : pixelSize
-				 });
-
-                 // we might have some requested defaults
-                 var initialTime =
-                     scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.TIME);
-                 initialTime =
-                    initialTime !== null ? (parseInt(initialTime)-1) :
-                    scope.image_info_['rdefs']['defaultT'];
-                if (initialTime < 0) initialTime = 0;
-                if (initialTime >= dims.t) initialTime =  dims.t-1;
-                 var initialPlane =
-                     scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.PLANE);
-                 initialPlane =
-                    initialPlane !== null ? (parseInt(initialPlane)-1) :
-                        scope.image_info_['rdefs']['defaultZ'];
-                if (initialPlane < 0) initialPlane = 0;
-                if (initialPlane >= dims.z) initialPlane =  dims.z-1;
-                 var initialCenterX =
-                     scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CENTER_X);
-                 var initialCenterY =
-                     scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CENTER_Y);
-                if (initialCenterX && !isNaN(parseFloat(initialCenterX)) &&
-                    initialCenterY && !isNaN(parseFloat(initialCenterY))) {
-                    initialCenterX = parseFloat(initialCenterX);
-                    initialCenterY = parseFloat(initialCenterY);
-                    if (initialCenterY > 0) initialCenterY = -initialCenterY;
-                    if (initialCenterX >=0 && initialCenterX <= dims['width'] &&
-                        -initialCenterY >=0 && -initialCenterX <= dims['height'])
-                    imgCenter = [initialCenterX, initialCenterY];
+        // the success handler builds the open layers map
+        var success = function(data) {
+            if (typeof(data) === 'string') {
+                try {
+                    data = JSON.parse(data);
+                } catch(parseError) {
+                    console.error("Failed to parse json response!");
                 }
-                var initialChannels =
-                    scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CHANNELS);
-                initialChannels =
-                    ome.ol3.utils.Misc.parseChannelParameters(initialChannels);
+            }
+            if (typeof(data) !== 'object') {
+                console.error("Image Request did not receive proper response!");
+                return;
+             }
+             // store response internally to be able to work with it later
+             scope.image_info_ = data;
 
-				// copy needed channels info
-				var channels = [];
-				for (var c in scope.image_info_['channels']) {
-						var oldC = scope.image_info_['channels'][c];
-					 	var newC = {
-							"active" : oldC['active'],
-							"color" :
-                                typeof oldC['lut'] === 'string' &&
-                                oldC['lut'].length > 0 ?
-                                    oldC['lut'] : oldC['color'],
-							"min" : oldC['window']['min'],
-							"max" : oldC['window']['max'],
-							"start" : oldC['window']['start'],
-							"end" : oldC['window']['end']
-					 	};
-                        if (typeof oldC['reverseIntensity'] === 'boolean')
-                            newC['reverse'] = oldC['reverseIntensity'];
-						channels.push(newC);
-					}
+             if (typeof(scope.image_info_['size']) === 'undefined') {
+                console.error("Image Info does not contain size info!");
+                return;
+            }
 
-				// create an OmeroImage source (tiled)
-				 var source = new ome.ol3.source.Image({
-					 server : scope.getServer(),
-					 uri : scope.getPrefixedURI(ome.ol3.WEBGATEWAY),
-					 image: scope.id_,
-					 width: dims['width'],
-					 height: dims['height'],
-					 plane: initialPlane,
-                     time: initialTime,
-					 channels: channels,
-					 resolutions: zoom > 1 ? zoomLevelScaling : [1],
-                     img_proj:  initialProjection,
-                     img_model:  initialModel,
-                     split: scope.split_,
-					 tile_size:  scope.image_info_['tile_size'] ?
-					 	scope.image_info_['tile_size'] : null
-				 });
-                 source.changeChannelRange(initialChannels, false);
+            // we might need to run some initialization handler after we have
+            // received the json respone.
+            if (typeof initHook === 'function') initHook.call(scope);
 
-                 var actualZoom = zoom > 1 ? zoomLevelScaling[0] : 1;
-                 var initialZoom =
-                     scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.ZOOM);
-                 var possibleResolutions =
-                    ome.ol3.utils.Misc.prepareResolutions(zoomLevelScaling);
-                 if (initialZoom && !isNaN(parseFloat(initialZoom))) {
-                     initialZoom = (1 / (parseFloat(initialZoom) / 100));
-                     var posLen = possibleResolutions.length;
-                     if (posLen > 1) {
-                         if (initialZoom >= possibleResolutions[0])
-                            actualZoom = possibleResolutions[0];
-                         else if (initialZoom <= possibleResolutions[posLen-1])
-                            actualZoom = possibleResolutions[posLen-1];
-                         else {
-                             // find nearest resolution
-                             for (var r=0;r<posLen-1;r++) {
-                                 if (initialZoom < possibleResolutions[r+1])
-                                    continue;
-                                 var d1 =
-                                    Math.abs(
-                                        possibleResolutions[r] - initialZoom);
-                                 var d2 =
-                                    Math.abs(
-                                       possibleResolutions[r+1] - initialZoom);
-                                 if (d1 < d2)
-                                    actualZoom = possibleResolutions[r];
-                                 else actualZoom = possibleResolutions[r+1];
-                                 break;
-                             }
-                         }
-                     } else actualZoom = 1;
-                 }
+            /*
+             * get dimensions of image: width,height, z, t and c sizes,
+             * as well as zoom levels for pyramids
+             * for openlayers we gotta prepare the resolutions
+             * as 1 / res and reverse the order
+             */
+            var zoomLevelScaling = null;
+            var dims = scope.image_info_['size'];
+            if (scope.image_info_['zoomLevelScaling']) {
+                var tmp = [];
+                for (var r in scope.image_info_['zoomLevelScaling'])
+                    tmp.push(1 / scope.image_info_['zoomLevelScaling'][r]);
+                zoomLevelScaling = tmp.reverse();
+            }
+            var zoom= zoomLevelScaling ? zoomLevelScaling.length : -1;
 
-				 // we need a View object for the map
-				 var view = new ol.View({
-	 					projection: proj,
-	 					center: imgCenter,
-	 					extent: [0, -dims['height'], dims['width'], 0],
-	 					resolutions : ome.ol3.utils.Misc.prepareResolutions(zoomLevelScaling),
-	 					resolution : actualZoom
-	 			});
+            // we have to check the initial projection so that we can adjust
+            // the view potentially to cater for split view in the code below
+            var initialProjection =
+                scope.getInitialRequestParam(
+                    ome.ol3.REQUEST_PARAMS.PROJECTION);
+            initialProjection =
+               initialProjection !== null ? initialProjection.toLowerCase() :
+                   scope.image_info_['rdefs']['projection']
+            if (initialProjection !== 'normal' &&
+                initialProjection !== 'intmax' &&
+                initialProjection !== 'split')
+                initialProjection = 'normal';
+           if (initialProjection === 'split')
+               scope.split_ = true;
 
-				// we have a need to keep a list & reference of the controls
-				// and interactions registered, therefore we need to take a
-				// slighlty longer route to add them to the map
-				var defaultInteractions = ome.ol3.defaultInteractions();
-				var interactions = new ol.Collection();
-				for (var inter in defaultInteractions) {
-					interactions.push(defaultInteractions[inter]['ref']);
-					scope.viewerState_[inter] = defaultInteractions[inter];
-				}
-				var defaultControls = ome.ol3.defaultControls();
-				var controls = new ol.Collection();
-				for (var contr in defaultControls) {
-					controls.push(defaultControls[contr]['ref']);
-                    scope.viewerState_[contr] = defaultControls[contr];
-				}
+           // in the same spirit we need the model so that in the split channel
+           // case we get the proper dimensions from the json
+           var initialModel =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.MODEL);
+            initialModel =
+               initialModel !== null ? initialModel :
+                   scope.image_info_['rdefs']['model']
+            var lowerCaseModel = initialModel.toLowerCase()[0];
+            switch (lowerCaseModel) {
+                case 'c': initialModel = 'color'; break;
+                case 'g': initialModel = 'greyscale'; break;
+                default: initialModel = 'color';
+            };
 
-                var targetElement = document.getElementById(scope.container_);
-                if (targetElement === null)
-                    return;
+            // should we be in the split view mode, we need to trick ol3
+            // and set the dims and tile sizes accordingly to essentially
+            // request 1 tile with the dimensions of the entire image extent
+            if (scope.split_) {
+                var tmpDims =
+                    scope.image_info_['split_channel'][initialModel[0]];
+                if (typeof tmpDims === 'object' && tmpDims) {
+                    dims['width'] = tmpDims['width'];
+                    dims['height'] = tmpDims['height'];
+                    scope.image_info_['tile_size'] =
+                    {"width" : dims['width'], "height" : dims['height']};
+                }
+                initialProjection = "split";
+            }
 
-                var children =
-                    Array.prototype.slice.call(targetElement.childNodes);
-                for (var child in children)
-                    targetElement.removeChild(children[child]);
+            // determine the center
+            var imgCenter = [dims['width'] / 2, -dims['height'] / 2];
+            // pixel size
+            var pixelSize =
+                typeof scope.image_info_['pixel_size'] === "object" &&
+                typeof scope.image_info_['pixel_size']['x'] === "number" ?
+                    scope.image_info_['pixel_size']['x'] : null;
 
-				// finally construct the open layers map object
-				scope.viewer_ = new ol.Map({
-					logo: false,
-					controls: controls,
-					interactions:  interactions,
-					renderer: ol.renderer.Type.CANVAS,
-					layers: [new ol.layer.Tile({source: source, preload: Infinity})],
-					target: scope.container_,
-					view: view
-				});
+            // instantiate a pixel projection for omero data
+            var proj = new ol.proj.Projection({
+                 code: 'OMERO',
+                 units: 'pixels',
+                 extent: [0, 0, dims['width'], dims['height']],
+                 metersPerUnit : pixelSize
+             });
 
-                // listens to resolution changes
-                scope.onViewResolutionListener =
-        			ol.events.listen( // register a resolution handler for zoom display
-        				scope.viewer_.getView(), "change:resolution",
-        				function(event) {
-                            this.displayResolutionInPercent();
-        				}, scope);
-                scope.displayResolutionInPercent();
+            // we might have some requested defaults
+            var initialTime =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.TIME);
+            initialTime =
+                initialTime !== null ? (parseInt(initialTime)-1) :
+                scope.image_info_['rdefs']['defaultT'];
+            if (initialTime < 0) initialTime = 0;
+            if (initialTime >= dims.t) initialTime =  dims.t-1;
+            var initialPlane =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.PLANE);
+            initialPlane =
+                initialPlane !== null ? (parseInt(initialPlane)-1) :
+                    scope.image_info_['rdefs']['defaultZ'];
+            if (initialPlane < 0) initialPlane = 0;
+            if (initialPlane >= dims.z) initialPlane =  dims.z-1;
+            var initialCenterX =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CENTER_X);
+            var initialCenterY =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CENTER_Y);
+            if (initialCenterX && !isNaN(parseFloat(initialCenterX)) &&
+                initialCenterY && !isNaN(parseFloat(initialCenterY))) {
+                initialCenterX = parseFloat(initialCenterX);
+                initialCenterY = parseFloat(initialCenterY);
+                if (initialCenterY > 0) initialCenterY = -initialCenterY;
+                if (initialCenterX >=0 && initialCenterX <= dims['width'] &&
+                    -initialCenterY >=0 && -initialCenterX <= dims['height'])
+                imgCenter = [initialCenterX, initialCenterY];
+            }
+            var initialChannels =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.CHANNELS);
+            initialChannels =
+                ome.ol3.utils.Misc.parseChannelParameters(initialChannels);
 
-                // an endMove listener to publish move events
-                if (scope.eventbus_)
-                    scope.onEndMoveListener =
-                        ol.events.listen(
-                            scope.viewer_, ol.MapEvent.Type.MOVEEND,
-                            function(event) {
-                                this.eventbus_.publish(
-                                    "IMAGE_INTERACTION",
-                                    {"config_id": this.getTargetId(),
-                                     "z": this.getDimensionIndex('z'),
-                                     "t": this.getDimensionIndex('t'),
-                                     "c": this.getDimensionIndex('c'),
-                                     "center": this.viewer_.getView().getCenter()});
-                            }, scope);
+            // copy needed channels info
+            var channels = [];
+            for (var c in scope.image_info_['channels']) {
+                var oldC = scope.image_info_['channels'][c];
+                var newC = {
+                    "active" : oldC['active'],
+                    "color" :
+                        typeof oldC['lut'] === 'string' &&
+                        oldC['lut'].length > 0 ? oldC['lut'] : oldC['color'],
+                    "min" : oldC['window']['min'],
+                    "max" : oldC['window']['max'],
+                    "start" : oldC['window']['start'],
+                    "end" : oldC['window']['end']
+                };
+                if (typeof oldC['reverseIntensity'] === 'boolean')
+                    newC['reverse'] = oldC['reverseIntensity'];
+                channels.push(newC);
+            }
 
-				// this is for work that needs to be done after,
-				// e.g we have just switched images
-				// because of the asynchronious nature of the initialization
-				// we need to do this here
-				if (typeof(postSuccessHook) === 'function')
-					postSuccessHook.call(scope);
+            // create an OmeroImage source (tiled)
+            var source = new ome.ol3.source.Image({
+                server : scope.getServer(),
+                uri : scope.getPrefixedURI(ome.ol3.WEBGATEWAY),
+                image: scope.id_,
+                width: dims['width'],
+                height: dims['height'],
+                plane: initialPlane,
+                time: initialTime,
+                channels: channels,
+                resolutions: zoom > 1 ? zoomLevelScaling : [1],
+                img_proj:  initialProjection,
+                img_model:  initialModel,
+                split: scope.split_,
+                tile_size:
+                    scope.image_info_['tile_size'] ?
+                        scope.image_info_['tile_size'] : null
+            });
+            source.changeChannelRange(initialChannels, false);
 
-                if (scope.tried_regions) scope.addRegions();
-			};
+            var actualZoom = zoom > 1 ? zoomLevelScaling[0] : 1;
+            var initialZoom =
+                scope.getInitialRequestParam(ome.ol3.REQUEST_PARAMS.ZOOM);
+            var possibleResolutions =
+                ome.ol3.utils.Misc.prepareResolutions(zoomLevelScaling);
+            if (initialZoom && !isNaN(parseFloat(initialZoom))) {
+                initialZoom = (1 / (parseFloat(initialZoom) / 100));
+                var posLen = possibleResolutions.length;
+                if (posLen > 1) {
+                    if (initialZoom >= possibleResolutions[0])
+                        actualZoom = possibleResolutions[0];
+                    else if (initialZoom <= possibleResolutions[posLen-1])
+                        actualZoom = possibleResolutions[posLen-1];
+                    else {
+                        // find nearest resolution
+                        for (var r=0;r<posLen-1;r++) {
+                            if (initialZoom < possibleResolutions[r+1])
+                                continue;
+                            var d1 =
+                                Math.abs(possibleResolutions[r] - initialZoom);
+                            var d2 =
+                                Math.abs(possibleResolutions[r+1] - initialZoom);
+                            if (d1 < d2)
+                                actualZoom = possibleResolutions[r];
+                            else actualZoom = possibleResolutions[r+1];
+                            break;
+                        }
+                    }
+                } else actualZoom = 1;
+            }
 
-			// define request settings
-			var reqParams = {
-				 "server" : scope.getServer(),
-				 "uri" : scope.getPrefixedURI(ome.ol3.WEBGATEWAY) +
-                            '/imgData/' + scope.id_,
-				 "jsonp" : true, // this will only count if we are cross-domain
-				 "success" : success,
-				 "error" : function(error) {
-					 console.error("Error retrieving image info for id: " + scope.id_ +
-					 	((error && error.length > 0) ? (" => " + error) : ""));
-				 }
-			};
+            // we need a View object for the map
+            var view = new ol.View({
+                projection: proj,
+                center: imgCenter,
+                extent: [0, -dims['height'], dims['width'], 0],
+                resolutions :
+                    ome.ol3.utils.Misc.prepareResolutions(zoomLevelScaling),
+                resolution : actualZoom
+            });
 
-			// send request
-			ome.ol3.utils.Net.sendRequest(reqParams);
-	 };
+            // we have a need to keep a list & reference of the controls
+            // and interactions registered, therefore we need to take a
+            // slighlty longer route to add them to the map
+            var defaultInteractions = ome.ol3.defaultInteractions();
+            var interactions = new ol.Collection();
+            for (var inter in defaultInteractions) {
+                interactions.push(defaultInteractions[inter]['ref']);
+                scope.viewerState_[inter] = defaultInteractions[inter];
+            }
+            var defaultControls = ome.ol3.defaultControls();
+            var controls = new ol.Collection();
+            for (var contr in defaultControls) {
+                controls.push(defaultControls[contr]['ref']);
+                scope.viewerState_[contr] = defaultControls[contr];
+            }
 
-	// execute initialization function
-	// for cross domain we check whether we need to have a login made, otherwise
-	// we redirect to there ...
-	if (ome.ol3.utils.Net.isSameOrigin(this.server_) || this.haveMadeCrossOriginLogin_) {
-		this.initialize_(this);
-	} else ome.ol3.utils.Net.makeCrossDomainLoginRedirect(this.server_);
+            var targetElement = document.getElementById(scope.container_);
+            if (targetElement === null) return;
+
+            var children =
+                Array.prototype.slice.call(targetElement.childNodes);
+            for (var child in children)
+                targetElement.removeChild(children[child]);
+
+            // finally construct the open layers map object
+            scope.viewer_ = new ol.Map({
+                logo: false,
+                controls: controls,
+                interactions:  interactions,
+                renderer: ol.renderer.Type.CANVAS,
+                layers: [new ol.layer.Tile({source: source, preload: Infinity})],
+                target: scope.container_,
+                view: view
+            });
+
+            // listens to resolution changes
+            scope.onViewResolutionListener =
+                ol.events.listen( // register a resolution handler for zoom display
+                    scope.viewer_.getView(), "change:resolution",
+                    function(event) {
+                        this.displayResolutionInPercent();
+                    }, scope);
+            scope.displayResolutionInPercent();
+
+            // an endMove listener to publish move events
+            if (scope.eventbus_)
+                scope.onEndMoveListener =
+                    ol.events.listen(
+                        scope.viewer_, ol.MapEvent.Type.MOVEEND,
+                        function(event) {
+                            this.eventbus_.publish(
+                                "IMAGE_INTERACTION",
+                                {"config_id": this.getTargetId(),
+                                 "z": this.getDimensionIndex('z'),
+                                 "t": this.getDimensionIndex('t'),
+                                 "c": this.getDimensionIndex('c'),
+                                 "center": this.viewer_.getView().getCenter()});
+                        }, scope);
+
+            // this is for work that needs to be done after,
+            // e.g we have just switched images
+            // because of the asynchronious nature of the initialization
+            // we need to do this here
+            if (typeof(postSuccessHook) === 'function')
+                postSuccessHook.call(scope);
+
+            if (scope.tried_regions) scope.addRegions();
+        };
+
+        // define request settings
+        var reqParams = {
+            "server" : scope.getServer(),
+            "uri" : scope.getPrefixedURI(ome.ol3.WEBGATEWAY) +
+                '/imgData/' + scope.id_,
+            "jsonp" : true, // this will only count if we are cross-domain
+            "success" : success,
+            "error" : function(error) {
+                console.error("Error retrieving image info for id: " +
+                    scope.id_ +
+                    ((error && error.length > 0) ? (" => " + error) : ""));
+            }
+        };
+
+        // send request
+        ome.ol3.utils.Net.sendRequest(reqParams);
+    };
+
+    // execute initialization function
+    // for cross domain we check whether we need to have a login made, otherwise
+    // we redirect to there ...
+    if (ome.ol3.utils.Net.isSameOrigin(this.server_) || this.haveMadeCrossOriginLogin_) {
+        this.initialize_(this);
+    } else ome.ol3.utils.Net.makeCrossDomainLoginRedirect(this.server_);
 };
 goog.inherits(ome.ol3.Viewer, ol.Object);
 
@@ -531,18 +532,16 @@ goog.inherits(ome.ol3.Viewer, ol.Object);
  * Shows the viewer
  */
 ome.ol3.Viewer.prototype.show = function() {
-	var viewerElement = document.getElementById(this.container_);
-	if (viewerElement)
-		viewerElement.style.visibility = "visible";
+    var viewerElement = document.getElementById(this.container_);
+    if (viewerElement) viewerElement.style.visibility = "visible";
 }
 
 /**
  * Hides the viewer
  */
 ome.ol3.Viewer.prototype.hide = function() {
-	var viewerElement = document.getElementById(this.container_);
-	if (viewerElement)
-		viewerElement.style.visibility = "hidden";
+    var viewerElement = document.getElementById(this.container_);
+    if (viewerElement) viewerElement.style.visibility = "hidden";
 }
 
 /**
@@ -567,13 +566,13 @@ ome.ol3.Viewer.prototype.toggleSplitView = function(flag) {
     for (var c in this.getImage().channels_info_) {
         var oldC = this.getImage().channels_info_[c];
         defC.push({
-             "active" : oldC.active,
-             "color" : oldC.color,
-             "window" : {
-                 "min" : oldC.min,
-                 "max" : oldC.max,
-                 "start": oldC.start,
-                 "end": oldC.end}
+            "active" : oldC.active,
+            "color" : oldC.color,
+            "window" : {
+                "min" : oldC.min,
+                "max" : oldC.max,
+                "start": oldC.start,
+                "end": oldC.end}
         });
     }
     var initHook = function() {
@@ -609,57 +608,58 @@ ome.ol3.Viewer.prototype.toggleSplitView = function(flag) {
  *  defaults to false and is only useful on rare occasions: e.g. split channel view
  */
 ome.ol3.Viewer.prototype.changeToImage =
-	function(id, keep_viewer_state,
-                reinitialize_on_same_image, reinit_handler) {
+    function(id, keep_viewer_state, reinitialize_on_same_image, reinit_handler) {
         var viewer_state =
-			typeof(keep_viewer_state) === 'boolean' ? keep_viewer_state : false;
+            typeof(keep_viewer_state) === 'boolean' ? keep_viewer_state : false;
         if (typeof reinitialize_on_same_image !== 'boolean')
             reinitialize_on_same_image = false;
         if (id === this.id_ && !reinitialize_on_same_image) return;
 
         // clean up, remember registered controls/interactions
-		var componentsRegistered = this.dispose(viewer_state);
+        var componentsRegistered = this.dispose(viewer_state);
 
-		// set new id
-		this.id_ = id;
-		try {
-			this.id_ = parseInt(this.id_);
-		} catch(not_a_number) {}
+        // set new id
+        this.id_ = id;
+        try {
+            this.id_ = parseInt(this.id_);
+        } catch(not_a_number) {}
         if (typeof this.id_ !== 'number' || this.id_ <=0)
             console.error('Image Id has to be a strictly positive integer');
 
-		/*
-		 * add controls and interactions to restore previous 'viewer state'
-		 * we also check if after initialization (see above) the control/interaction
-		 * hasn't been established already by default so as to avoid multiple Loading
-		 * in order to get the interaction/control class that we need to instantiate
-		 * we look it up at {@link ome.ol3.AVAILABLE_VIEWER_CONTROLS} or
-		 * {@link ome.ol3.AVAILABLE_VIEWER_INTERACTIONS}
-		 * via the key value stored for the previously registered components
-		 *
-		 * Important: all of this needs to be done post reinitialization since we
-		 * require an ajax request to get the new image info and reestablishe the
-		 * viewer
-		 */
-		var postSuccessHook = function() {
-			// reastablish registered controls/interactions
-			for (var c in componentsRegistered) {
-				var prevComp = componentsRegistered[c];
-				var type = prevComp['type'];
-				var key = prevComp['key'];
+        /*
+         * add controls and interactions to restore previous 'viewer state'
+         * we also check if after initialization (see above) the control/interaction
+         * hasn't been established already by default so as to avoid multiple Loading
+         * in order to get the interaction/control class that we need to instantiate
+         * we look it up at {@link ome.ol3.AVAILABLE_VIEWER_CONTROLS} or
+         * {@link ome.ol3.AVAILABLE_VIEWER_INTERACTIONS}
+         * via the key value stored for the previously registered components
+         *
+         * Important: all of this needs to be done post reinitialization since we
+         * require an ajax request to get the new image info and reestablishe the
+         * viewer
+         */
+        var postSuccessHook = function() {
+            // reastablish registered controls/interactions
+            for (var c in componentsRegistered) {
+                var prevComp = componentsRegistered[c];
+                var type = prevComp['type'];
+                var key = prevComp['key'];
 
-				this.addInteractionOrControl(key, type);
-			}
-		}
+                this.addInteractionOrControl(key, type);
+            }
+        }
 
-		// reinitialize everything
-		// we also check for cross domain if we have the login flag set to true already
-		// otherwise we don't need to bother
-		if (ome.ol3.utils.Net.isSameOrigin(this.server_) || this.haveMadeCrossOriginLogin_) {
-			this.initialize_(
-                this, postSuccessHook,
-                typeof reinit_handler === 'function' ? reinit_handler : null);
-		} else ome.ol3.utils.Net.makeCrossDomainLoginRedirect(this.server_);
+        // reinitialize everything
+        // we also check for cross domain if we have the login flag set to true already
+        // otherwise we don't need to bother
+        if (ome.ol3.utils.Net.isSameOrigin(this.server_) ||
+            this.haveMadeCrossOriginLogin_) {
+                this.initialize_(
+                    this, postSuccessHook,
+                    typeof reinit_handler === 'function' ?
+                        reinit_handler : null);
+        } else ome.ol3.utils.Net.makeCrossDomainLoginRedirect(this.server_);
 }
 
 /**
@@ -684,34 +684,34 @@ ome.ol3.Viewer.prototype.changeToImage =
  * @param {Object.<string, *>=} options properties not used yet and maybe never
  */
 ome.ol3.Viewer.prototype.addRegions = function(options) {
-	// without a map, no need for a regions overlay...
-	if (!(this.viewer_ instanceof ol.Map)) {
+    // without a map, no need for a regions overlay...
+    if (!(this.viewer_ instanceof ol.Map)) {
         this.tried_regions = true;
         return;
     }
     this.tried_regions = false;
-	if (this.regions_ instanceof ome.ol3.source.Regions)
-		return;
+    if (this.regions_ instanceof ome.ol3.source.Regions)
+        return;
 
-	this.regions_ = new ome.ol3.source.Regions(this, options);
-	// add a vector layer with the regions
-	if (this.regions_) {
-		this.viewer_.addLayer(new ol.layer.Vector({source : this.regions_}));
-		// enable roi selection by default,
+    this.regions_ = new ome.ol3.source.Regions(this, options);
+    // add a vector layer with the regions
+    if (this.regions_) {
+        this.viewer_.addLayer(new ol.layer.Vector({source : this.regions_}));
+        // enable roi selection by default,
         // as well as modify and translate
-		this.regions_.setModes(
+        this.regions_.setModes(
             [ome.ol3.REGIONS_MODE['SELECT'],
              ome.ol3.REGIONS_MODE['MODIFY'],
              ome.ol3.REGIONS_MODE['TRANSLATE']]);
 
-		this.onViewRotationListener =
-			ol.events.listen( // register a rerender action on rotation
-				this.viewer_.getView(), "change:rotation",
-				function(event) {
-					var regions = this.getRegions();
-					if (regions) regions.changed();
-				}, this);
-	}
+        this.onViewRotationListener =
+            ol.events.listen( // register a rerender action on rotation
+                this.viewer_.getView(), "change:rotation",
+                function(event) {
+                    var regions = this.getRegions();
+                    if (regions) regions.changed();
+                }, this);
+    }
 }
 
 /**
@@ -723,16 +723,16 @@ ome.ol3.Viewer.prototype.addRegions = function(options) {
  * @param {Array<string>} roi_shape_ids a list of string ids of the form: roi_id:shape_id
  */
 ome.ol3.Viewer.prototype.setRegionsVisibility = function(visible, roi_shape_ids) {
-	// without a regions layer there will be no regions to hide...
-	var regionsLayer = this.getRegionsLayer();
-	if (regionsLayer) {
-		var flag = visible || false;
+    // without a regions layer there will be no regions to hide...
+    var regionsLayer = this.getRegionsLayer();
+    if (regionsLayer) {
+        var flag = visible || false;
 
-		if (!ome.ol3.utils.Misc.isArray(roi_shape_ids) || roi_shape_ids.length === 0)
-			regionsLayer.setVisible(flag);
-		else
-			this.getRegions().setProperty(roi_shape_ids, "visible", flag);
-	}
+        if (!ome.ol3.utils.Misc.isArray(roi_shape_ids) || roi_shape_ids.length === 0)
+            regionsLayer.setVisible(flag);
+        else
+            this.getRegions().setProperty(roi_shape_ids, "visible", flag);
+    }
 }
 
 /**
@@ -743,9 +743,9 @@ ome.ol3.Viewer.prototype.setRegionsVisibility = function(visible, roi_shape_ids)
  * @param {boolean} flag if true we are displaying the text (if there), otherwise no
  */
 ome.ol3.Viewer.prototype.showShapeComments = function(flag) {
-	// without a regions layer there will be no regions to hide...
-	var regions = this.getRegions();
-	if (regions && typeof flag === 'boolean') {
+    // without a regions layer there will be no regions to hide...
+    var regions = this.getRegions();
+    if (regions && typeof flag === 'boolean') {
         regions.show_comments_ = flag;
         regions.changed();
     }
@@ -762,16 +762,17 @@ ome.ol3.Viewer.prototype.showShapeComments = function(flag) {
  */
 ome.ol3.Viewer.prototype.selectShapes = function(
     roi_shape_ids, selected, clear, center) {
-	// without a regions layer there will be no select of regions ...
-	var regions = this.getRegions();
-	if (regions === null || regions.select_ === null) return;
+    // without a regions layer there will be no select of regions ...
+    var regions = this.getRegions();
+    if (regions === null || regions.select_ === null) return;
 
     if (typeof clear === 'boolean' && clear) regions.select_.clearSelection();
     regions.setProperty(roi_shape_ids, "selected", selected);
 
     if (roi_shape_ids.length === 1 && typeof center === 'boolean' && center &&
-            typeof regions.idIndex_[roi_shape_ids[0]] === 'object')
-        this.fitRegionOrExtent(regions.idIndex_[roi_shape_ids[0]].getGeometry());
+        typeof regions.idIndex_[roi_shape_ids[0]] === 'object')
+            this.fitRegionOrExtent(
+                regions.idIndex_[roi_shape_ids[0]].getGeometry());
 }
 
 /**
@@ -782,11 +783,10 @@ ome.ol3.Viewer.prototype.selectShapes = function(
  * @param {boolean} undo if true we roll back, default: false
  * @param {function=} callback a success handler
  */
-ome.ol3.Viewer.prototype.deleteShapes = function(
-    roi_shape_ids, undo, callback) {
-	// without a regions layer there will be no select of regions ...
-	var regions = this.getRegions();
-	if (regions === null) return;
+ome.ol3.Viewer.prototype.deleteShapes = function(roi_shape_ids, undo, callback) {
+    // without a regions layer there will be no select of regions ...
+    var regions = this.getRegions();
+    if (regions === null) return;
 
     regions.setProperty(
         roi_shape_ids, "state",
@@ -802,10 +802,11 @@ ome.ol3.Viewer.prototype.deleteShapes = function(
  * @param {ol.geom.SimpleGeometry|ol.Extent} extent an extent
  */
 ome.ol3.Viewer.prototype.fitRegionOrExtent = function(extent) {
-	// without a regions layer there will be no select of regions ...
-	var regions = this.getRegions();
-	if (regions === null ||
-        (!ome.ol3.utils.Misc.isArray(extent) && !(extent instanceof ol.geom.SimpleGeometry))) return;
+    // without a regions layer there will be no select of regions ...
+    var regions = this.getRegions();
+    if (regions === null ||
+        (!ome.ol3.utils.Misc.isArray(extent) &&
+         !(extent instanceof ol.geom.SimpleGeometry))) return;
 
     regions.viewer_.viewer_.getView().fit(
         extent, regions.viewer_.viewer_.getSize());
@@ -824,9 +825,9 @@ ome.ol3.Viewer.prototype.centerOnShapeOrCoordinate = function(shape_or_coord) {
         return;
     }
 
-	// without a regions layer there will be no select of regions ...
-	var regions = this.getRegions();
-	if (regions === null || regions.idIndex_ === null ||
+    // without a regions layer there will be no select of regions ...
+    var regions = this.getRegions();
+    if (regions === null || regions.idIndex_ === null ||
         typeof shape_or_coord !== 'string' ||
         !(regions.idIndex_[shape_or_coord] instanceof ol.Feature)) return;
 
@@ -840,36 +841,36 @@ ome.ol3.Viewer.prototype.centerOnShapeOrCoordinate = function(shape_or_coord) {
  *
  */
 ome.ol3.Viewer.prototype.removeRegions = function(masks_only) {
-	var removeMasksOnly = false;
-	if (typeof(masks_only) === 'boolean')
-		removeMasksOnly = masks_only;
+    var removeMasksOnly = false;
+    if (typeof(masks_only) === 'boolean')
+        removeMasksOnly = masks_only;
 
-	// without an existing instance no need to destroy it...
-	if (!removeMasksOnly && this.regions_ instanceof ome.ol3.source.Regions) {
-		// reset mode which will automatically deregister interactions
-		this.regions_.setModes([ome.ol3.REGIONS_MODE['DEFAULT']]);
-		// dispose of the internal OmeroRegions instance
-		this.regions_.dispose();
-		this.regions_ = null;
-	}
+    // without an existing instance no need to destroy it...
+    if (!removeMasksOnly && this.regions_ instanceof ome.ol3.source.Regions) {
+        // reset mode which will automatically deregister interactions
+        this.regions_.setModes([ome.ol3.REGIONS_MODE['DEFAULT']]);
+        // dispose of the internal OmeroRegions instance
+        this.regions_.dispose();
+        this.regions_ = null;
+    }
 
-	// remove any onViewRotationListener
-	if (typeof(this.onViewRotationListener) !== 'undefined' &&
-				this.onViewRotationListener)
-			ol.events.unlistenByKey(this.onViewRotationListener);
+    // remove any onViewRotationListener
+    if (typeof(this.onViewRotationListener) !== 'undefined' &&
+        this.onViewRotationListener)
+            ol.events.unlistenByKey(this.onViewRotationListener);
 
-	var regionsLayer = this.getRegionsLayer();
-	if (regionsLayer) {
-		//remove everything down to the image layer
-		var len = this.viewer_.getLayers().getLength();
-		if (removeMasksOnly) --len;
-		for (var i=len-1; i > 0;i--) {
-			var l = this.viewer_.getLayers().item(i);
-			l.setSource(null);
-			l.sourceChangeKey_ = null;
-			this.viewer_.getLayers().removeAt(i);
-		}
-	}
+    var regionsLayer = this.getRegionsLayer();
+    if (regionsLayer) {
+        //remove everything down to the image layer
+        var len = this.viewer_.getLayers().getLength();
+        if (removeMasksOnly) --len;
+        for (var i=len-1; i > 0;i--) {
+            var l = this.viewer_.getLayers().item(i);
+            l.setSource(null);
+            l.sourceChangeKey_ = null;
+            this.viewer_.getLayers().removeAt(i);
+        }
+    }
 }
 
 /**
@@ -880,11 +881,11 @@ ome.ol3.Viewer.prototype.removeRegions = function(masks_only) {
  * @param {boolean=} rotateText flag whether text should be rotated with view resolution
  */
 ome.ol3.Viewer.prototype.setTextBehaviorForRegions = function(scaleText, rotateText) {
-	// without a regions layer there will be no regions to hide...
-	if (this.getRegionsLayer()) {
-		this.getRegions().setScaleText(scaleText);
-		this.getRegions().setRotateText(rotateText);
-	}
+    // without a regions layer there will be no regions to hide...
+    if (this.getRegionsLayer()) {
+        this.getRegions().setScaleText(scaleText);
+        this.getRegions().setRotateText(rotateText);
+    }
 }
 
 /**
@@ -898,35 +899,35 @@ ome.ol3.Viewer.prototype.setTextBehaviorForRegions = function(scaleText, rotateT
  * @param {Object} interaction an object that is an interaction
  */
 ome.ol3.Viewer.prototype.addInteraction = function(key, interaction) {
-	// if we have no interaction given as the second argument => delegate to the factory
-	if (typeof interaction !== 'object' || interaction === null) {
-		this.addInteractionOrControl(key, 'interaction');
-		return;
-	}
+    // if we have no interaction given as the second argument => delegate to the factory
+    if (typeof interaction !== 'object' || interaction === null) {
+        this.addInteractionOrControl(key, 'interaction');
+        return;
+    }
 
-	// we do have to have the key listed in the AVAILABLE_VIEWER_INTERACTIONS
-	var availableInteraction =
+    // we do have to have the key listed in the AVAILABLE_VIEWER_INTERACTIONS
+    var availableInteraction =
         typeof ome.ol3.AVAILABLE_VIEWER_INTERACTIONS[key] === 'object' ?
             ome.ol3.AVAILABLE_VIEWER_INTERACTIONS[key] : null;
-	// the given interaction has to also match the clazz
-	// of the one registered under that key
-	if (availableInteraction == null || !(interaction instanceof availableInteraction['clazz']))
-		 return;
+    // the given interaction has to also match the clazz
+    // of the one registered under that key
+    if (availableInteraction == null || !(interaction instanceof availableInteraction['clazz']))
+         return;
 
-	// if we don't have an instance in our viewer state, we return
-	if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
-				(typeof(key) !== 'string')) // key not a string
-					return;
+    // if we don't have an instance in our viewer state, we return
+    if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
+                (typeof(key) !== 'string')) // key not a string
+                    return;
 
-	if (typeof this.viewerState_[key] === 'object')
-		return;  // control/interaction already registered
+    if (typeof this.viewerState_[key] === 'object')
+        return;  // control/interaction already registered
 
-	// now we can safely add the interaction
-	this.viewer_.addInteraction(interaction);
+    // now we can safely add the interaction
+    this.viewer_.addInteraction(interaction);
     this.viewerState_[key] =
-		{"type": 'interaction', "ref": interaction,
-		"defaults" : false,
-		"links" : []};
+        {"type": 'interaction', "ref": interaction,
+        "defaults" : false,
+        "links" : []};
 }
 
 
@@ -938,8 +939,8 @@ ome.ol3.Viewer.prototype.addInteraction = function(key, interaction) {
  * @param {string} key the unique control key
  */
 ome.ol3.Viewer.prototype.addControl = function(key) {
-	// delegate
-	this.addInteractionOrControl(key, "control");
+    // delegate
+    this.addInteractionOrControl(key, "control");
 }
 
 /**
@@ -954,48 +955,48 @@ ome.ol3.Viewer.prototype.addControl = function(key) {
  * @param {boolean} descend a flag whether we should follow linked interactions/controls
  */
 ome.ol3.Viewer.prototype.addInteractionOrControl = function(key, type, descend) {
-	if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
-				(typeof(key) !== 'string') || // key not a string
-				(typeof(type) !== 'string')) return; // type is not a string
+    if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
+        (typeof(key) !== 'string') || // key not a string
+        (typeof(type) !== 'string')) return; // type is not a string
 
-	if (typeof this.viewerState_[key] === 'object')
-		return;  // control/interaction already registered
+    if (typeof this.viewerState_[key] === 'object')
+        return;  // control/interaction already registered
 
-	var followLinkedComponents = true;
-	if (typeof(descend) === 'boolean')
-		followLinkedComponents = descend;
+    var followLinkedComponents = true;
+    if (typeof(descend) === 'boolean')
+        followLinkedComponents = descend;
 
-	var componentFound =
-		(type === 'control') ?
+    var componentFound =
+        (type === 'control') ?
             (typeof ome.ol3.AVAILABLE_VIEWER_CONTROLS[key] === 'object' ?
                 ome.ol3.AVAILABLE_VIEWER_CONTROLS[key] : null) :
             (typeof ome.ol3.AVAILABLE_VIEWER_INTERACTIONS[key] === 'object' ?
                 ome.ol3.AVAILABLE_VIEWER_INTERACTIONS[key] : null);
-	if (componentFound == null) // interaction/control is not available
-		return;
+    if (componentFound == null) // interaction/control is not available
+        return;
 
-	var Constructor = componentFound['clazz'];
-	var newComponent = new Constructor(componentFound['options']);
+    var Constructor = componentFound['clazz'];
+    var newComponent = new Constructor(componentFound['options']);
 
-	if (type === 'control')
-		this.viewer_.addControl(newComponent);
-	else
-		this.viewer_.addInteraction(newComponent);
-	this.viewerState_[key] =
-		{"type": type, "ref": newComponent,
-		"defaults" : componentFound['defaults'],
-		"links" : componentFound['links']};
+    if (type === 'control')
+        this.viewer_.addControl(newComponent);
+    else
+        this.viewer_.addInteraction(newComponent);
+    this.viewerState_[key] =
+        {"type": type, "ref": newComponent,
+        "defaults" : componentFound['defaults'],
+        "links" : componentFound['links']};
 
-	// because controls have interactions and interactions have controls linked to them
-	// we are going to call ourselves again with an IMPORTANT flag that we are not
-	// going to continue this way in a cyclic manner!
-	if (followLinkedComponents) {
-		for (var link in componentFound['links'])
-			this.addInteractionOrControl(
-				componentFound['links'][link],
-				type === 'control' ? 'interaction' : 'control',
-				false);
-		}
+    // because controls have interactions and interactions have controls linked to them
+    // we are going to call ourselves again with an IMPORTANT flag that we are not
+    // going to continue this way in a cyclic manner!
+    if (followLinkedComponents) {
+        for (var link in componentFound['links'])
+            this.addInteractionOrControl(
+                componentFound['links'][link],
+                type === 'control' ? 'interaction' : 'control',
+                false);
+        }
 }
 
 /**
@@ -1006,34 +1007,34 @@ ome.ol3.Viewer.prototype.addInteractionOrControl = function(key, type, descend) 
  * @param {boolean} descend a flag whether we should follow linked interactions/controls
  */
 ome.ol3.Viewer.prototype.removeInteractionOrControl = function(key, descend) {
-	if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
-				(typeof(key) !== 'string')) return; // key is not a string
+    if (!(this.viewer_ instanceof ol.Map) || // could be the viewer was not initialized
+        (typeof(key) !== 'string')) return; // key is not a string
 
-	if (typeof this.viewerState_[key] !== 'object')
-		return;  // control/interaction already removed
+    if (typeof this.viewerState_[key] !== 'object')
+        return;  // control/interaction already removed
 
     var controlOrInteraction = this.viewerState_[key];
-	var followLinkedComponents = true;
-	if (typeof(descend) === 'boolean')
-		followLinkedComponents = descend;
+    var followLinkedComponents = true;
+    if (typeof(descend) === 'boolean')
+        followLinkedComponents = descend;
 
-	if (controlOrInteraction['type'] === 'control')
-		this.viewer_.getControls().remove(controlOrInteraction['ref']);
-	else
-		this.viewer_.getInteractions().remove(controlOrInteraction['ref']);
-	if (typeof(controlOrInteraction['ref'].disposeInternal) === 'function' &&
-				typeof(controlOrInteraction['ref'].dispose) === 'function')
-			controlOrInteraction['ref'].dispose();
-	delete this.viewerState_[key];
+    if (controlOrInteraction['type'] === 'control')
+        this.viewer_.getControls().remove(controlOrInteraction['ref']);
+    else
+        this.viewer_.getInteractions().remove(controlOrInteraction['ref']);
+    if (typeof(controlOrInteraction['ref'].disposeInternal) === 'function' &&
+                typeof(controlOrInteraction['ref'].dispose) === 'function')
+            controlOrInteraction['ref'].dispose();
+    delete this.viewerState_[key];
 
-	// because controls have interactions and interactions have controls linked to them
-	// we are going to call ourselves again with an IMPORTANT flag that we are not
-	// going to continue this way in a cyclic manner!
-	if (followLinkedComponents) {
-		for (var link in controlOrInteraction['links'])
-			this.removeInteractionOrControl(
-				controlOrInteraction['links'][link], false);
-		}
+    // because controls have interactions and interactions have controls linked to them
+    // we are going to call ourselves again with an IMPORTANT flag that we are not
+    // going to continue this way in a cyclic manner!
+    if (followLinkedComponents) {
+        for (var link in controlOrInteraction['links'])
+            this.removeInteractionOrControl(
+                controlOrInteraction['links'][link], false);
+        }
 }
 
 /**
@@ -1052,52 +1053,52 @@ ome.ol3.Viewer.prototype.removeInteractionOrControl = function(key, descend) {
  * @param {number|string} value the var-length arguments list
  */
 ome.ol3.Viewer.prototype.setDimensionIndex = function(key, value) {
-	if (typeof(key) !== 'string' || key.length === 0) // dimension key checks
-		return;
-	var lowerCaseKey = key.substr(0,1).toLowerCase();
+    if (typeof(key) !== 'string' || key.length === 0) // dimension key checks
+        return;
+    var lowerCaseKey = key.substr(0,1).toLowerCase();
 
-	var omeroImage = this.getImage();
-	var dimLookup =
+    var omeroImage = this.getImage();
+    var dimLookup =
         typeof ome.ol3.DIMENSION_LOOKUP[lowerCaseKey] === 'object' ?
             ome.ol3.DIMENSION_LOOKUP[lowerCaseKey] : null;
-	// image not there, dim key not found or dimension not settable (i.e. width, height)
-	if (omeroImage === null || dimLookup == null ||
-				!dimLookup['settable']) return;
+    // image not there, dim key not found or dimension not settable (i.e. width, height)
+    if (omeroImage === null || dimLookup == null || !dimLookup['settable'])
+        return;
 
-	var values = Array.prototype.slice.call(arguments, 1);
-	 // do some bounds checking
-	 var max = 0;
-	 try {
-		if (key === 'x') key = 'width'; // use alias
-		if (key === 'y') key = 'height'; // use alias
- 		max = this.image_info_.size[key];
-		for (var c in values) {
-			if (typeof(values[c]) === 'string')
-					values[c] = parseInt(values[c]);
-			if (typeof(values[c]) !== 'number' || values[c] < 0)
-				return;
-			// just in case of the crazy event of floating point
-			values[c] = parseInt(values[c]);
-			if (values[c] > max)
-				return;
-		}
- 	} catch(methodNotDefined) {
- 		// there is the very remote possibility that the method was not defined
- 		return;
- 	}
+    var values = Array.prototype.slice.call(arguments, 1);
+    // do some bounds checking
+    var max = 0;
+    try {
+        if (key === 'x') key = 'width'; // use alias
+        if (key === 'y') key = 'height'; // use alias
+         max = this.image_info_.size[key];
+        for (var c in values) {
+            if (typeof(values[c]) === 'string')
+                    values[c] = parseInt(values[c]);
+            if (typeof(values[c]) !== 'number' || values[c] < 0)
+                return;
+            // just in case of the crazy event of floating point
+            values[c] = parseInt(values[c]);
+            if (values[c] > max)
+                return;
+        }
+    } catch(methodNotDefined) {
+        // there is the very remote possibility that the method was not defined
+        return;
+    }
 
-	// now call setter
-	var setter = "set" + dimLookup['method'];
-	try {
-		omeroImage[setter](key !== 'c' ? values[0] : values);
-	} catch(methodNotDefined) {
-		// there is the very remote possibility that the method was not defined
-		return;
-	}
+    // now call setter
+    var setter = "set" + dimLookup['method'];
+    try {
+        omeroImage[setter](key !== 'c' ? values[0] : values);
+    } catch(methodNotDefined) {
+        // there is the very remote possibility that the method was not defined
+        return;
+    }
 
     // we want to affect a rerender,
     // only clearing the cache for tiled sources and channel changes
-	omeroImage.forceRender(omeroImage.tiled_ && key === 'c');
+    omeroImage.forceRender(omeroImage.tiled_ && key === 'c');
 
     // update regions (if necessary)
     if (this.getRegionsLayer()) this.getRegions().changed();
@@ -1113,26 +1114,26 @@ ome.ol3.Viewer.prototype.setDimensionIndex = function(key, value) {
  * @return {number|null} the present index or null (if an invalid dim key was supplied)
  */
 ome.ol3.Viewer.prototype.getDimensionIndex = function(key) {
-	if (typeof(key) !== 'string' || key.length === 0) // dimension key checks
-		return;
-	var lowerCaseKey = key.substr(0,1).toLowerCase();
+    if (typeof(key) !== 'string' || key.length === 0) // dimension key checks
+        return;
+    var lowerCaseKey = key.substr(0,1).toLowerCase();
 
-	var omeroImage = this.getImage();
-	if (omeroImage == null) return; // we could be null
+    var omeroImage = this.getImage();
+    if (omeroImage == null) return; // we could be null
 
-	var dimLookup =
+    var dimLookup =
         typeof ome.ol3.DIMENSION_LOOKUP[lowerCaseKey] === 'object' ?
             ome.ol3.DIMENSION_LOOKUP[lowerCaseKey] : null;
-	if (dimLookup == null) return; // dim key not found
+    if (dimLookup == null) return; // dim key not found
 
-	// now call getter
-	var getter = "get" + dimLookup['method'];
-	try {
-		return omeroImage[getter]();
-	} catch(methodNotDefined) {
-		// there is the very remote possibility that the method was not defined
-		return null;
-	}
+    // now call getter
+    var getter = "get" + dimLookup['method'];
+    try {
+        return omeroImage[getter]();
+    } catch(methodNotDefined) {
+        // there is the very remote possibility that the method was not defined
+        return null;
+    }
 }
 
 /**
@@ -1148,9 +1149,8 @@ ome.ol3.Viewer.prototype.getDimensionIndex = function(key) {
  * @param {ol.TileLoadFunctionType} func a function with signature function(tile) {}
  */
 ome.ol3.Viewer.prototype.addPostTileLoadHook = function(func) {
-	var omeroImage = this.getImage();
-	if (omeroImage)
-		omeroImage.setPostTileLoadFunction(func);
+    var omeroImage = this.getImage();
+    if (omeroImage) omeroImage.setPostTileLoadFunction(func);
 }
 
 /**
@@ -1158,9 +1158,8 @@ ome.ol3.Viewer.prototype.addPostTileLoadHook = function(func) {
  * {@link addPostTileLoadHook} *
  */
 ome.ol3.Viewer.prototype.removePostTileLoadHook = function() {
-	var omeroImage = this.getImage();
-	if (omeroImage)
-		omeroImage.clearPostTileLoadFunction();
+    var omeroImage = this.getImage();
+    if (omeroImage) omeroImage.clearPostTileLoadFunction();
 }
 
 /**
@@ -1170,11 +1169,11 @@ ome.ol3.Viewer.prototype.removePostTileLoadHook = function() {
  * @return {ol.layer.Tile|null} the open layers tile layer being our image or null
  */
 ome.ol3.Viewer.prototype.getImageLayer = function() {
-	if (!(this.viewer_ instanceof ol.Map) || // mandatory viewer presence check
-		this.viewer_.getLayers().getLength() == 0) // unfathomable event of layer missing...
-		return null;
+    if (!(this.viewer_ instanceof ol.Map) || // mandatory viewer presence check
+        this.viewer_.getLayers().getLength() == 0) // unfathomable event of layer missing...
+        return null;
 
-		return this.viewer_.getLayers().item(0);
+    return this.viewer_.getLayers().item(0);
 }
 
 /**
@@ -1184,11 +1183,11 @@ ome.ol3.Viewer.prototype.getImageLayer = function() {
  * @return { ol.layer.Vector|null} the open layers vector layer being our regions or null
  */
 ome.ol3.Viewer.prototype.getRegionsLayer = function() {
-	if (!(this.viewer_ instanceof ol.Map) || // mandatory viewer presence check
-		this.viewer_.getLayers().getLength() < 2) // unfathomable event of layer missing...
-		return null;
+    if (!(this.viewer_ instanceof ol.Map) || // mandatory viewer presence check
+        this.viewer_.getLayers().getLength() < 2) // unfathomable event of layer missing...
+        return null;
 
-		return this.viewer_.getLayers().item(this.viewer_.getLayers().getLength()-1);
+    return this.viewer_.getLayers().item(this.viewer_.getLayers().getLength()-1);
 }
 
 /**
@@ -1198,11 +1197,11 @@ ome.ol3.Viewer.prototype.getRegionsLayer = function() {
  * @return {ome.ol3.source.Image|null} an instance of OmeroImage or null
  */
 ome.ol3.Viewer.prototype.getImage = function() {
-	// delegate
-	var imageLayer = this.getImageLayer();
-	if (imageLayer) return imageLayer.getSource();
+    // delegate
+    var imageLayer = this.getImageLayer();
+    if (imageLayer) return imageLayer.getSource();
 
-	return null;
+    return null;
 }
 
 /**
@@ -1212,11 +1211,11 @@ ome.ol3.Viewer.prototype.getImage = function() {
  * @return {ome.ol3.source.Regions|null} an instance of OmeroRegions or null
  */
 ome.ol3.Viewer.prototype.getRegions = function() {
-	// delegate
-	var regionsLayer = this.getRegionsLayer();
-	if (regionsLayer) return regionsLayer.getSource();
+    // delegate
+    var regionsLayer = this.getRegionsLayer();
+    if (regionsLayer) return regionsLayer.getSource();
 
-	return null;
+    return null;
 }
 
 /**
@@ -1225,7 +1224,7 @@ ome.ol3.Viewer.prototype.getRegions = function() {
  * @return {number} the image id
  */
 ome.ol3.Viewer.prototype.getId = function() {
-	  return this.id_;
+    return this.id_;
 }
 
 /**
@@ -1265,7 +1264,7 @@ ome.ol3.Viewer.prototype.readPrefixedUris = function(params) {
         if (typeof params[resource] === 'string')
             this.prefixed_uris_[resource] = params[resource];
         else this.prefixed_uris_[resource] = '/' + resource.toLowerCase();
-        }
+    }
 }
 
 /**
@@ -1274,7 +1273,7 @@ ome.ol3.Viewer.prototype.readPrefixedUris = function(params) {
  * @return {object} the server information
  */
 ome.ol3.Viewer.prototype.getServer = function() {
-	  return this.server_;
+    return this.server_;
 }
 
 /**
@@ -1290,9 +1289,9 @@ ome.ol3.Viewer.prototype.getServer = function() {
  * @return {Array.<number>} the present modes set
  */
 ome.ol3.Viewer.prototype.setRegionsModes = function(modes) {
-	// delegate
-	if (this.getRegionsLayer()) {
-		this.getRegions().setModes(modes);
+    // delegate
+    if (this.getRegionsLayer()) {
+        this.getRegions().setModes(modes);
         return this.getRegions().present_modes_;
     }
 
@@ -1313,85 +1312,84 @@ ome.ol3.Viewer.prototype.setRegionsModes = function(modes) {
  * @param {number=} hist_id a history id to pass through and return
  */
 ome.ol3.Viewer.prototype.generateShapes =
- 	function(shape_info, number, random_placement, extent, theDims,
-                add_history, hist_id) {
-    // we don't do generation any more for the case where we don't
-    // have a regions layer, nor do we do it without shape definition or
-    // if the given number is nonsensical
-    if (this.getRegionsLayer() === null || typeof shape_info !== 'object' ||
-            typeof number !== 'number' || number <= 0)
-        return;
+     function(shape_info, number, random_placement, extent, theDims, add_history, hist_id) {
+        // we don't do generation any more for the case where we don't
+        // have a regions layer, nor do we do it without shape definition or
+        // if the given number is nonsensical
+        if (this.getRegionsLayer() === null || typeof shape_info !== 'object' ||
+                typeof number !== 'number' || number <= 0) return;
 
-    // more checks
-    // default to false for random_placement if not provided/wrong type
-    if (typeof random_placement !== 'boolean') random_placement = false;
-    // use image extent if none given
-	if (!ome.ol3.utils.Misc.isArray(extent) || extent.length === 0)
-		extent = this.viewer_.getView().getProjection().getExtent();
-    // shouldn't there be dims we want to associate with
-    // we use the present z/t
-    if (!ome.ol3.utils.Misc.isArray(theDims) || theDims.length === 0)
-		theDims = [{
-            "z" : this.getDimensionIndex('z'),
-            "t" : this.getDimensionIndex('t'),
-            "c" : -1}];
+        // more checks
+        // default to false for random_placement if not provided/wrong type
+        if (typeof random_placement !== 'boolean') random_placement = false;
+        // use image extent if none given
+        if (!ome.ol3.utils.Misc.isArray(extent) || extent.length === 0)
+            extent = this.viewer_.getView().getProjection().getExtent();
+        // shouldn't there be dims we want to associate with
+        // we use the present z/t
+        if (!ome.ol3.utils.Misc.isArray(theDims) || theDims.length === 0)
+            theDims = [{
+                "z" : this.getDimensionIndex('z'),
+                "t" : this.getDimensionIndex('t'),
+                "c" : -1
+            }];
 
-    // sanity check: we are going to need matching numbers for shapes
-    // and associated t/zs for the association loop below to make sense
-    // exception is random generation which we allow for only 1 z/t combination
-    if ((random_placement && theDims.length !== 1) ||
-        (!random_placement && number !== theDims.length)) return;
+        // sanity check: we are going to need matching numbers for shapes
+        // and associated t/zs for the association loop below to make sense
+        // exception is random generation which we allow for only 1 z/t combination
+        if ((random_placement && theDims.length !== 1) ||
+            (!random_placement && number !== theDims.length)) return;
 
-	// delegate
-	var generatedShapes = ome.ol3.utils.Regions.generateRegions(
-		shape_info, number, extent, random_placement);
-    // another brief sanity check in case not all shapes were created
-    if (generatedShapes === null ||
-            (!random_placement && generatedShapes.length !== theDims.length))
-		return;
+        // delegate
+        var generatedShapes = ome.ol3.utils.Regions.generateRegions(
+            shape_info, number, extent, random_placement);
+        // another brief sanity check in case not all shapes were created
+        if (generatedShapes === null ||
+                (!random_placement &&
+                 generatedShapes.length !== theDims.length)) return;
 
-    // post generation work
-	// update the styling and associate with dimensions
-	for (var i=0;i<generatedShapes.length;i++) {
-        var f = generatedShapes[i];
-        // and associate them to the proper dims
-        f['theZ'] =
-            random_placement ? theDims[0]['z'] : theDims[i]['z'];
-        f['theT'] =
-            random_placement ? theDims[0]['t'] : theDims[i]['t'];
-        var theC =
-            random_placement ? theDims[0]['c'] :
-                (typeof theDims[i]['c'] === 'number' ?
-                    theDims[i]['c'] : -1);
-        f['theC'] = theC;
-		// in case we got created in a rotated view
-		var res = this.viewer_.getView().getResolution();
-		var rot = this.viewer_.getView().getRotation();
-		if (f.getGeometry() instanceof ome.ol3.geom.Label && rot !== 0 &&
-				!this.getRegions().rotate_text_)
-			f.getGeometry().rotate(-rot);
-			ome.ol3.utils.Style.updateStyleFunction(f, this.regions_, true);
-	}
-	this.getRegions().addFeatures(generatedShapes);
+        // post generation work
+        // update the styling and associate with dimensions
+        for (var i=0;i<generatedShapes.length;i++) {
+            var f = generatedShapes[i];
+            // and associate them to the proper dims
+            f['theZ'] =
+                random_placement ? theDims[0]['z'] : theDims[i]['z'];
+            f['theT'] =
+                random_placement ? theDims[0]['t'] : theDims[i]['t'];
+            var theC =
+                random_placement ? theDims[0]['c'] :
+                    (typeof theDims[i]['c'] === 'number' ?
+                        theDims[i]['c'] : -1);
+            f['theC'] = theC;
+            // in case we got created in a rotated view
+            var res = this.viewer_.getView().getResolution();
+            var rot = this.viewer_.getView().getRotation();
+            if (f.getGeometry() instanceof ome.ol3.geom.Label && rot !== 0 &&
+                    !this.getRegions().rotate_text_)
+                f.getGeometry().rotate(-rot);
+                ome.ol3.utils.Style.updateStyleFunction(f, this.regions_, true);
+        }
+        this.getRegions().addFeatures(generatedShapes);
 
-    // notify about generation
-    var eventbus = this.eventbus_;
-    var config_id = this.getTargetId();
-    if (eventbus)
-        setTimeout(function() {
-            var newRegionsObject =
-                ome.ol3.utils.Conversion.toJsonObject(
-                    new ol.Collection(generatedShapes), false, true);
-            if (typeof newRegionsObject !== 'object' ||
-                !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
-                newRegionsObject['rois'].length === 0) return;
-            var opts = { "config_id": config_id,
-                            "shapes": newRegionsObject['rois']};
-            if (typeof hist_id === 'number') opts['hist_id'] = hist_id;
-            if (typeof add_history === 'boolean')
-                opts['add_history'] = add_history;
-            eventbus.publish("REGIONS_SHAPE_GENERATED", opts);
-        },25);
+        // notify about generation
+        var eventbus = this.eventbus_;
+        var config_id = this.getTargetId();
+        if (eventbus)
+            setTimeout(function() {
+                var newRegionsObject =
+                    ome.ol3.utils.Conversion.toJsonObject(
+                        new ol.Collection(generatedShapes), false, true);
+                if (typeof newRegionsObject !== 'object' ||
+                    !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
+                    newRegionsObject['rois'].length === 0) return;
+                var opts = { "config_id": config_id,
+                                "shapes": newRegionsObject['rois']};
+                if (typeof hist_id === 'number') opts['hist_id'] = hist_id;
+                if (typeof add_history === 'boolean')
+                    opts['add_history'] = add_history;
+                eventbus.publish("REGIONS_SHAPE_GENERATED", opts);
+            },25);
 };
 
 /**
@@ -1451,22 +1449,22 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  */
  ome.ol3.Viewer.prototype.modifyRegionsStyle =
     function(shape_info, ids, callback) {
-	 if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
-	  	typeof(shape_info) !== 'object' || shape_info === null)
-	 	return;
+        if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
+            typeof(shape_info) !== 'object' || shape_info === null) return;
 
-    var col = null;
-    if (ome.ol3.utils.Misc.isArray(ids) && ids.length > 0 && this.regions_.idIndex_) {
-        col = new ol.Collection();
-        for (var id in ids)
-            if (this.regions_.idIndex_[ids[id]] instanceof ol.Feature &&
-                    this.regions_.idIndex_[ids[id]]['state'] !==
+        var col = null;
+        if (ome.ol3.utils.Misc.isArray(ids) && ids.length > 0 &&
+            this.regions_.idIndex_) {
+                col = new ol.Collection();
+                for (var id in ids)
+                    if (this.regions_.idIndex_[ids[id]] instanceof ol.Feature &&
+                        this.regions_.idIndex_[ids[id]]['state'] !==
                         ome.ol3.REGIONS_STATE.REMOVED)
-                col.push(this.regions_.idIndex_[ids[id]]);
-    }
+                            col.push(this.regions_.idIndex_[ids[id]]);
+        }
 
-	 ome.ol3.utils.Style.modifyStyles(
-         shape_info, this.regions_, col, callback);
+        ome.ol3.utils.Style.modifyStyles(
+            shape_info, this.regions_, col, callback);
  }
 
 /**
@@ -1481,45 +1479,47 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * @return {boolean} true if a storage request was made, false otherwise
  */
 ome.ol3.Viewer.prototype.storeRegions =
-	function(selectedOnly,useSeparateRoiForEachNewShape, uri, omit_client_update) {
+    function(selectedOnly,useSeparateRoiForEachNewShape, uri, omit_client_update) {
 
-	if (!(this.regions_ instanceof ome.ol3.source.Regions))
-		return false; // no regions, nothing to persist...
+        if (!(this.regions_ instanceof ome.ol3.source.Regions))
+            return false; // no regions, nothing to persist...
 
-	selectedOnly = typeof(selectedOnly) === 'boolean' ? selectedOnly : false;
-	useSeparateRoiForEachNewShape =
-		typeof(useSeparateRoiForEachNewShape) === 'boolean' ?
-			useSeparateRoiForEachNewShape : true;
-    if (typeof uri !== 'string' || uri.length === 0) uri = '/persist_rois';
+        selectedOnly =
+            typeof(selectedOnly) === 'boolean' ? selectedOnly : false;
+        useSeparateRoiForEachNewShape =
+            typeof(useSeparateRoiForEachNewShape) === 'boolean' ?
+                useSeparateRoiForEachNewShape : true;
+        if (typeof uri !== 'string' || uri.length === 0) uri = '/persist_rois';
 
-	var collectionOfFeatures =
-		(selectedOnly && this.regions_.select_) ? this.regions_.select_.getFeatures() :
-			new ol.Collection(this.regions_.getFeatures());
+        var collectionOfFeatures =
+            (selectedOnly &&
+             this.regions_.select_) ? this.regions_.select_.getFeatures() :
+                new ol.Collection(this.regions_.getFeatures());
 
-	var roisAsJsonObject =
-	ome.ol3.utils.Conversion.toJsonObject(
-		collectionOfFeatures, useSeparateRoiForEachNewShape);
+        var roisAsJsonObject =
+        ome.ol3.utils.Conversion.toJsonObject(
+            collectionOfFeatures, useSeparateRoiForEachNewShape);
 
-	// either something happened or we don't have anything to persist
-	if (roisAsJsonObject === null || roisAsJsonObject['count'] === 0)
-		return false;
+        // either something happened or we don't have anything to persist
+        if (roisAsJsonObject === null || roisAsJsonObject['count'] === 0)
+            return false;
 
-	return this.regions_.storeRegions(roisAsJsonObject, uri, omit_client_update);
+        return this.regions_.storeRegions(roisAsJsonObject, uri, omit_client_update);
 }
 
 /**
  * Enables/Disables context menu for regions
  * see: {@link ome.ol3.interaction.Select.enableContextMenu}
  *
- * @param {boolean} flag if true the context menu will be shown on right click, otherwise not
+ * @param {boolean} flag if true the context menu will be shown on right click,
+ *                       otherwise not
  */
 ome.ol3.Viewer.prototype.enableRegionsContextMenu = function(flag) {
+    if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
+        !(this.regions_.select_ instanceof ome.ol3.interaction.Select))
+            return; // no regions or select => no context menu...
 
-	if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
-			!(this.regions_.select_ instanceof ome.ol3.interaction.Select))
-		return; // no regions or select => no context menu...
-
-	this.regions_.select_.enableContextMenu(flag);
+    this.regions_.select_.enableContextMenu(flag);
 }
 
 /**
@@ -1535,18 +1535,17 @@ ome.ol3.Viewer.prototype.enableRegionsContextMenu = function(flag) {
  * @param {number=} hist_id an optional history id to pass through and return
  */
 ome.ol3.Viewer.prototype.drawShape = function(type, roi_id, hist_id) {
-	if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
-			typeof(type) !== 'string' || type.length === 0)
-		return;
+    if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
+        typeof(type) !== 'string' || type.length === 0) return;
 
-	var oldModes = this.regions_.present_modes_.slice();
-	this.setRegionsModes([ome.ol3.REGIONS_MODE.DRAW]);
-	if (!(this.regions_.draw_ instanceof ome.ol3.interaction.Draw)) {
-		this.setRegionsModes(oldModes);
-		return;
-	}
+    var oldModes = this.regions_.present_modes_.slice();
+    this.setRegionsModes([ome.ol3.REGIONS_MODE.DRAW]);
+    if (!(this.regions_.draw_ instanceof ome.ol3.interaction.Draw)) {
+        this.setRegionsModes(oldModes);
+        return;
+    }
 
-	this.regions_.draw_.drawShape(type, roi_id, hist_id);
+    this.regions_.draw_.drawShape(type, roi_id, hist_id);
 }
 
 /**
@@ -1554,49 +1553,47 @@ ome.ol3.Viewer.prototype.drawShape = function(type, roi_id, hist_id) {
  */
 ome.ol3.Viewer.prototype.abortDrawing = function() {
     if (!(this.regions_ instanceof ome.ol3.source.Regions) ||
-            !(this.regions_.draw_ instanceof ome.ol3.interaction.Draw)) return;
+        !(this.regions_.draw_ instanceof ome.ol3.interaction.Draw)) return;
     this.regions_.draw_.endDrawingInteraction();
 }
 
 /**
  * Cleans up, calling the dispose() methods of the regions instance and the ol3 map
  * @private
- * @param {boolean} rememberEnabled a flag if the presently enabled controls/
- * 		interactions should be remembered
- * @return {Array|null} if rememberEnabled is true:
- * 								an array of enabled controls/interactions, otherwise null
+ * @param {boolean} rememberEnabled a flag if the presently enabled controls/interactions should be remembered
+ * @return {Array|null} if rememberEnabled is true: an array of enabled controls/interactions, otherwise null
  */
 ome.ol3.Viewer.prototype.dispose = function(rememberEnabled) {
-	// remove regions first (if exists) since it holds a reference to the viewer
-	this.removeRegions();
+    // remove regions first (if exists) since it holds a reference to the viewer
+    this.removeRegions();
 
-	if (typeof(rememberEnabled) !== 'boolean')
-		rememberEnabled = false;
-	var componentsRegistered = rememberEnabled ? [] : null;
+    if (typeof(rememberEnabled) !== 'boolean')
+        rememberEnabled = false;
+    var componentsRegistered = rememberEnabled ? [] : null;
 
-	// tidy up viewer incl. layers, controls and interactions
-	if (this.viewer_ instanceof ol.Map) {
-		if (rememberEnabled && this.viewerState_) {
-			// delete them from the list as well as the viewer
+    // tidy up viewer incl. layers, controls and interactions
+    if (this.viewer_ instanceof ol.Map) {
+        if (rememberEnabled && this.viewerState_) {
+            // delete them from the list as well as the viewer
             for (var K in this.viewerState_) {
                 var V = this.viewerState_[K];
-				this.removeInteractionOrControl(K);
-				// remember which controls and interactions were used
-				// we do not remember controls and interactions that are not defaults
-				// i.e. the more involved ones such as roi stuff (i.e. drawing, translation, etc)
-				if (typeof(V) === 'object' && V['defaults'])
-					componentsRegistered.push({ "key" : K, "type" : V['type']});
-			};
-			this.viewerState_ = {};
-		} else {
-			this.viewerState_ = {};
-			this.viewer_.getControls().clear();
-			this.viewer_.getInteractions().clear();
-		}
-		var omeroImage = this.getImage();
-		if (omeroImage) omeroImage.dispose();
-		this.viewer_.getLayers().clear();
-		this.viewer_.getOverlays().clear();
+                this.removeInteractionOrControl(K);
+                // remember which controls and interactions were used
+                // we do not remember controls and interactions that are not defaults
+                // i.e. the more involved ones such as roi stuff (i.e. drawing, translation, etc)
+                if (typeof(V) === 'object' && V['defaults'])
+                    componentsRegistered.push({ "key" : K, "type" : V['type']});
+            };
+            this.viewerState_ = {};
+        } else {
+            this.viewerState_ = {};
+            this.viewer_.getControls().clear();
+            this.viewer_.getInteractions().clear();
+        }
+        var omeroImage = this.getImage();
+        if (omeroImage) omeroImage.dispose();
+        this.viewer_.getLayers().clear();
+        this.viewer_.getOverlays().clear();
         // remove global ol event listeners
         if (typeof(this.onEndMoveListener) !== 'undefined' &&
                     this.onEndMoveListener)
@@ -1604,15 +1601,15 @@ ome.ol3.Viewer.prototype.dispose = function(rememberEnabled) {
         if (typeof(this.onViewResolutionListener) !== 'undefined' &&
             this.onViewResolutionListener)
                 ol.events.unlistenByKey(this.onViewResolutionListener);
-		this.viewer_.dispose();
-	}
+        this.viewer_.dispose();
+    }
 
-	// reset internally stored viewer and image information
+    // reset internally stored viewer and image information
     this.initParams_ = {};
-	this.image_info_ = null;
-	this.viewer_ = null;
+    this.image_info_ = null;
+    this.viewer_ = null;
 
-	return componentsRegistered;
+    return componentsRegistered;
 }
 
 /**
@@ -1622,8 +1619,8 @@ ome.ol3.Viewer.prototype.dispose = function(rememberEnabled) {
  *
  */
 ome.ol3.Viewer.prototype.destroyViewer = function() {
-	this.dispose();
-	if (this.eventbus_) this.eventbus_ = null;
+    this.dispose();
+    if (this.eventbus_) this.eventbus_ = null;
 }
 
 /**
@@ -1633,7 +1630,7 @@ ome.ol3.Viewer.prototype.destroyViewer = function() {
  * @param {Array.<Object>} ranges an array of objects with channel props
  */
 ome.ol3.Viewer.prototype.changeChannelRange = function(ranges) {
-	if (this.getImage() === null) return;
+    if (this.getImage() === null) return;
 
     this.getImage().changeChannelRange(ranges);
 }
@@ -1645,9 +1642,9 @@ ome.ol3.Viewer.prototype.changeChannelRange = function(ranges) {
  * @param {string} value the new value
  */
 ome.ol3.Viewer.prototype.changeImageProjection = function(value) {
-		if (this.getImage() === null) return;
+    if (this.getImage() === null) return;
 
-		this.getImage().setImageProjection(value);
+    this.getImage().setImageProjection(value);
 }
 
 /**
@@ -1657,9 +1654,9 @@ ome.ol3.Viewer.prototype.changeImageProjection = function(value) {
  * @param {string} value the new value
  */
 ome.ol3.Viewer.prototype.changeImageModel = function(value) {
-		if (this.getImage() === null) return;
+    if (this.getImage() === null) return;
 
-		this.getImage().setImageModel(value);
+    this.getImage().setImageModel(value);
 }
 
 /**
@@ -1667,16 +1664,15 @@ ome.ol3.Viewer.prototype.changeImageModel = function(value) {
  *
  * @param {boolean} show if true we show the scale bar, otherwise not
  */
- ome.ol3.Viewer.prototype.toggleScaleBar =
- 	function(show) {
-        // check if we have an image and a pixel size specified
- 		if (this.getImage() === null ||
-            typeof this.image_info_['pixel_size'] !== "object" ||
-            typeof this.image_info_['pixel_size']['x'] !== "number") return;
+ ome.ol3.Viewer.prototype.toggleScaleBar = function(show) {
+    // check if we have an image and a pixel size specified
+    if (this.getImage() === null ||
+        typeof this.image_info_['pixel_size'] !== "object" ||
+        typeof this.image_info_['pixel_size']['x'] !== "number") return;
 
-        if (typeof show !== 'boolean') show = false;
+    if (typeof show !== 'boolean') show = false;
 
- 	if (show) {
+    if (show) {
         this.addControl("scalebar");
         return;
     }
@@ -1690,10 +1686,11 @@ ome.ol3.Viewer.prototype.changeImageModel = function(value) {
  */
 ome.ol3.Viewer.prototype.redraw = function(delay) {
     if (this.viewer_) {
-        if (typeof delay !== 'number' || delay < 0)
-            delay = 0;
-        var update = function() {
-            if (this.viewer_) this.viewer_.updateSize()}.bind(this);
+        if (typeof delay !== 'number' || delay < 0) delay = 0;
+        var update =
+            function() {
+                if (this.viewer_) this.viewer_.updateSize();
+            }.bind(this);
         setTimeout(update, delay);
     }
 }
@@ -1704,14 +1701,16 @@ ome.ol3.Viewer.prototype.redraw = function(delay) {
  */
 ome.ol3.Viewer.prototype.getTargetId = function() {
     try {
-        var elemId = typeof this.viewer_.getTargetElement() === 'string' ?
-            this.viewer_.getTargetElement() :
-                typeof this.viewer_.getTargetElement() === 'object' &&
-                typeof this.viewer_.getTargetElement().id === 'string' ?
-                    this.viewer_.getTargetElement().id : null;
+        var elemId =
+            typeof this.viewer_.getTargetElement() === 'string' ?
+                this.viewer_.getTargetElement() :
+                    typeof this.viewer_.getTargetElement() === 'object' &&
+                    typeof this.viewer_.getTargetElement().id === 'string' ?
+                        this.viewer_.getTargetElement().id : null;
 
         var _pos = -1;
-        if (elemId === null || ((_pos = elemId.lastIndexOf("_")) === -1)) return null;
+        if (elemId === null ||
+            ((_pos = elemId.lastIndexOf("_")) === -1)) return null;
 
         var id = parseInt(elemId.substring(_pos+1));
         if (!isNaN(id)) return id;
@@ -1747,14 +1746,14 @@ ome.ol3.Viewer.prototype.getInitialRequestParam = function(key) {
  * @return {object} an object populated with the properties mentioned above
  */
 ome.ol3.Viewer.prototype.captureViewParameters = function() {
-     if (this.getImage() === null) return null;
+    if (this.getImage() === null) return null;
 
-     var center = this.viewer_.getView().getCenter();
-     var ret = this.getImage().captureImageSettings();
-     ret["resolution"] = this.viewer_.getView().getResolution();
-     ret["center"] = [center[0], -center[1]];
+    var center = this.viewer_.getView().getCenter();
+    var ret = this.getImage().captureImageSettings();
+    ret["resolution"] = this.viewer_.getView().getResolution();
+    ret["center"] = [center[0], -center[1]];
 
-     return ret;
+    return ret;
 }
 
 /**
@@ -1764,9 +1763,9 @@ ome.ol3.Viewer.prototype.captureViewParameters = function() {
  * @param {boolean=} undo if true we undo, if false we redo, default: undo
  */
 ome.ol3.Viewer.prototype.doHistory = function(hist_id, undo) {
-     if (typeof hist_id !== 'number' || this.getRegions() === null) return;
+    if (typeof hist_id !== 'number' || this.getRegions() === null) return;
 
-     this.getRegions().doHistory(hist_id, undo);
+    this.getRegions().doHistory(hist_id, undo);
 }
 
 /**
@@ -1776,12 +1775,11 @@ ome.ol3.Viewer.prototype.doHistory = function(hist_id, undo) {
  * @return {Object} the shape definition or null if id does not have a feature
  */
 ome.ol3.Viewer.prototype.getShapeDefinition = function(shape_id) {
-     if (this.getRegions() === null || typeof shape_id !== 'string' ||
-            typeof this.getRegions().idIndex_[shape_id] !== 'object')
-        return null;
+    if (this.getRegions() === null || typeof shape_id !== 'string' ||
+        typeof this.getRegions().idIndex_[shape_id] !== 'object') return null;
 
-     return ome.ol3.utils.Conversion.featureToJsonObject(
-         this.getRegions().idIndex_[shape_id]);
+    return ome.ol3.utils.Conversion.featureToJsonObject(
+        this.getRegions().idIndex_[shape_id]);
 }
 
 /**
@@ -1791,12 +1789,11 @@ ome.ol3.Viewer.prototype.displayResolutionInPercent = function() {
     var zoomDisplay =
         document.getElementsByClassName('ol-zoom-display');
     if (typeof zoomDisplay !== 'object' ||
-            typeof zoomDisplay.length !== 'number' ||
-            zoomDisplay.length === 0) return;
+        typeof zoomDisplay.length !== 'number' ||
+        zoomDisplay.length === 0) return;
 
     zoomDisplay[0].value =
-        Math.round(
-            (1 / this.viewer_.getView().getResolution()) * 100);
+        Math.round((1 / this.viewer_.getView().getResolution()) * 100);
 }
 
 /**
@@ -1825,164 +1822,164 @@ ome.ol3.Viewer.prototype.getRenderStatus = function(reset) {
  * This section determines which methods are exposed and usable after compilation
  */
 goog.exportSymbol(
-	'ome.ol3.Viewer',
-	ome.ol3.Viewer,
-	OME);
+    'ome.ol3.Viewer',
+    ome.ol3.Viewer,
+    OME);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'show',
-	ome.ol3.Viewer.prototype.show);
+    ome.ol3.Viewer.prototype,
+    'show',
+    ome.ol3.Viewer.prototype.show);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'hide',
-	ome.ol3.Viewer.prototype.hide);
+    ome.ol3.Viewer.prototype,
+    'hide',
+    ome.ol3.Viewer.prototype.hide);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'addControl',
-	ome.ol3.Viewer.prototype.addControl);
+    ome.ol3.Viewer.prototype,
+    'addControl',
+    ome.ol3.Viewer.prototype.addControl);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'addInteraction',
-	ome.ol3.Viewer.prototype.addInteraction);
+    ome.ol3.Viewer.prototype,
+    'addInteraction',
+    ome.ol3.Viewer.prototype.addInteraction);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'removeInteractionOrControl',
-	ome.ol3.Viewer.prototype.removeInteractionOrControl);
+    ome.ol3.Viewer.prototype,
+    'removeInteractionOrControl',
+    ome.ol3.Viewer.prototype.removeInteractionOrControl);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'changeToImage',
-	ome.ol3.Viewer.prototype.changeToImage);
+    ome.ol3.Viewer.prototype,
+    'changeToImage',
+    ome.ol3.Viewer.prototype.changeToImage);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'setDimensionIndex',
-	ome.ol3.Viewer.prototype.setDimensionIndex);
+    ome.ol3.Viewer.prototype,
+    'setDimensionIndex',
+    ome.ol3.Viewer.prototype.setDimensionIndex);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'getDimensionIndex',
-	ome.ol3.Viewer.prototype.getDimensionIndex);
+    ome.ol3.Viewer.prototype,
+    'getDimensionIndex',
+    ome.ol3.Viewer.prototype.getDimensionIndex);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'addRegions',
-	ome.ol3.Viewer.prototype.addRegions);
+    ome.ol3.Viewer.prototype,
+    'addRegions',
+    ome.ol3.Viewer.prototype.addRegions);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'removeRegions',
-	ome.ol3.Viewer.prototype.removeRegions);
+    ome.ol3.Viewer.prototype,
+    'removeRegions',
+    ome.ol3.Viewer.prototype.removeRegions);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'setRegionsVisibility',
-	ome.ol3.Viewer.prototype.setRegionsVisibility);
+    ome.ol3.Viewer.prototype,
+    'setRegionsVisibility',
+    ome.ol3.Viewer.prototype.setRegionsVisibility);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'setTextBehaviorForRegions',
-	ome.ol3.Viewer.prototype.setTextBehaviorForRegions);
+    ome.ol3.Viewer.prototype,
+    'setTextBehaviorForRegions',
+    ome.ol3.Viewer.prototype.setTextBehaviorForRegions);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'setRegionsModes',
-	ome.ol3.Viewer.prototype.setRegionsModes);
+    ome.ol3.Viewer.prototype,
+    'setRegionsModes',
+    ome.ol3.Viewer.prototype.setRegionsModes);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'generateShapes',
-	ome.ol3.Viewer.prototype.generateShapes);
+    ome.ol3.Viewer.prototype,
+    'generateShapes',
+    ome.ol3.Viewer.prototype.generateShapes);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'modifyRegionsStyle',
-	ome.ol3.Viewer.prototype.modifyRegionsStyle);
+    ome.ol3.Viewer.prototype,
+    'modifyRegionsStyle',
+    ome.ol3.Viewer.prototype.modifyRegionsStyle);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'storeRegions',
-	ome.ol3.Viewer.prototype.storeRegions);
+    ome.ol3.Viewer.prototype,
+    'storeRegions',
+    ome.ol3.Viewer.prototype.storeRegions);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'enableRegionsContextMenu',
-	ome.ol3.Viewer.prototype.enableRegionsContextMenu);
+    ome.ol3.Viewer.prototype,
+    'enableRegionsContextMenu',
+    ome.ol3.Viewer.prototype.enableRegionsContextMenu);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'drawShape',
-	ome.ol3.Viewer.prototype.drawShape);
+    ome.ol3.Viewer.prototype,
+    'drawShape',
+    ome.ol3.Viewer.prototype.drawShape);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'destroyViewer',
-	ome.ol3.Viewer.prototype.destroyViewer);
+    ome.ol3.Viewer.prototype,
+    'destroyViewer',
+    ome.ol3.Viewer.prototype.destroyViewer);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'changeChannelRange',
-	ome.ol3.Viewer.prototype.changeChannelRange);
+    ome.ol3.Viewer.prototype,
+    'changeChannelRange',
+    ome.ol3.Viewer.prototype.changeChannelRange);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'selectShapes',
-	ome.ol3.Viewer.prototype.selectShapes);
+    ome.ol3.Viewer.prototype,
+    'selectShapes',
+    ome.ol3.Viewer.prototype.selectShapes);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'centerOnShapeOrCoordinate',
-	ome.ol3.Viewer.prototype.centerOnShapeOrCoordinate);
+    ome.ol3.Viewer.prototype,
+    'centerOnShapeOrCoordinate',
+    ome.ol3.Viewer.prototype.centerOnShapeOrCoordinate);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'redraw',
-	ome.ol3.Viewer.prototype.redraw);
+    ome.ol3.Viewer.prototype,
+    'redraw',
+    ome.ol3.Viewer.prototype.redraw);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'toggleScaleBar',
-	ome.ol3.Viewer.prototype.toggleScaleBar);
+    ome.ol3.Viewer.prototype,
+    'toggleScaleBar',
+    ome.ol3.Viewer.prototype.toggleScaleBar);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'changeImageProjection',
-	ome.ol3.Viewer.prototype.changeImageProjection);
+    ome.ol3.Viewer.prototype,
+    'changeImageProjection',
+    ome.ol3.Viewer.prototype.changeImageProjection);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'changeImageModel',
-	ome.ol3.Viewer.prototype.changeImageModel);
+    ome.ol3.Viewer.prototype,
+    'changeImageModel',
+    ome.ol3.Viewer.prototype.changeImageModel);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'captureViewParameters',
-	ome.ol3.Viewer.prototype.captureViewParameters);
+    ome.ol3.Viewer.prototype,
+    'captureViewParameters',
+    ome.ol3.Viewer.prototype.captureViewParameters);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'toggleSplitView',
-	ome.ol3.Viewer.prototype.toggleSplitView);
+    ome.ol3.Viewer.prototype,
+    'toggleSplitView',
+    ome.ol3.Viewer.prototype.toggleSplitView);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'abortDrawing',
-	ome.ol3.Viewer.prototype.abortDrawing);
+    ome.ol3.Viewer.prototype,
+    'abortDrawing',
+    ome.ol3.Viewer.prototype.abortDrawing);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'deleteShapes',
-	ome.ol3.Viewer.prototype.deleteShapes);
+    ome.ol3.Viewer.prototype,
+    'deleteShapes',
+    ome.ol3.Viewer.prototype.deleteShapes);
 
 goog.exportProperty(
-	ome.ol3.Viewer.prototype,
-	'showShapeComments',
-	ome.ol3.Viewer.prototype.showShapeComments);
+    ome.ol3.Viewer.prototype,
+    'showShapeComments',
+    ome.ol3.Viewer.prototype.showShapeComments);
 
 goog.exportProperty(
     ome.ol3.Viewer.prototype,

--- a/ol3-viewer/src/ome/ol3/interaction/Modify.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Modify.js
@@ -20,34 +20,39 @@ ome.ol3.interaction.Modify = function(regions_reference) {
         console.error("Select needs a Select instance!");
 
     /**
-   * @type {ome.ol3.source.Regions}
-   * @private
-   */
+     * @type {ome.ol3.source.Regions}
+     * @private
+     */
     this.regions_ = regions_reference;
 
     /**
-   * @type {number}
-   * @private
-   */
-	this.hist_id_ = -1;
+     * @type {number}
+     * @private
+     */
+    this.hist_id_ = -1;
 
-    goog.base(this, {features : this.regions_.select_.getFeatures()}); // call super
+    // call super
+    goog.base(
+        this, {
+            pixelTolerance : 5,
+            features : this.regions_.select_.getFeatures()
+        });
 
-	this.handleDragEvent_ = ome.ol3.interaction.Modify.handleDragEvent_;
-	this.handleEvent = ome.ol3.interaction.Modify.handleEvent;
-	this.handleUpEvent_ = ome.ol3.interaction.Modify.handleUpEvent_;
+    this.handleDragEvent_ = ome.ol3.interaction.Modify.handleDragEvent_;
+    this.handleEvent = ome.ol3.interaction.Modify.handleEvent;
+    this.handleUpEvent_ = ome.ol3.interaction.Modify.handleUpEvent_;
 
-	this.deleteCondition_ = function(mapBrowserEvent) {
-		return ol.events.condition.noModifierKeys(mapBrowserEvent) &&
-			ol.events.condition.click(mapBrowserEvent);
-	}
+    this.deleteCondition_ = function(mapBrowserEvent) {
+        return ol.events.condition.noModifierKeys(mapBrowserEvent) &&
+               ol.events.condition.click(mapBrowserEvent);
+    }
 
     // a listener to react on modify start
     ol.events.listen(this, ol.interaction.Modify.EventType.MODIFYSTART,
         function(event) {
             this.hist_id_ =
-                this.regions_.addHistory(event.features.array_, true)},
-        this);
+                this.regions_.addHistory(event.features.array_, true);
+        }, this);
 
     // a listener to react on modify end
     ol.events.listen(this, ol.interaction.Modify.EventType.MODIFYEND,
@@ -57,7 +62,8 @@ ome.ol3.interaction.Modify = function(regions_reference) {
                 this.regions_.addHistory(
                     event.features.array_, false, this.hist_id_);
                 this.regions_.sendHistoryNotification(this.hist_id_);
-            }},this);
+            }
+        },this);
 };
 goog.inherits(ome.ol3.interaction.Modify, ol.interaction.Modify);
 
@@ -69,90 +75,99 @@ goog.inherits(ome.ol3.interaction.Modify, ol.interaction.Modify);
  * @private
  */
 ome.ol3.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
-	if (!(this.features_ instanceof ol.Collection) || this.features_.getLength() === 0)
-		return;
+    if (!(this.features_ instanceof ol.Collection) ||
+          this.features_.getLength() === 0) return;
 
-	var pixelCoordinate = map.getCoordinateFromPixel(pixel);
-	var sortByDistance = function(a, b) {
-		return ol.coordinate.squaredDistanceToSegment(pixelCoordinate, a.segment) -
-			ol.coordinate.squaredDistanceToSegment(pixelCoordinate, b.segment);
-	};
+    var pixelCoordinate = map.getCoordinateFromPixel(pixel);
+    var sortByDistance = function(a, b) {
+        return ol.coordinate.squaredDistanceToSegment(
+                    pixelCoordinate, a.segment) -
+                    ol.coordinate.squaredDistanceToSegment(
+                        pixelCoordinate, b.segment);
+    };
 
-	var lowerLeft = map.getCoordinateFromPixel(
-		[pixel[0] - this.pixelTolerance_, pixel[1] + this.pixelTolerance_]);
-	var upperRight = map.getCoordinateFromPixel(
-		[pixel[0] + this.pixelTolerance_, pixel[1] - this.pixelTolerance_]);
-	var box = ol.extent.boundingExtent([lowerLeft, upperRight]);
+    var lowerLeft =
+        map.getCoordinateFromPixel(
+            [pixel[0] - this.pixelTolerance_, pixel[1] + this.pixelTolerance_]);
+    var upperRight =
+        map.getCoordinateFromPixel(
+            [pixel[0] + this.pixelTolerance_, pixel[1] - this.pixelTolerance_]);
+    var box = ol.extent.boundingExtent([lowerLeft, upperRight]);
 
-	var rBush = this.rBush_;
-	var nodes = rBush.getInExtent(box);
+    var rBush = this.rBush_;
+    var nodes = rBush.getInExtent(box);
 
-	// we are within a feature's bounding box
-	if (nodes.length > 0) {
-		nodes.sort(sortByDistance);
-		// get closest node
-		var node = nodes[0];
+    // we are within a feature's bounding box
+    if (nodes.length > 0) {
+        nodes.sort(sortByDistance);
+        // get closest node
+        var node = nodes[0];
         if ((typeof node.feature['visible'] === 'boolean' &&
-            !node.feature['visible']) ||
-            (typeof node.feature['state'] === 'number' &&
-            node.feature['state'] === ome.ol3.REGIONS_STATE.REMOVED)) return;
+             !node.feature['visible']) ||
+             (typeof node.feature['state'] === 'number' &&
+             node.feature['state'] === ome.ol3.REGIONS_STATE.REMOVED)) return;
 
-		// we only continue if we don't have an unmodifyable labels
-		if (!(node.geometry instanceof ome.ol3.geom.Label)) {
-			var closestSegment = node.segment;
-			var vertex = (ol.coordinate.closestOnSegment(pixelCoordinate,
-				closestSegment));
-			var vertexPixel = map.getPixelFromCoordinate(vertex);
+        // we only continue if we don't have an unmodifyable labels
+        if (!(node.geometry instanceof ome.ol3.geom.Label)) {
+            var closestSegment = node.segment;
+            var vertex =
+                (ol.coordinate.closestOnSegment(
+                    pixelCoordinate,closestSegment));
+            var vertexPixel = map.getPixelFromCoordinate(vertex);
 
-			if (Math.sqrt(ol.coordinate.squaredDistance(pixel, vertexPixel)) <=
-				this.pixelTolerance_) {
-				var pixel1 = map.getPixelFromCoordinate(closestSegment[0]);
-				var pixel2 = map.getPixelFromCoordinate(closestSegment[1]);
-				var squaredDist1 = ol.coordinate.squaredDistance(vertexPixel, pixel1);
-				var squaredDist2 = ol.coordinate.squaredDistance(vertexPixel, pixel2);
-				var dist = Math.sqrt(Math.min(squaredDist1, squaredDist2));
-				this.snappedToVertex_ = dist <= this.pixelTolerance_;
+            if (Math.sqrt(ol.coordinate.squaredDistance(pixel, vertexPixel)) <=
+                this.pixelTolerance_) {
+                    var pixel1 = map.getPixelFromCoordinate(closestSegment[0]);
+                    var pixel2 = map.getPixelFromCoordinate(closestSegment[1]);
+                    var squaredDist1 =
+                        ol.coordinate.squaredDistance(vertexPixel, pixel1);
+                    var squaredDist2 =
+                        ol.coordinate.squaredDistance(vertexPixel, pixel2);
+                    var dist = Math.sqrt(Math.min(squaredDist1, squaredDist2));
+                    this.snappedToVertex_ = dist <= this.pixelTolerance_;
 
-				// for rectangles we force snap to vertex to only be able to drag them
-				// at one of the vertices
-				if ((node.geometry instanceof ome.ol3.geom.Rectangle ||
-							node.geometry instanceof ome.ol3.geom.Ellipse)
-					&& !this.snappedToVertex_)
-						return;
+                    // for rectangles we force snap to vertex
+                    // to only be able to drag them at one of the vertices
+                    if ((node.geometry instanceof ome.ol3.geom.Rectangle ||
+                         node.geometry instanceof ome.ol3.geom.Ellipse ||
+                         node.geometry instanceof ome.ol3.geom.Line) &&
+                         !this.snappedToVertex_) return;
 
-				if (this.snappedToVertex_) {
-					vertex = squaredDist1 > squaredDist2 ?
-						closestSegment[1] : closestSegment[0];
-				}
+                    if (this.snappedToVertex_) {
+                        vertex = squaredDist1 > squaredDist2 ?
+                        closestSegment[1] : closestSegment[0];
+                    }
 
-				this.createOrUpdateVertexFeature_(vertex);
-				var vertexSegments = {};
-				vertexSegments[ol.getUid(closestSegment)] = true;
-				var segment;
-				for (var i = 1, ii = nodes.length; i < ii; ++i) {
-					segment = nodes[i].segment;
-					if ((ol.coordinate.equals(closestSegment[0], segment[0]) &&
-						ol.coordinate.equals(closestSegment[1], segment[1]) ||
-						(ol.coordinate.equals(closestSegment[0], segment[1]) &&
-						ol.coordinate.equals(closestSegment[1], segment[0])))) {
-							vertexSegments[ol.getUid(segment)] = true;
-					} else {
-						break;
-					}
-				}
-				this.vertexSegments_ = vertexSegments;
-				return;
-	    }
-	  }
-	}
+                    this.createOrUpdateVertexFeature_(vertex);
+                    var vertexSegments = {};
+                    vertexSegments[ol.getUid(closestSegment)] = true;
+                    var segment;
+                    for (var i = 1, ii = nodes.length; i < ii; ++i) {
+                        segment = nodes[i].segment;
+                        if ((ol.coordinate.equals(
+                            closestSegment[0], segment[0]) &&
+                            ol.coordinate.equals(
+                                closestSegment[1], segment[1]) ||
+                            (ol.coordinate.equals(
+                                closestSegment[0], segment[1]) &&
+                            ol.coordinate.equals(
+                                closestSegment[1], segment[0])))) {
+                                    vertexSegments[ol.getUid(segment)] = true;
+                        } else break;
+                    }
+                    this.vertexSegments_ = vertexSegments;
+                    this.regions_['is_modified'] = true;
+                    return;
+            }
+        }
+    }
 
-	// remove if we are not within a feature's bounding box
-	if (this.vertexFeature_) {
-		//this.removeFeature_(this.vertexFeature_);
-		//this.removeFeatureSegmentData_(this.vertexFeature_);
-		this.overlay_.getSource().removeFeature(this.vertexFeature_);
-		this.vertexFeature_ = null;
-	}
+    // remove if we are not within a feature's bounding box
+    if (this.vertexFeature_) {
+        this.regions_['is_modified'] = false;
+        this.overlay_.getSource().removeFeature(this.vertexFeature_);
+        this.vertexFeature_ = null;
+    }
 };
 
 /**
@@ -163,92 +178,96 @@ ome.ol3.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map
  * @private
  */
 ome.ol3.interaction.Modify.handleDragEvent_ = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (mapBrowserEvent instanceof ol.MapBrowserPointerEvent &&
-			mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3)
-		return;
+    // short circuit right for click context menu
+    if (mapBrowserEvent instanceof ol.MapBrowserPointerEvent &&
+        mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3) return;
 
-  this.ignoreNextSingleClick_ = false;
-  this.willModifyFeatures_(mapBrowserEvent);
+    this.ignoreNextSingleClick_ = false;
+    this.willModifyFeatures_(mapBrowserEvent);
 
-	var vertex = mapBrowserEvent.coordinate;
-	for (var i = 0, ii = this.dragSegments_.length; i < ii; ++i) {
-		var dragSegment = this.dragSegments_[i];
-		var segmentData = dragSegment[0];
-		var depth = segmentData.depth;
-		var geometry = segmentData.geometry;
-		var coordinates = geometry.getCoordinates();
-		var segment = segmentData.segment;
-		var index = dragSegment[1];
+    var vertex = mapBrowserEvent.coordinate;
+    for (var i = 0, ii = this.dragSegments_.length; i < ii; ++i) {
+        var dragSegment = this.dragSegments_[i];
+        var segmentData = dragSegment[0];
+        var depth = segmentData.depth;
+        var geometry = segmentData.geometry;
+        var coordinates = geometry.getCoordinates();
+        var segment = segmentData.segment;
+        var index = dragSegment[1];
 
-		while (vertex.length < geometry.getStride()) {
-			vertex.push(0);
-		}
+        while (vertex.length < geometry.getStride()) vertex.push(0);
 
-		if (geometry instanceof ol.geom.Point) {
-			coordinates = vertex;
-			segment[0] = segment[1] = vertex;
-		} else if (geometry instanceof ol.geom.MultiPoint) {
-			coordinates[segmentData.index] = vertex;
-			segment[0] = segment[1] = vertex;
-		} else if (geometry instanceof ol.geom.LineString) {
-			coordinates[segmentData.index + index] = vertex;
-			segment[index] = vertex;
-		} else if (geometry instanceof ol.geom.MultiLineString) {
-			coordinates[depth[0]][segmentData.index + index] = vertex;
-			segment[index] = vertex;
-		} else if (geometry instanceof ome.ol3.geom.Ellipse) {
+        if (geometry instanceof ol.geom.Point) {
+            coordinates = vertex;
+            segment[0] = segment[1] = vertex;
+        } else if (geometry instanceof ol.geom.MultiPoint) {
+            coordinates[segmentData.index] = vertex;
+            segment[0] = segment[1] = vertex;
+        } else if (geometry instanceof ol.geom.LineString) {
+            coordinates[segmentData.index + index] = vertex;
+            segment[index] = vertex;
+        } else if (geometry instanceof ol.geom.MultiLineString) {
+            coordinates[depth[0]][segmentData.index + index] = vertex;
+            segment[index] = vertex;
+        } else if (geometry instanceof ome.ol3.geom.Ellipse) {
             var potentialTransform = geometry.getTransform();
             var v = vertex;
             if (potentialTransform)
                 v = geometry.applyInverseTransform([v[0], v[1]]);
-			geometry.rx_ = Math.abs(geometry.cx_-v[0]);
-			geometry.ry_ = Math.abs(geometry.cy_-v[1]);
-			var tmp = new ome.ol3.geom.Ellipse(
-				geometry.cx_, geometry.cy_,
-                geometry.rx_, geometry.ry_,
-                potentialTransform);
-			coordinates = tmp.getCoordinates();
-		} else if (geometry instanceof ome.ol3.geom.Rectangle) {
-			var vertexBeingDragged =
-				this.vertexFeature_.getGeometry().getCoordinates();
-			if (this.oppVertBeingDragged == null)
-				for (var j=0;j<coordinates[depth[0]].length;j++)
-					if (coordinates[depth[0]][j][0] !=  vertexBeingDragged[0] &&
-							coordinates[depth[0]][j][1] !=  vertexBeingDragged[1]) {
-								this.oppVertBeingDragged = coordinates[depth[0]][j];
-								break;
-					}
+            geometry.rx_ = Math.abs(geometry.cx_-v[0]);
+            geometry.ry_ = Math.abs(geometry.cy_-v[1]);
+            var tmp =
+                new ome.ol3.geom.Ellipse(
+                    geometry.cx_, geometry.cy_,
+                    geometry.rx_, geometry.ry_,
+                    potentialTransform);
+            coordinates = tmp.getCoordinates();
+        } else if (geometry instanceof ome.ol3.geom.Rectangle) {
+            var vertexBeingDragged =
+                this.vertexFeature_.getGeometry().getCoordinates();
+            if (this.oppVertBeingDragged == null)
+                for (var j=0;j<coordinates[depth[0]].length;j++)
+                    if (coordinates[depth[0]][j][0] !=  vertexBeingDragged[0] &&
+                        coordinates[depth[0]][j][1] !=  vertexBeingDragged[1]) {
+                            this.oppVertBeingDragged = coordinates[depth[0]][j];
+                            break;
+                    }
 
-			var minX =
-				vertex[0] < this.oppVertBeingDragged[0] ? vertex[0] : this.oppVertBeingDragged[0];
-			var maxX =
-				vertex[0] > this.oppVertBeingDragged[0] ? vertex[0] : this.oppVertBeingDragged[0];
-			var minY =
-				-vertex[1] < -this.oppVertBeingDragged[1] ? vertex[1] : this.oppVertBeingDragged[1];
-			var maxY =
-				-vertex[1] > -this.oppVertBeingDragged[1] ? vertex[1] : this.oppVertBeingDragged[1];
+                var minX =
+                    vertex[0] < this.oppVertBeingDragged[0] ?
+                        vertex[0] : this.oppVertBeingDragged[0];
+                var maxX =
+                    vertex[0] > this.oppVertBeingDragged[0] ?
+                        vertex[0] : this.oppVertBeingDragged[0];
+                var minY =
+                    -vertex[1] < -this.oppVertBeingDragged[1] ?
+                        vertex[1] : this.oppVertBeingDragged[1];
+                var maxY =
+                    -vertex[1] > -this.oppVertBeingDragged[1] ?
+                        vertex[1] : this.oppVertBeingDragged[1];
 
-			// set new top left corner
-			coordinates[depth[0]][0] = [minX, minY];
-			coordinates[depth[0]][1] = [maxX, minY];
-			coordinates[depth[0]][2] = [maxX, maxY];
-			coordinates[depth[0]][3] = [minX, maxY];
-			coordinates[depth[0]][4] = [minX, minY];
+                // set new top left corner
+                coordinates[depth[0]][0] = [minX, minY];
+                coordinates[depth[0]][1] = [maxX, minY];
+                coordinates[depth[0]][2] = [maxX, maxY];
+                coordinates[depth[0]][3] = [minX, maxY];
+                coordinates[depth[0]][4] = [minX, minY];
 
-			segment[index] = geometry.getExtent().slice(index*2, (index+1)*2);
-		} else if (geometry instanceof ol.geom.Polygon) {
-			coordinates[depth[0]][segmentData.index + index] = vertex;
-			segment[index] = vertex;
-		} else if (geometry instanceof ol.geom.MultiPolygon) {
-			coordinates[depth[1]][depth[0]][segmentData.index + index] = vertex;
-			segment[index] = vertex;
-		}
-    this.setGeometryCoordinates_(geometry, coordinates);
-  }
-  this.createOrUpdateVertexFeature_(vertex);
+                segment[index] =
+                    geometry.getExtent().slice(index*2, (index+1)*2);
+            } else if (geometry instanceof ol.geom.Polygon) {
+                coordinates[depth[0]][segmentData.index + index] = vertex;
+                segment[index] = vertex;
+            } else if (geometry instanceof ol.geom.MultiPolygon) {
+                coordinates[depth[1]][depth[0]][segmentData.index + index] =
+                    vertex;
+                segment[index] = vertex;
+            }
+            this.setGeometryCoordinates_(geometry, coordinates);
+        }
+        this.createOrUpdateVertexFeature_(vertex);
 };
 
 /**
@@ -259,45 +278,44 @@ ome.ol3.interaction.Modify.handleDragEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ome.ol3.interaction.Modify.handleUpEvent_ = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (mapBrowserEvent instanceof ol.MapBrowserPointerEvent &&
-			mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3)
-		return false;
+    // short circuit right for click context menu
+    if (mapBrowserEvent instanceof ol.MapBrowserPointerEvent &&
+        mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3) return false;
 
-	this.oppVertBeingDragged = null;
-	var segmentData;
+    this.oppVertBeingDragged = null;
+    var segmentData;
 
     var id = null;
-	for (var i = this.dragSegments_.length - 1; i >= 0; --i) {
-		segmentData = this.dragSegments_[i][0];
+    for (var i = this.dragSegments_.length - 1; i >= 0; --i) {
+        segmentData = this.dragSegments_[i][0];
 
-		if (segmentData.geometry instanceof ome.ol3.geom.Rectangle ||
-				segmentData.geometry instanceof ome.ol3.geom.Ellipse) {
-			this.removeFeatureSegmentData_(segmentData.feature);
-			this.writePolygonGeometry_(segmentData.feature, segmentData.geometry);
-		} else {
-			this.rBush_.update(
-				ol.extent.boundingExtent(segmentData.segment),
-				segmentData);
-			if (this.vertexFeature_) {
-				this.features_.remove(this.vertexFeature_);
-			}
-		}
+        if (segmentData.geometry instanceof ome.ol3.geom.Rectangle ||
+            segmentData.geometry instanceof ome.ol3.geom.Ellipse) {
+                this.removeFeatureSegmentData_(segmentData.feature);
+                this.writePolygonGeometry_(
+                    segmentData.feature, segmentData.geometry);
+        } else {
+            this.rBush_.update(
+                ol.extent.boundingExtent(segmentData.segment), segmentData);
+            if (this.vertexFeature_) this.features_.remove(this.vertexFeature_);
+        }
         id = segmentData.feature.getId();
-	}
+    }
 
     if (id) this.regions_.setProperty(
         [id], "state", ome.ol3.REGIONS_STATE.MODIFIED);
-	if (this.modified_) {
-		this.dispatchEvent(new ol.interaction.Modify.Event(
-			ol.interaction.Modify.EventType.MODIFYEND, this.features_, mapBrowserEvent));
-		this.modified_ = false;
-	}
+    if (this.modified_) {
+        this.dispatchEvent(
+            new ol.interaction.Modify.Event(
+                ol.interaction.Modify.EventType.MODIFYEND,
+                this.features_, mapBrowserEvent));
+        this.modified_ = false;
+    }
     this.hist_id_ = -1; // reset
 
-	return false;
+    return false;
 };
 
 /**
@@ -309,49 +327,48 @@ ome.ol3.interaction.Modify.handleUpEvent_ = function(mapBrowserEvent) {
  * @api
  */
 ome.ol3.interaction.Modify.handleEvent = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
-			(mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3))
-		return true;
+    // short circuit right for click context menu
+    if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
+        (mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3)) return true;
 
-  var handled;
-  if (!mapBrowserEvent.map.getView().getHints()[ol.View.Hint.INTERACTING] &&
-      mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERMOVE &&
-      !this.handlingDownUpSequence) {
-    this.handlePointerMove_(mapBrowserEvent);
-  }
-
-  if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
-    if (mapBrowserEvent.type != ol.MapBrowserEvent.EventType.SINGLECLICK ||
-        !this.ignoreNextSingleClick_) {
-
-			// we do not allow to delete any vertex of a rectangle/ellipse
-			if (this.features_ instanceof ol.Collection &&
-				this.features_.getLength() > 0 &&
-					(this.features_.item(0).getGeometry() instanceof ome.ol3.geom.Rectangle ||
-					this.features_.item(0).getGeometry() instanceof ome.ol3.geom.Ellipse))
-					handled = true;
-			else {
-	      var geometry = this.vertexFeature_.getGeometry();
-          if (!(geometry instanceof ol.geom.Point))
-              console.error("geometry should be an ol.geom.Point!");
-	      this.willModifyFeatures_(mapBrowserEvent);
-	      handled = this.removeVertex_();
-	      this.dispatchEvent(new ol.interaction.Modify.Event(
-	          ol.interaction.Modify.EventType.MODIFYEND, this.features_, mapBrowserEvent));
-	      this.modified_ = false;
-			}
-    } else {
-      handled = true;
+    var handled;
+    if (!mapBrowserEvent.map.getView().getHints()[ol.View.Hint.INTERACTING] &&
+        mapBrowserEvent.type == ol.MapBrowserEvent.EventType.POINTERMOVE &&
+        !this.handlingDownUpSequence) {
+            this.handlePointerMove_(mapBrowserEvent);
     }
-  }
 
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.SINGLECLICK) {
-    this.ignoreNextSingleClick_ = false;
-  }
+    if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
+        if (mapBrowserEvent.type != ol.MapBrowserEvent.EventType.SINGLECLICK ||
+            !this.ignoreNextSingleClick_) {
+            // we do not allow to delete any vertex of a rectangle/ellipse
+            if (this.features_ instanceof ol.Collection &&
+                this.features_.getLength() > 0 &&
+                (this.features_.item(0).getGeometry()
+                    instanceof ome.ol3.geom.Rectangle ||
+                 this.features_.item(0).getGeometry()
+                    instanceof ome.ol3.geom.Ellipse)) handled = true;
+            else {
+                var geometry = this.vertexFeature_.getGeometry();
+                if (!(geometry instanceof ol.geom.Point))
+                    console.error("geometry should be an ol.geom.Point!");
+                this.willModifyFeatures_(mapBrowserEvent);
+                handled = this.removeVertex_();
+                this.dispatchEvent(
+                    new ol.interaction.Modify.Event(
+                        ol.interaction.Modify.EventType.MODIFYEND,
+                        this.features_, mapBrowserEvent));
+                this.modified_ = false;
+            }
+        } else handled = true;
+    }
 
-  return ol.interaction.Pointer.handleEvent.call(this, mapBrowserEvent) &&
-      !handled;
+    if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.SINGLECLICK) {
+        this.ignoreNextSingleClick_ = false;
+    }
+
+    return ol.interaction.Pointer.handleEvent.call(this, mapBrowserEvent) &&
+            !handled;
 };

--- a/ol3-viewer/src/ome/ol3/interaction/Select.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Select.js
@@ -190,10 +190,11 @@ ome.ol3.interaction.Select.handleEvent = function(mapBrowserEvent) {
  * coordinates.
  * @private
  */
-ome.ol3.interaction.Select.prototype.featuresAtCoords_ = function(pixel) {
+ome.ol3.interaction.Select.prototype.featuresAtCoords_ =
+    function(pixel, tolerance) {
     if (!ome.ol3.utils.Misc.isArray(pixel) || pixel.length !== 2) return;
 
-    var tolerance = 5; // 5 pixel buffer
+    if (typeof tolerance !== 'number') tolerance = 5; // 5 pixel buffer
     var v = this.regions_.viewer_.viewer_;
     var min = v.getCoordinateFromPixel(
                 [pixel[0]-tolerance, pixel[1]+tolerance]);

--- a/ol3-viewer/src/ome/ol3/interaction/Translate.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Translate.js
@@ -12,49 +12,49 @@ goog.require('ol.Collection');
  * @param {ome.ol3.source.Regions} regions_reference an Regions instance.
  */
 ome.ol3.interaction.Translate = function(regions_reference) {
-	// we do need the regions reference to do translations
+    // we do need the regions reference to do translations
     if (!(regions_reference instanceof ome.ol3.source.Regions))
         console.error("Translate needs Regions instance!");
 
-	/**
-   * @type {ome.ol3.source.Regions}
-   * @private
-   */
-   this.regions_ = regions_reference;
+    /**
+     * @type {ome.ol3.source.Regions}
+     * @private
+     */
+    this.regions_ = regions_reference;
 
     /**
-   * @type {number}
-   * @private
-   */
-   this.hist_id_ = -1;
+     * @type {number}
+     * @private
+     */
+    this.hist_id_ = -1;
 
-	// call super
+    // call super
     goog.base(this, {});
 
-	// we use our event handlers altogether
-	this.handleDownEvent_ = ome.ol3.interaction.Translate.handleDownEvent_;
-	this.handleMoveEvent_ = ome.ol3.interaction.Translate.handleMoveEvent_;
-	this.handleUpEvent_ = ome.ol3.interaction.Translate.handleUpEvent_;
+    // we use our event handlers altogether
+    this.handleDownEvent_ = ome.ol3.interaction.Translate.handleDownEvent_;
+    this.handleMoveEvent_ = ome.ol3.interaction.Translate.handleMoveEvent_;
+    this.handleUpEvent_ = ome.ol3.interaction.Translate.handleUpEvent_;
 
-	/**
-   * @type {ol.Collection.<ol.Feature>}
-   * @private
-   */
-  this.features_ = this.regions_.select_.getFeatures();
+    /**
+     * @type {ol.Collection.<ol.Feature>}
+     * @private
+     */
+    this.features_ = this.regions_.select_.getFeatures();
 
-  // a listener to react on translate start
-  ol.events.listen(
-      this,
-      ol.interaction.Translate.EventType.TRANSLATESTART,
-      ome.ol3.interaction.Translate.prototype.handleTranslateStart,
-      this);
+    // a listener to react on translate start
+    ol.events.listen(
+        this,
+        ol.interaction.Translate.EventType.TRANSLATESTART,
+        ome.ol3.interaction.Translate.prototype.handleTranslateStart,
+        this);
 
-	// a listener to react on translate end
-	ol.events.listen(
-		this,
-		ol.interaction.Translate.EventType.TRANSLATEEND,
-		ome.ol3.interaction.Translate.prototype.handleTranslateEnd,
-		this);
+    // a listener to react on translate end
+    ol.events.listen(
+        this,
+        ol.interaction.Translate.EventType.TRANSLATEEND,
+        ome.ol3.interaction.Translate.prototype.handleTranslateEnd,
+        this);
 };
 goog.inherits(ome.ol3.interaction.Translate, ol.interaction.Translate);
 
@@ -63,16 +63,16 @@ goog.inherits(ome.ol3.interaction.Translate, ol.interaction.Translate);
  * @param {ol.interaction.Translate.Event} event a translate event.
  */
 ome.ol3.interaction.Translate.prototype.handleTranslateEnd = function(event) {
-	var featuresTranslated = event.features.array_;
+    var featuresTranslated = event.features.array_;
     var ids = [];
-	for (var f in featuresTranslated) {
-		if (featuresTranslated[f].getGeometry() instanceof ome.ol3.geom.Label)
-			featuresTranslated[f].getGeometry().modifyOriginalCoordinates(
-				event.target.getMap().getView().getRotation(),
-				event.target.getMap().getView().getResolution()
-			);
+    for (var f in featuresTranslated) {
+        if (featuresTranslated[f].getGeometry() instanceof ome.ol3.geom.Label)
+            featuresTranslated[f].getGeometry().modifyOriginalCoordinates(
+                event.target.getMap().getView().getRotation(),
+                event.target.getMap().getView().getResolution()
+            );
         ids.push(featuresTranslated[f].getId());
-	}
+    }
     // complete history entry
     if (this.hist_id_ >= 0) {
         this.regions_.addHistory(featuresTranslated, false, this.hist_id_);
@@ -100,24 +100,24 @@ ome.ol3.interaction.Translate.prototype.handleTranslateStart = function(event) {
  * @private
  */
 ome.ol3.interaction.Translate.handleDownEvent_ = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
-			(mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3))
-		return false;
+    // short circuit right for click context menu
+    if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
+        (mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3)) return false;
 
-  this.lastFeature_ = this.featuresAtCoords_(mapBrowserEvent.pixel);
-  if (!this.lastCoordinate_ && this.lastFeature_) {
-    this.lastCoordinate_ = mapBrowserEvent.coordinate;
-    ome.ol3.interaction.Translate.handleMoveEvent_.call(this, mapBrowserEvent);
-    this.dispatchEvent(
-        new ol.interaction.Translate.Event(
-            ol.interaction.Translate.EventType.TRANSLATESTART, this.features_,
-            mapBrowserEvent.coordinate));
-    return true;
-  }
-  return false;
+    this.lastFeature_ = this.featuresAtCoords_(mapBrowserEvent.pixel);
+    if (!this.lastCoordinate_ && this.lastFeature_) {
+        this.lastCoordinate_ = mapBrowserEvent.coordinate;
+        ome.ol3.interaction.Translate.handleMoveEvent_.call(
+            this, mapBrowserEvent);
+        this.dispatchEvent(
+            new ol.interaction.Translate.Event(
+                ol.interaction.Translate.EventType.TRANSLATESTART,
+                this.features_, mapBrowserEvent.coordinate));
+        return true;
+    }
+    return false;
 };
 
 /**
@@ -126,12 +126,11 @@ ome.ol3.interaction.Translate.handleDownEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ome.ol3.interaction.Translate.handleMoveEvent_ = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
-			(mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3))
-		return;
+    // short circuit right for click context menu
+    if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
+        (mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3)) return;
 };
 
 /**
@@ -141,23 +140,23 @@ ome.ol3.interaction.Translate.handleMoveEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ome.ol3.interaction.Translate.handleUpEvent_ = function(mapBrowserEvent) {
-	// short circuit right for click context menu
-	if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
-			(mapBrowserEvent.originalEvent instanceof MouseEvent &&
-				typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
-				mapBrowserEvent.originalEvent.which === 3))
-		return true;
+    // short circuit right for click context menu
+    if (!(mapBrowserEvent instanceof ol.MapBrowserPointerEvent) ||
+        (mapBrowserEvent.originalEvent instanceof MouseEvent &&
+        typeof(mapBrowserEvent.originalEvent.which) === 'number' &&
+        mapBrowserEvent.originalEvent.which === 3)) return true;
 
-  if (this.lastCoordinate_) {
-    this.lastCoordinate_ = null;
-    ome.ol3.interaction.Translate.handleMoveEvent_.call(this, mapBrowserEvent);
-    this.dispatchEvent(
-        new ol.interaction.Translate.Event(
-            ol.interaction.Translate.EventType.TRANSLATEEND, this.features_,
-            mapBrowserEvent.coordinate));
-    return true;
-  }
-  return false;
+    if (this.lastCoordinate_) {
+        this.lastCoordinate_ = null;
+        ome.ol3.interaction.Translate.handleMoveEvent_.call(
+            this, mapBrowserEvent);
+        this.dispatchEvent(
+            new ol.interaction.Translate.Event(
+                ol.interaction.Translate.EventType.TRANSLATEEND,
+                this.features_, mapBrowserEvent.coordinate));
+        return true;
+    }
+    return false;
 };
 
 /**
@@ -168,17 +167,16 @@ ome.ol3.interaction.Translate.handleUpEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ome.ol3.interaction.Translate.prototype.featuresAtCoords_ = function(coord) {
-    var found = this.regions_.select_.featuresAtCoords_(coord);
-
-    if (this.features_ &&
-        ol.array.includes(this.features_.getArray(), found)) return found;
-    else return null;
+    var hit = this.regions_.select_.featuresAtCoords_(coord, 5);
+    if (hit === null || (typeof this.regions_['is_modified'] === 'boolean' &&
+        this.regions_['is_modified'])) return null;
+    return hit;
 };
 
 /**
  * a sort of desctructor
  */
 ome.ol3.interaction.Translate.prototype.disposeInternal = function() {
-	this.features_  = null;
-	this.regions_ = null;
+    this.features_  = null;
+    this.regions_ = null;
 }

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -24,7 +24,7 @@ ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
 		 					(typeof(shape['y']) === 'number' ? shape['y'] : -1);
 
 		var feat = new ol.Feature({"geometry" :
-			new ol.geom.Circle([x, -y], 2)});
+			new ol.geom.Circle([x, -y], 5)});
 		feat['type'] = "point";
 		feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
 		return feat;

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -57,7 +57,9 @@ export default class RegionsInfo extends EventSubscriber {
      * @memberof RegionsInfo
      * @type {Array.<number>}
      */
-    regions_modes = [REGIONS_MODE.SELECT, REGIONS_MODE.TRANSLATE];
+    regions_modes = [
+        REGIONS_MODE.SELECT, REGIONS_MODE.MODIFY, REGIONS_MODE.TRANSLATE
+    ];
 
     /**
      * the drawing mode

--- a/src/regions/regions-edit.html
+++ b/src/regions/regions-edit.html
@@ -28,8 +28,6 @@
                                     regions_info.copied_shapes.length !== 0"
                          click.delegate="pasteShapes()"><a href="#">Paste</a></li>
                     <li click.delegate="selectAllShapes()"><a href="#">Select All</a></li>
-                    <li click.delegate="setEditMode()"><a href="#">Translate</a></li>
-                    <li click.delegate="setEditMode(true)"><a href="#">Modify</a></li>
                 </ul>
             </div>
         </div>

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -5,8 +5,8 @@ import {Utils} from '../utils/regions';
 import {Converters} from '../utils/converters';
 import {REGIONS_MODE} from '../utils/constants';
 import {
-    REGIONS_SET_PROPERTY, REGIONS_GENERATE_SHAPES,
-    REGIONS_MODIFY_SHAPES, REGIONS_COPY_SHAPES
+    REGIONS_COPY_SHAPES, REGIONS_GENERATE_SHAPES,
+    REGIONS_MODIFY_SHAPES, REGIONS_SET_PROPERTY
 } from '../events/events';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {spectrum} from 'spectrum-colorpicker';

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -5,8 +5,8 @@ import {Utils} from '../utils/regions';
 import {Converters} from '../utils/converters';
 import {REGIONS_MODE} from '../utils/constants';
 import {
-    REGIONS_CHANGE_MODES, REGIONS_SET_PROPERTY,
-    REGIONS_GENERATE_SHAPES,REGIONS_MODIFY_SHAPES, REGIONS_COPY_SHAPES
+    REGIONS_SET_PROPERTY, REGIONS_GENERATE_SHAPES,
+    REGIONS_MODIFY_SHAPES, REGIONS_COPY_SHAPES
 } from '../events/events';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {spectrum} from 'spectrum-colorpicker';
@@ -442,21 +442,6 @@ export default class RegionsEdit {
                 (color) => this.onColorChange(color.toRgbString(), fill, shape);
 
         return options;
-    }
-
-    /**
-     * Sets edit mode to either modify or translate
-     *
-     * @memberof RegionsEdit
-     */
-    setEditMode(modify=false) {
-        let mode = [REGIONS_MODE.TRANSLATE];
-        if (typeof modify === 'boolean' && modify) mode = [REGIONS_MODE.MODIFY];
-
-        this.context.publish(
-            REGIONS_CHANGE_MODES, {
-                config_id : this.regions_info.image_info.config_id,
-                modes : mode});
     }
 
     /**

--- a/test/unit/utils/regions.js
+++ b/test/unit/utils/regions.js
@@ -74,7 +74,7 @@ describe("Regions", function() {
 		assert.instanceOf(feature, ol.Feature);
 		assert.instanceOf(feature.getGeometry(),  ol.geom.Circle);
 		expect(feature.getGeometry().getCenter()).to.eql([10,-25]);
-		expect(feature.getGeometry().getRadius()).to.eql(2);
+		expect(feature.getGeometry().getRadius()).to.eql(5);
 
 		feature = ome.ol3.utils.Regions.featureFactory(label_info);
 		assert.instanceOf(feature, ol.Feature);


### PR DESCRIPTION
Geometric modification of shapes used to be mutually exclusive with translation. 

Now both can be done without switching modes. 

TEST: use https://cowfish.openmicroscopy.org/webtrial/, select shapes, then modify and translate them.