### PR TITLE
showing only 10 dataset thumbnails by default

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -4,8 +4,8 @@ import {IMAGE_CONFIG_SELECT} from '../events/events';
 import Misc from '../utils/misc';
 import ImageConfig from '../model/image_config';
 import {
-    REQUEST_PARAMS,
-    WEBGATEWAY, WEBCLIENT, PLUGIN_NAME, URI_PREFIX, IVIEWER
+    API_PREFIX, IVIEWER, PLUGIN_NAME, REQUEST_PARAMS,
+    WEBCLIENT, WEBGATEWAY, URI_PREFIX
 } from '../utils/constants';
 
 /**
@@ -40,6 +40,12 @@ export default class Context {
      * @type {string}
      */
     server = null;
+
+    /**
+     * api prefix
+     * @type {string}
+     */
+    api_prefix = 'api/v0/m/';
 
     /**
      * a list of potentially prefixes resources
@@ -187,6 +193,7 @@ export default class Context {
             typeof params[URI_PREFIX] === 'string' ?
                 Misc.prepareURI(params[URI_PREFIX]) : "";
         this.prefixed_uris.set(URI_PREFIX, prefix);
+        this.prefixed_uris.set(API_PREFIX, prefix + "/" + this.api_prefix);
         this.prefixed_uris.set(IVIEWER, prefix + "/" + PLUGIN_NAME);
         [WEBGATEWAY, WEBCLIENT].map(
             (key) =>

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -301,7 +301,7 @@ export default class Context {
         let newPath =
             oldPath.replace(old_image_id, image_id);
         if (typeof dataset_id === 'number')
-            newPath += '?dataset_id=' + dataset_id;
+            newPath += '?dataset=' + dataset_id;
         if (this.is_dev_server) {
             newPath += (newPath.indexOf('?') === -1) ? '?' : '&';
             newPath += 'haveMadeCrossOriginLogin_';

--- a/src/app/header.js
+++ b/src/app/header.js
@@ -144,7 +144,7 @@ export class Header extends EventSubscriber {
                     settings);
                 // let's add the dataset id if we have one
                 if (typeof selConf.image_info.dataset_id === 'number')
-                    url += "&dataset_id=" + selConf.image_info.dataset_id;
+                    url += "&dataset=" + selConf.image_info.dataset_id;
 
                 // show link and register close button
                 $('.link-url button').blur();

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -12,8 +12,8 @@
         style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
         title="Show more images"></div>
     </div>
-    <div class="disabled-color"
-        show.bind="requesting_thumbnail_data">
+    <div class="disabled-color" style="position: relative;top: 40%;"
+         show.bind="requesting_thumbnail_data">
             Gathering<br>Thumbnail<br>Info...
     </div>
 </template>

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -1,12 +1,18 @@
 <template>
     <div class="thumbnail-scroll-panel"
         show.bind="!requesting_thumbnail_data">
-        <img repeat.for="[id, thumb] of thumbnails"
+        <div if.bind="thumbnails_start_index > 0"
+             click.delegate="requestMoreThumbnails(false, false)"
+             class='collapse-up'
+             style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
+             title="Show more images">
+        </div>
+        <img repeat.for="thumb of thumbnails"
              src="${thumb.url}?version=${thumb.revision}"
              title="${thumb.title}"
-             click.delegate="onClick(id)"/>
-        <div if.bind="thumbnails_count !== thumbnails.size"
-             click.delegate="requestMoreThumbnails()"
+             click.delegate="onClick(thumb.id)"/>
+        <div if.bind="thumbnails_end_index < thumbnails_count"
+             click.delegate="requestMoreThumbnails(false, true)"
              class='expand-down'
              style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
              title="Show more images">

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -1,16 +1,16 @@
 <template>
     <div class="thumbnail-scroll-panel"
         show.bind="!requesting_thumbnail_data">
-      <img repeat.for="[id, thumb] of thumbnails"
-        src="${context.server}${thumb.url}?version=${thumb.revision}"
-        title="${thumb.title}"
-        click.delegate="onClick(id)"/>
-      <div
-        if.bind="thumbnails_response && thumbnails_response.length > 0"
-        click.delegate="addThumbnails()"
-        class='expand-down'
-        style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
-        title="Show more images"></div>
+        <img repeat.for="[id, thumb] of thumbnails"
+             src="${thumb.url}?version=${thumb.revision}"
+             title="${thumb.title}"
+             click.delegate="onClick(id)"/>
+        <div if.bind="thumbnails_count !== thumbnails.size"
+             click.delegate="requestMoreThumbnails()"
+             class='expand-down'
+             style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
+             title="Show more images">
+        </div>
     </div>
     <div class="disabled-color" style="position: relative;top: 40%;"
          show.bind="requesting_thumbnail_data">

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -2,6 +2,13 @@
     <div class="thumbnail-scroll-panel">
       <img repeat.for="[id, thumb] of thumbnails"
         src="${context.server}${thumb.url}?version=${thumb.revision}"
+        title="${thumb.title}"
         click.delegate="onClick(id)"/>
+      <div
+        if.bind="thumbnails_response && thumbnails_response.length > 0"
+        click.delegate="addThumbnails()"
+        class='expand-down'
+        style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
+        title="Show more images"></div>
     </div>
 </template>

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -8,6 +8,8 @@
              title="Show more images">
         </div>
         <img repeat.for="thumb of thumbnails"
+             css="${image_showing === thumb.id ?
+                 'border: 2px solid rgba(0,60,136,0.5)' : 'border: none'}"
              src="${thumb.url}?version=${thumb.revision}"
              title="${thumb.title}"
              click.delegate="onClick(thumb.id)"/>

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -1,5 +1,6 @@
 <template>
-    <div class="thumbnail-scroll-panel">
+    <div class="thumbnail-scroll-panel"
+        show.bind="!requesting_thumbnail_data">
       <img repeat.for="[id, thumb] of thumbnails"
         src="${context.server}${thumb.url}?version=${thumb.revision}"
         title="${thumb.title}"
@@ -10,5 +11,9 @@
         class='expand-down'
         style="width: 100%; margin-top: 5px; margin-bottom: 5px; cursor: pointer"
         title="Show more images"></div>
+    </div>
+    <div class="disabled-color"
+        show.bind="requesting_thumbnail_data">
+            Gathering<br>Thumbnail<br>Info...
     </div>
 </template>

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -164,7 +164,7 @@ export default class ThumbnailSlider extends EventSubscriber {
      */
     addThumbnails() {
         if (this.thumbnails_response === null ||
-            this.thumbnails_response.length === 0) return false;
+            this.thumbnails_response.length === 0) return;
 
         let toBeLoaded =
             this.thumbnails_response.splice(0, this.thumbnails_request_size);
@@ -193,7 +193,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             }
         });
 
-        return false;
+        return;
     }
 
     /**

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -295,13 +295,13 @@ export default class ThumbnailSlider extends EventSubscriber {
                     while (updateCount < this.thumbnails_request_size &&
                            position < params.ids.length) {
                         let thumb = this.thumbnails.get(params.ids[position]);
+                        position++;
                         if (thumb && typeof thumb.revision === 'number') {
                             thumb.revision++;
                             updateCount++;
                         }
-                        accUpdateCount += updateCount;
-                        position++;
                     }
+                    accUpdateCount += updateCount;
                 } catch(err) {
                     error = true;
                 }

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -13,9 +13,12 @@
         // modify according to your needs
         window.INITIAL_REQUEST_PARAMS =
             {
-                'DEV_SERVER' : true,
-                'SERVER' : "https://demo.openmicroscopy.org",
-             'IMAGE_ID' : 208443};
+                'DEV_SERVER': true,
+                //'SERVER': "https://cowfish.openmicroscopy.org/webtrial",
+                //'IMAGE_ID': 20901,
+                'SERVER': "https://demo.openmicroscopy.org",
+                'IMAGE_ID': 208443,
+            };
       </script>
 
       <title>iViewer</title>

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -202,8 +202,10 @@ export default class ImageInfo {
                     this.context.publish(
                         IMAGE_CONFIG_UPDATE,
                             {config_id: this.config_id,
-                                dataset_id: this.dataset_id,
-                            ready: this.ready});
+                             image_id: this.image_id,
+                             dataset_id: this.dataset_id,
+                             ready: this.ready
+                            });
             },
             error : (error) => {
                 this.ready = false;

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -117,7 +117,7 @@ export default class Settings extends EventSubscriber {
         $.ajax({
             url : this.context.server +
                     this.context.getPrefixedURI(WEBGATEWAY) +
-                        "/get_image_rdefs_json/" + img_id,
+                        "/get_image_rdefs_json/" + img_id + '/',
             success : (response) => {
                 if (!Misc.isArray(response.rdefs)) return;
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,6 +12,12 @@ export const APP_NAME = 'iViewer';
 export const PLUGIN_NAME = 'omero_iviewer';
 
 /**
+ * a convenience string lookup for API_PREFIX
+ * @type {string}
+ */
+export const API_PREFIX = "API_PREFIX";
+
+/**
  * a convenience string lookup for URI_PREFIX
  * @type {string}
  */


### PR DESCRIPTION
see: https://trello.com/c/6bKLBqO5/280-todos

It's best to limit the number of thumbnails (dataset images) shown in the left hand panel, just in case one happens to have lots of images. Therefore the limit has been set to 10 with the option to show more on demand (by clicking the expand symbol/downward arrows).

TEST: https://cowfish.openmicroscopy.org/webtrial
Choose an image from a dataset that has fewer than 10 images associated. The left hand panel should not display the double down arrorw. Then choose an image from a dataset that has lots of images. 10 should be loaded by default, then 10 more each time you click the arrow.

