### PR TITLE
openlayer patching mechanism

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -163,6 +163,7 @@
             <arg line="install openlayers@${ol3-version}"/>
         </exec>
         <echo>Applying patches...</echo>
+        <mkdir dir="${ol-patches}" />
         <copy todir="${ol-sources}">
             <fileset dir="${ol-patches}" includes="*.patch"/>
         </copy>

--- a/build.xml
+++ b/build.xml
@@ -13,6 +13,8 @@
     <property name="closure-calcdeps.py" value="${basedir}/closure/calcdeps.py" />
     <property name="node_modules" value="${basedir}/node_modules" />
     <property name="ol.js" value="${node_modules}/openlayers" />
+    <property name="ol-sources" value="${ol.js}/src" />
+    <property name="ol-patches" value="${ant.project.name}/patches" />
     <property name="mocha-phantomjs" value="${node_modules}/mocha-phantomjs/bin/mocha-phantomjs" />
 
     <property name="src" value="${basedir}/${ant.project.name}/src" />
@@ -60,7 +62,7 @@
                 <arg line='-i "@{inputfiles}"' />
                 <arg line='--output_file "@{outputfile}"' />
                 <arg line='-p "${node_modules}/closure-util"' />
-                <arg line='-p "${ol.js}/src"' />
+                <arg line='-p "${ol-sources}"' />
                 <arg line='-p "${ol.js}/build/ol.ext"' />
                 <extrapaths />
                 <arg line="-o @{outputmode}" />
@@ -156,11 +158,15 @@
     </target>
 
     <target name="init">
-        <echo>Fetching deps with npm (bulk of stdout swallowed)</echo>
-        <echo>May the patience be with you...</echo>
+        <echo>Fetching openlayers release/sources...</echo>
         <exec dir="${basedir}" executable="npm">
             <arg line="install openlayers@${ol3-version}"/>
         </exec>
+        <echo>Applying patches...</echo>
+        <copy todir="${ol-sources}">
+            <fileset dir="${ol-patches}" includes="*.patch"/>
+        </copy>
+        <exec executable="${basedir}/${ant.project.name}/apply_patches.sh" dir="${ol-sources}" failonerror="true" logError="true" />
     </target>
 
     <target name="prepare-unit-tests">

--- a/ol3-viewer/apply_patches.sh
+++ b/ol3-viewer/apply_patches.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 for p in *.patch
 do
+    [ -f "$p" ] || continue
     patch -p0 -N < "$p"
 done

--- a/ol3-viewer/apply_patches.sh
+++ b/ol3-viewer/apply_patches.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+for p in *.patch
+do
+    patch -p0 -N < "$p"
+done

--- a/ol3-viewer/patches/tilelayer_canvas.patch
+++ b/ol3-viewer/patches/tilelayer_canvas.patch
@@ -1,0 +1,11 @@
+--- ol/renderer/canvas/tilelayer.js	2017-03-02 13:30:25.257547216 +1000
++++ ol/renderer/canvas/tilelayer_fixed.js	2017-03-02 13:34:08.404537831 +1000
+@@ -180,7 +180,7 @@
+ 
+     var tilePixelSize = tileSource.getTilePixelSize(z, pixelRatio, projection);
+     var width = Math.round(tileRange.getWidth() * tilePixelSize[0] / oversampling);
+-    var height = Math.round(tileRange.getHeight() * tilePixelSize[0] / oversampling);
++    var height = Math.round(tileRange.getHeight() * tilePixelSize[1] / oversampling);
+     var context = this.context;
+     var canvas = context.canvas;
+     var opaque = tileSource.getOpaque(projection);


### PR DESCRIPTION
Potential bugs in openlayers (see: https://trello.com/c/6bKLBqO5/280-todos) may require a patching mechanism until, ideally, the problem has been fixed with the next openlayers release.

While using not stable releases could sometimes also be a solution to the issue it's safer to apply just the specific code change needed.

This PR enables such patching by simply putting the patch into PROJECT_ROOT/ol3-viewer/patches.
It will then be picked up and applied to the ol3 source tree before compilation.

TEST: 

not entirely sure what test instructions I should give in general. it's on cowfish and was building fine.
you could test malformed patches locally which will cause the build to fail, an empty patch directory should not.

as for the patch that's part of the PR, the image https://cowfish.openmicroscopy.org/webtrial/omero_iviewer/56752/ (user: root) would ordinarily have not shown entirely (cut off height/y at a length of x/width). it's now shown fully.