### PR TITLE
birdseye view: start with collapsed view unless bigger/tiled image

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -468,6 +468,12 @@ ome.ol3.Viewer = function(id, options) {
                 view: view
             });
 
+            // expand bird's eye view for tiles sources
+            if (source.use_tiled_retrieval_ && scope.viewerState_["birdseye"] &&
+                scope.viewerState_["birdseye"]['ref']
+                    instanceof ome.ol3.controls.BirdsEye)
+                        scope.viewerState_["birdseye"]['ref'].setCollapsed(false);
+
             // listens to resolution changes
             scope.onViewResolutionListener =
                 ol.events.listen( // register a resolution handler for zoom display

--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -98,7 +98,7 @@ ome.ol3.AVAILABLE_VIEWER_CONTROLS = {
 		"links" : []},
     "birdseye" :
         {"clazz" : ome.ol3.controls.BirdsEye,
-        "options": {collapsed : false, collapseLabel : "»", label: "«"},
+        "options": {collapsed : true, collapseLabel : "»", label: "«"},
         "defaults": true,
         "enabled": true,
         "links" : []},

--- a/plugin/ol3-viewer/templates/ol3-viewer/plugin.html
+++ b/plugin/ol3-viewer/templates/ol3-viewer/plugin.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en" style='width: 100%; height: 100%'>
 
 <head>
      <title>Omero Open Layers 3 Viewer Plugin</title>
@@ -12,9 +12,10 @@
 		 <link rel="stylesheet" type="text/css" href="{% static 'ol3-viewer/css/viewer.css' %}" />
 </head>
 
-<body>
+<body style='font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
+             font-size:14px; margin: 0px; width: 100%; height: 100%'>
 
-	<div id="ome_viewer"></div>
+	<div id="ome_viewer" style="width: 100%; height: 100%"></div>
 
 	<script type="text/javascript">
         var p = {};

--- a/src/css/ol3-viewer.css
+++ b/src/css/ol3-viewer.css
@@ -1,72 +1,274 @@
-/** ol3 styles **/
-.ol-control,.ol-scale-line{position:absolute;padding:2px}.ol-box{box-sizing:border-box;border-radius:2px;border:2px solid #00f}.ol-mouse-position{top:8px;right:8px;position:absolute}.ol-scale-line{background:rgba(0,60,136,.3);border-radius:4px;bottom:8px;left:8px}.ol-scale-line-inner{border:1px solid #eee;border-top:none;color:#eee;font-size:10px;text-align:center;margin:1px;will-change:contents,width}.ol-overlay-container{will-change:left,right,top,bottom}.ol-unsupported{display:none}.ol-viewport .ol-unselectable{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:transparent}.ol-control{background-color:rgba(255,255,255,.4);border-radius:4px}.ol-control:hover{background-color:rgba(255,255,255,.6)}.ol-zoom{top:.5em;left:.5em}.ol-rotate{top:.5em;right:.5em;transition:opacity .25s linear,visibility 0s linear}.ol-rotate.ol-hidden{opacity:0;visibility:hidden;transition:opacity .25s linear,visibility 0s linear .25s}.ol-zoom-extent{top:4.643em;left:.5em}.ol-full-screen{right:.5em;top:.5em}@media print{.ol-control{display:none}}.ol-control button{display:block;margin:1px;padding:0;color:#fff;font-size:1.14em;font-weight:700;text-decoration:none;text-align:center;height:1.375em;width:1.375em;line-height:.4em;background-color:rgba(0,60,136,.5);border:none;border-radius:2px}.ol-control button::-moz-focus-inner{border:none;padding:0}.ol-zoom-extent button{line-height:1.4em}.ol-compass{display:block;font-weight:400;font-size:1.2em;will-change:transform}.ol-touch .ol-control button{font-size:1.5em}.ol-touch .ol-zoom-extent{top:5.5em}.ol-control button:focus,.ol-control button:hover{text-decoration:none;background-color:rgba(0,60,136,.7)}.ol-zoom .ol-zoom-in{border-radius:2px 2px 0 0}.ol-zoom .ol-zoom-out{border-radius:0 0 2px 2px}.ol-attribution{text-align:right;bottom:.5em;right:.5em;max-width:calc(100% - 1.3em)}.ol-attribution ul{margin:0;padding:0 .5em;font-size:.7rem;line-height:1.375em;color:#000;text-shadow:0 0 2px #fff}.ol-attribution li{display:inline;list-style:none;line-height:inherit}.ol-attribution li:not(:last-child):after{content:" "}.ol-attribution img{max-height:2em;max-width:inherit;vertical-align:middle}.ol-attribution button,.ol-attribution ul{display:inline-block}.ol-attribution.ol-collapsed ul{display:none}.ol-attribution.ol-logo-only ul{display:block}.ol-attribution:not(.ol-collapsed){background:rgba(255,255,255,.8)}.ol-attribution.ol-uncollapsible{bottom:0;right:0;border-radius:4px 0 0;height:1.1em;line-height:1em}.ol-attribution.ol-logo-only{background:0 0;bottom:.4em;height:1.1em;line-height:1em}.ol-attribution.ol-uncollapsible img{margin-top:-.2em;max-height:1.6em}.ol-attribution.ol-logo-only button,.ol-attribution.ol-uncollapsible button{display:none}.ol-zoomslider{top:4.5em;left:.5em;height:200px}.ol-zoomslider button{position:relative;height:10px}.ol-touch .ol-zoomslider{top:5.5em}.ol-overviewmap{left:.5em;bottom:.5em}.ol-overviewmap.ol-uncollapsible{bottom:0;left:0;border-radius:0 4px 0 0}.ol-overviewmap .ol-overviewmap-map,.ol-overviewmap button{display:inline-block}.ol-overviewmap .ol-overviewmap-map{border:1px solid #7b98bc;height:150px;margin:2px;width:150px}.ol-overviewmap:not(.ol-collapsed) button{bottom:4px;right:3px;position:absolute}.ol-overviewmap.ol-collapsed .ol-overviewmap-map,.ol-overviewmap.ol-uncollapsible button{display:none}.ol-overviewmap:not(.ol-collapsed){background:rgba(255,255,255,.8)}.ol-overviewmap-box{border:2px dotted rgba(0,60,136,.7)}
-
-/** move rotation icon **/
-.ol-rotate {
-	top:2.5em;
-	right:.5em;
-	transition:opacity .25s linear,visibility 0s linear;
+.ol-box {
+    box-sizing: border-box;
+    border-radius: 2px;
+    border: 2px solid blue;
 }
 
-/** CUSTOM ZOOM START **/
+.ol-mouse-position {
+    top: 8px;
+    right: 8px;
+    position: absolute;
+}
+
+.ol-scale-line {
+    background: rgba(0,60,136,0.3);
+    border-radius: 4px;
+    bottom: 8px;
+    left: 8px;
+    padding: 2px;
+    position: absolute;
+}
+.ol-scale-line-inner {
+    border: 1px solid #eee;
+    border-top: none;
+    color: #eee;
+    font-size: 10px;
+    text-align: center;
+    margin: 1px;
+    will-change: contents, width;
+}
+.ol-overlay-container {
+    will-change: left,right,top,bottom;
+}
+
+.ol-unsupported {
+    display: none;
+}
+.ol-viewport .ol-unselectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+.ol-control {
+    position: absolute;
+    background-color: rgba(255,255,255,0.4);
+    border-radius: 4px;
+    padding: 2px;
+}
+.ol-control:hover {
+    background-color: rgba(255,255,255,0.6);
+}
 .ol-zoom {
     box-sizing: content-box;
     width: 55px;
+    top: .5em;
+    left: .5em;
 }
-.ol-zoom-1-1 {
-    width: 53px!important;
+.ol-rotate {
+    top: 3em;
+    right: .5em;
+    transition: opacity .25s linear, visibility 0s linear;
 }
-.ol-zoom-fit {
-    width: 53px!important;;
+.ol-rotate.ol-hidden {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .25s linear, visibility 0s linear .25s;
 }
-.ol-zoom-in {
-    width: 53px!important;
+.ol-zoom-extent {
+    top: 4.643em;
+    left: .5em;
 }
-.ol-zoom-out {
-    width: 53px!important;
+.ol-full-screen {
+    right: .5em;
+    top: .5em;
 }
-.ol-zoom-display {
-    float: left;
-    margin-bottom: 1px;
-    border-width: 1px;
-    border-style: solid;
-    border-color: rgba(0,60,136,.5);
-    width: 35px;
-    margin-left: 1px;
-    text-align: center;
+@media print {
+    .ol-control {
+        display: none;
+    }
 }
-.ol-zoom-percent {
-    float: left;
-    padding: 0px;
-    margin-left: 1px;
-    margin-top: 1px;
-    font-weight: normal;
-    width: 16px!important;
-}
-/** CUSTOM ZOOM END **/
 
-/** BIRDS EYE STYLE START **/
+.ol-control button {
+    display: block;
+    margin: 1px;
+    padding: 0;
+    color: white;
+    font-size: 1.14em;
+    font-weight: bold;
+    text-decoration: none;
+    text-align: center;
+    height: 1.375em;
+    width: 1.375em;
+    line-height: .4em;
+    background-color: rgba(0,60,136,0.5);
+    border: none;
+    border-radius: 2px;
+}
+.ol-control button::-moz-focus-inner {
+    border: none;
+    padding: 0;
+}
+.ol-zoom-extent button {
+    line-height: 1.4em;
+}
+.ol-compass {
+    display: block;
+    font-weight: normal;
+    font-size: 1.2em;
+    will-change: transform;
+}
+.ol-touch .ol-control button {
+    font-size: 1.5em;
+}
+.ol-touch .ol-zoom-extent {
+    top: 5.5em;
+}
+.ol-control button:hover,
+.ol-control button:focus {
+    text-decoration: none;
+    background-color: rgba(0,60,136,0.7);
+}
+.ol-zoom {
+    width: 60px;
+    padding-left: 2px;
+    padding-right: 2px;
+}
+.ol-zoom button {
+    width: 58px;
+}
+
+.ol-zoom .ol-zoom-in {
+    border-radius: 2px 2px 0 0;
+}
+.ol-zoom .ol-zoom-out {
+    border-radius: 0 0 2px 2px;
+}
+
+.ol-attribution {
+    text-align: right;
+    bottom: .5em;
+    right: .5em;
+    max-width: calc(100% - 1.3em);
+}
+
+.ol-attribution ul {
+    margin: 0;
+    padding: 0 .5em;
+    font-size: .7rem;
+    line-height: 1.375em;
+    color: #000;
+    text-shadow: 0 0 2px #fff;
+}
+.ol-attribution li {
+    display: inline;
+    list-style: none;
+    line-height: inherit;
+}
+.ol-attribution li:not(:last-child):after {
+    content: " ";
+}
+.ol-attribution img {
+    max-height: 2em;
+    max-width: inherit;
+    vertical-align: middle;
+}
+.ol-attribution ul, .ol-attribution button {
+    display: inline-block;
+}
+.ol-attribution.ol-collapsed ul {
+    display: none;
+}
+.ol-attribution.ol-logo-only ul {
+    display: block;
+}
+.ol-attribution:not(.ol-collapsed) {
+    background: rgba(255,255,255,0.8);
+}
+.ol-attribution.ol-uncollapsible {
+    bottom: 0;
+    right: 0;
+    border-radius: 4px 0 0;
+    height: 1.1em;
+    line-height: 1em;
+}
+.ol-attribution.ol-logo-only {
+    background: transparent;
+    bottom: .4em;
+    height: 1.1em;
+    line-height: 1em;
+}
+.ol-attribution.ol-uncollapsible img {
+    margin-top: -.2em;
+    max-height: 1.6em;
+}
+.ol-attribution.ol-logo-only button,
+.ol-attribution.ol-uncollapsible button {
+    display: none;
+}
+
+.ol-zoomslider {
+    top: 4.5em;
+    left: .5em;
+    height: 200px;
+}
+.ol-zoomslider button {
+    position: relative;
+    height: 10px;
+}
+
+.ol-touch .ol-zoomslider {
+    top: 5.5em;
+}
+
 .ol-overviewmap {
     right: .5em;
     bottom: .5em;
     left: auto;
     left: initial;
 }
-.ol-overviewmap-box {
-    border: 2px dotted rgba(255,0,0,255);
+.ol-overviewmap.ol-uncollapsible {
+    bottom: 0;
+    left: 0;
+    border-radius: 0 4px 0 0;
 }
+.ol-overviewmap .ol-overviewmap-map,
 .ol-overviewmap button {
-    bottom: 4px;
-    right: 3px;
-    position: absolute;
-    left: auto;
-    left: initial;
+    display: inline-block;
+}
+.ol-overviewmap .ol-overviewmap-map {
+    height: 100px;
+    margin: 2px;
+    width: 150px;
+}
+.ol-overviewmap:not(.ol-collapsed) {
+    border: 1px solid #7b98bc;
 }
 .ol-overviewmap:not(.ol-collapsed) button {
-    bottom: 4px;
-    right: 3px;
+    bottom: 1px;
+    right: 1px;
     position: absolute;
     left: auto;
     left: initial;
 }
-/** BIRDS EYE STYLE END **/
+.ol-overviewmap.ol-collapsed .ol-overviewmap-map,
+.ol-overviewmap.ol-uncollapsible button {
+    display: none;
+}
+.ol-overviewmap:not(.ol-collapsed) {
+    background: rgba(255,255,255,1);
+}
+.ol-overviewmap-box {
+    border: 2px dotted rgba(255,0,0,1);
+}
+
+.ol-zoom-display {
+    float: left;
+    margin-bottom: 1px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: rgba(0,60,136,.5);
+    width: 38px;
+    margin-left: 1px;
+    text-align: center;
+}
+.ol-zoom-percent {
+    float: left;
+    margin-left: 2px!important;
+    font-weight: normal;
+    width: 18px!important;
+}


### PR DESCRIPTION
see: https://trello.com/c/Zbpqg5MR/281-rfe

When opening the iviewer or another image within the iviewer it is not necessary to start with the birdseye view in the expanded state for smaller images (takes up space too). It can always opened on demand when zooming is done and it makes sense to use it. 


TEST: https://cowfish.openmicroscopy.org/webtrial
Choose small images as well as big images/pyramids and check that the birdseye view is closed in the former case and open in the latter.