### PR TITLE
regions table: shows shapes within roi

### DIFF
--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -109,7 +109,7 @@ ome.ol3.interaction.Draw.prototype.drawShapeCommonCode_ =
                 event.feature.setId(
                     (typeof this.roi_id_ === 'number' && this.roi_id_ < 0 ?
                         "" + this.roi_id_ + ":" :
-                        "-1:") + ol.getUid(event.feature));
+                        "-1:") + (-ol.getUid(event.feature)));
                 event.feature['state'] = ome.ol3.REGIONS_STATE.ADDED;
                 event.feature['type'] = shape_type;
 

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -656,12 +656,14 @@ ome.ol3.source.Regions.prototype.setProperty =
             // as well as the state for removed, modified and rollback deletes
             var presentState = null;
             var hasSelect = (this.select_ instanceof ome.ol3.interaction.Select);
-            if (hasSelect && property === 'selected' && value)
-                this.select_.getFeatures().push(this.idIndex_[s]);
-            else if (hasSelect && !value &&
+            if (hasSelect && property === 'selected' && value) {
+                this.select_.getFeatures().getArray().push(this.idIndex_[s]);
+                this.select_.getFeatures().updateLength_();
+                eventProperty = "selected";
+            } else if (hasSelect && !value &&
                         (property === 'selected' || property === 'visible')) {
-                this.select_.toggleFeatureSelection(
-                    this.idIndex_[s], false);
+                this.select_.toggleFeatureSelection(this.idIndex_[s], false);
+                eventProperty = "selected";
             } else if (property === 'state') {
                 presentState = this.idIndex_[s][property];
                 if (value === ome.ol3.REGIONS_STATE.REMOVED) {

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -19,45 +19,44 @@ goog.provide('ome.ol3.utils.Conversion');
  * @param {number=} alpha an optional alpha channel for rgb strings
  * @return {object|null} returns the color as an object or null if parse errors
  */
- ome.ol3.utils.Conversion.convertRgbaColorFormatToObject = function(rgba, alpha) {
-		if (typeof(rgba) !== 'string' || rgba.length === 0) return null;
-		if (typeof(alpha) !== 'number')
-			alpha = 1.0;
+ome.ol3.utils.Conversion.convertRgbaColorFormatToObject = function(rgba, alpha) {
+    if (typeof(rgba) !== 'string' || rgba.length === 0) return null;
+    if (typeof(alpha) !== 'number') alpha = 1.0;
 
-		try {
-			var strippedRgba = rgba.replace(/\(rgba|\(|rgba|rgb|\)/g, "");
-			var tokens = strippedRgba.split(",");
-			if (tokens.length < 3) return null; // at a minimum we need 3 channels
+    try {
+        var strippedRgba = rgba.replace(/\(rgba|\(|rgba|rgb|\)/g, "");
+        var tokens = strippedRgba.split(",");
+        if (tokens.length < 3) return null; // at a minimum we need 3 channels
 
-			// prepare return object
-			var ret = {'red' : 255, 'green' : 255, 'blue' : 255, 'alpha' : alpha};
+        // prepare return object
+        var ret = {'red' : 255, 'green' : 255, 'blue' : 255, 'alpha' : alpha};
 
-			ret['red'] = parseInt(tokens[0], 10);
-			ret['green'] = parseInt(tokens[1], 10);
-			ret['blue'] = parseInt(tokens[2], 10);
-			if (tokens.length > 3) // optional alpha
-				ret['alpha'] = parseFloat(tokens[3], 10);
-		} catch (parse_error) {
-			return null;
-		}
+        ret['red'] = parseInt(tokens[0], 10);
+        ret['green'] = parseInt(tokens[1], 10);
+        ret['blue'] = parseInt(tokens[2], 10);
+        if (tokens.length > 3) // optional alpha
+        	ret['alpha'] = parseFloat(tokens[3], 10);
+    } catch (parse_error) {
+        return null;
+    }
 
-	// some final asserts to verify bounds
-	if (ret['red'] < 0 || ret['red'] > 255 ||
-				ret['green'] < 0 || ret['green'] > 255 ||
-				ret['blue'] < 0 || ret['blue'] > 255)
-		console.error('RGB values need to range in between 0 and 255!');
-		if (ret['alpha'] < 0 || ret['alpha'] > 1)
-			console.error('Alpha values need to range in between 0 and 1!');
+    // some final asserts to verify bounds
+    if (ret['red'] < 0 || ret['red'] > 255 ||
+        ret['green'] < 0 || ret['green'] > 255 ||
+        ret['blue'] < 0 || ret['blue'] > 255)
+            console.error('RGB values need to range in between 0 and 255!');
+    if (ret['alpha'] < 0 || ret['alpha'] > 1)
+        console.error('Alpha values need to range in between 0 and 1!');
 
-		return ret;
+    return ret;
 }
 
 /**
  * Converts a color given as a rgb(a) array, e.g. [244,112,444, 0.5]
  * into an internal color object looking like this:
- *<pre>
+ * <pre>
  * { red: 255, green: 255, blue: 255, alpha: 0.75 }
- *</pre>
+ * </pre>
  *
  * If the string is only rgb, you can either hand in an alpha value as a
  * second (optional) argument, otherwise it will default to : 1.0
@@ -68,15 +67,15 @@ goog.provide('ome.ol3.utils.Conversion');
  * @param {number=} alpha an optional alpha channel for rgb strings
  * @return {object|null} returns the color as an object or null if parse errors
  */
- ome.ol3.utils.Conversion.convertColorArrayToObject = function(rgba, alpha) {
-     if (!ome.ol3.utils.Misc.isArray(rgba) || rgba.length < 3) return null;
+ome.ol3.utils.Conversion.convertColorArrayToObject = function(rgba, alpha) {
+    if (!ome.ol3.utils.Misc.isArray(rgba) || rgba.length < 3) return null;
 
-     if (rgba.length === 3 && typeof(alpha) !== 'number') alpha = 1.0;
-     else alpha = rgba[3];
+    if (rgba.length === 3 && typeof(alpha) !== 'number') alpha = 1.0;
+    else alpha = rgba[3];
 
-     return {
-         "red" : rgba[0], "green" : rgba[1], "blue" : rgba[2], "alpha" : alpha
-     }
+    return {
+        "red" : rgba[0], "green" : rgba[1], "blue" : rgba[2], "alpha" : alpha
+    }
 }
 
 /**
@@ -95,39 +94,37 @@ goog.provide('ome.ol3.utils.Conversion');
  * @param {number=} alpha an optional alpha channel or 1.0 by default
  * @return {object|null} returns the color as an object or null if parse errors
  */
- ome.ol3.utils.Conversion.convertHexColorFormatToObject = function(hex, alpha) {
-		 if (typeof(hex) !== 'string' || hex.length === 0) return null;
-		 if (typeof(alpha) !== 'number')
-			 alpha = 1.0;
+ome.ol3.utils.Conversion.convertHexColorFormatToObject = function(hex, alpha) {
+    if (typeof(hex) !== 'string' || hex.length === 0) return null;
+    if (typeof(alpha) !== 'number') alpha = 1.0;
 
-		try {
-			// strip white space and #
-			var strippedHex = hex.replace(/#|\s/g, "");
-            if (strippedHex.length === 3)
-                strippedHex = '' +
-                    strippedHex[0] + strippedHex[0] +
-                    strippedHex[1] + strippedHex[1] +
-                    strippedHex[2] + strippedHex[2];
-			if (strippedHex.length != 6) return null;
+    try {
+        // strip white space and #
+        var strippedHex = hex.replace(/#|\s/g, "");
+        if (strippedHex.length === 3)
+            strippedHex = '' +
+                strippedHex[0] + strippedHex[0] +
+                strippedHex[1] + strippedHex[1] +
+                strippedHex[2] + strippedHex[2];
+        if (strippedHex.length != 6) return null;
 
-			// prepare return object
-			var ret = {'red' : 255, 'green' : 255, 'blue' : 255, 'alpha' : alpha};
+        // prepare return object
+        var ret = {'red' : 255, 'green' : 255, 'blue' : 255, 'alpha' : alpha};
+        ret['red'] = parseInt(strippedHex.substring(0,2), 16);
+        ret['green'] = parseInt(strippedHex.substring(2,4), 16);
+        ret['blue'] = parseInt(strippedHex.substring(4,6), 16);
 
-			ret['red'] = parseInt(strippedHex.substring(0,2), 16);
-			ret['green'] = parseInt(strippedHex.substring(2,4), 16);
-			ret['blue'] = parseInt(strippedHex.substring(4,6), 16);
-
-			return ret;
-		} catch (parse_error) {
-			return null;
-		}
+        return ret;
+    } catch (parse_error) {
+        return null;
+    }
 }
 
 /**
  * Builds a hex color string (#ffffff) from a color object such as this one.
- *<pre>
+ * <pre>
  * { red: 255, green: 255, blue: 255, alpha: 0.75 }
- *</pre>
+ * </pre>
  *
  * Alpha will be ignored since hex strings don't encode the alpha channel
  *
@@ -136,25 +133,24 @@ goog.provide('ome.ol3.utils.Conversion');
  * @return {string|null} returns the color as hex string or null (if incorrect color object)
  */
 ome.ol3.utils.Conversion.convertColorObjectToHex = function(color) {
-	var checkedColorObject =
-		ome.ol3.utils.Conversion.checkColorObjectCorrectness(color);
+    var checkedColorObject =
+        ome.ol3.utils.Conversion.checkColorObjectCorrectness(color);
+    if (checkedColorObject == null) return null;
 
-	if (checkedColorObject == null) return null;
+    var ret = "#";
+    ret +=  ("00" + checkedColorObject['red'].toString(16)).substr(-2);
+    ret +=  ("00" + checkedColorObject['green'].toString(16)).substr(-2);
+    ret +=  ("00" + checkedColorObject['blue'].toString(16)).substr(-2);
 
-	var ret = "#";
-	ret +=  ("00" + checkedColorObject['red'].toString(16)).substr(-2);
-	ret +=  ("00" + checkedColorObject['green'].toString(16)).substr(-2);
-	ret +=  ("00" + checkedColorObject['blue'].toString(16)).substr(-2);
-
-	return ret;
+    return ret;
 }
 
 /**
  * Builds a rgba color string, e.g. 'rgba(255,255,255,1.0)'
  * from a color object such as this one.
- *<pre>
+ * <pre>
  * { red: 255, green: 255, blue: 255, alpha: 0.75 }
- *</pre>
+ * </pre>
  *
  *
  * @static
@@ -162,26 +158,25 @@ ome.ol3.utils.Conversion.convertColorObjectToHex = function(color) {
  * @return {string|null} returns the color as rgba string or null (if incorrect color object)
  */
 ome.ol3.utils.Conversion.convertColorObjectToRgba = function(color) {
-	var checkedColorObject =
-		ome.ol3.utils.Conversion.checkColorObjectCorrectness(color);
+    var checkedColorObject =
+        ome.ol3.utils.Conversion.checkColorObjectCorrectness(color);
+    if (checkedColorObject == null) return null;
 
-	if (checkedColorObject == null) return null;
+    var ret = "rgba(";
+    ret += checkedColorObject['red'].toString(10) + ",";
+    ret += checkedColorObject['green'].toString(10) + ",";
+    ret += checkedColorObject['blue'].toString(10) + ",";
+    ret += checkedColorObject['alpha'].toString(10);
+    ret += ")";
 
-	var ret = "rgba(";
-	ret += checkedColorObject['red'].toString(10) + ",";
-	ret += checkedColorObject['green'].toString(10) + ",";
-	ret += checkedColorObject['blue'].toString(10) + ",";
-	ret += checkedColorObject['alpha'].toString(10);
-	ret += ")";
-
-	return ret;
+    return ret;
 }
 
 /**
  * Checks the correctness of a color object which has to look like this
- *<pre>
+ * <pre>
  * { red: 255, green: 255, blue: 255, alpha: 0.75 }
- *</pre>
+ * </pre>
  *
  * We take the alpha channel to be optional
  *
@@ -191,21 +186,19 @@ ome.ol3.utils.Conversion.convertColorObjectToRgba = function(color) {
  * @return {object|null} returns the handed in object or null (if incorrect)
  */
 ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
-	if (typeof(color) !== 'object') return null;
+    if (typeof(color) !== 'object') return null;
 
-	// check correctness of color object,
-	// we take alpha to be optional, setting it to 1
-	var needsToBeThere = ["red", "green", "blue"];
-	for (var n in needsToBeThere) {
-		if (typeof(color[needsToBeThere[n]]) === 'undefined')
-			return null;
-		var c = color[needsToBeThere[n]];
-		if (c < 0 || c > 255) return null;
-	}
-	if (typeof(color['alpha']) === 'undefined')
-		color['alpha'] = 1.0;
+    // check correctness of color object,
+    // we take alpha to be optional, setting it to 1
+    var needsToBeThere = ["red", "green", "blue"];
+    for (var n in needsToBeThere) {
+        if (typeof(color[needsToBeThere[n]]) === 'undefined') return null;
+        var c = color[needsToBeThere[n]];
+        if (c < 0 || c > 255) return null;
+    }
+    if (typeof(color['alpha']) === 'undefined') color['alpha'] = 1.0;
 
-	return color;
+    return color;
 }
 
 /**
@@ -213,7 +206,7 @@ ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
  * while open layers works with ol.style.Style objects that accept color/alpha
  * as rgba(255,255,255, 0.75) as well as hex rgb colors, i.e. #ffffff.
  * This routine does the conversion.
- *<p/>
+ * <p/>
  *
  * Note: Depending on the format it might employ the services of 2 other conversion
  * routines
@@ -224,9 +217,9 @@ ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
  * </ul>
  * Alternatively it also accepts color information in internal object notation
  * (such as the aboved functions will convert it into):
- *<pre>
+ * <pre>
  * { red: 255, green: 255, blue: 255, alpha: 0.75 }
- *</pre>
+ * </pre>
  *
  * @static
  * @function
@@ -236,26 +229,29 @@ ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
  */
 ome.ol3.utils.Conversion.convertColorToSignedInteger = function(color, alpha) {
     if (typeof(alpha) !== 'number') {
-		alpha = parseInt(alpha);
-		if (isNaN(alpha)) alpha = 1.0;
-	}
+        alpha = parseInt(alpha);
+        if (isNaN(alpha)) alpha = 1.0;
+    }
 
-	if (typeof(color) == 'string') { // delegate to appropriate conversion
-		if (color.indexOf('rgba') != -1)
-			color = ome.ol3.utils.Conversion.convertRgbaColorFormatToObject(color, alpha);
-		else
-			color = ome.ol3.utils.Conversion.convertHexColorFormatToObject(color, alpha);
-	} else if (ome.ol3.utils.Misc.isArray(color))
+    if (typeof(color) == 'string') { // delegate to appropriate conversion
+        if (color.indexOf('rgba') != -1)
+        color =
+            ome.ol3.utils.Conversion.convertRgbaColorFormatToObject(color, alpha);
+        else
+            color = ome.ol3.utils.Conversion.convertHexColorFormatToObject(
+                        color, alpha);
+    } else if (ome.ol3.utils.Misc.isArray(color))
         color = ome.ol3.utils.Conversion.convertColorArrayToObject(color, alpha);
 
-	if ((typeof(color) !== 'object') || // last check of correctness
-		typeof((color = ome.ol3.utils.Conversion.checkColorObjectCorrectness(color))) !== 'object') {
-		return null;
-	}
+    if ((typeof(color) !== 'object') || // last check of correctness
+        typeof(
+            (color =
+                ome.ol3.utils.Conversion.checkColorObjectCorrectness(
+                    color))) !== 'object') return null;
 
-	var decimalMultiplied = color['alpha'] * 255;
-	var decimalOnly = decimalMultiplied - parseInt(decimalMultiplied);
-	alpha =
+    var decimalMultiplied = color['alpha'] * 255;
+    var decimalOnly = decimalMultiplied - parseInt(decimalMultiplied);
+    alpha =
         decimalOnly <= 0.5 ?
             Math.floor(decimalMultiplied) : Math.ceil(decimalMultiplied);
 
@@ -269,26 +265,21 @@ ome.ol3.utils.Conversion.convertColorToSignedInteger = function(color, alpha) {
  * @static
  * @function
  * @param {ol.geom.Circle} geometry the circle instance for the point feature
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.pointToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ol.geom.Circle))
-		throw "shape type point must be of instance ol.geom.Circle!";
+    if (!(geometry instanceof ol.geom.Circle))
+        throw "shape type point must be of instance ol.geom.Circle!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Point";
+    var center = geometry.getCenter();
+    ret['X'] = center[0];
+    ret['Y'] = -center[1];
 
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Point";
-
-	var center = geometry.getCenter();
-	ret['X'] = center[0];
-	ret['Y'] = -center[1];
-
-	return ret;
+    return ret;
 }
 
 /**
@@ -297,29 +288,22 @@ ome.ol3.utils.Conversion.pointToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ome.ol3.geom.Ellipse} geometry the ellipse instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.ellipseToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ome.ol3.geom.Ellipse))
-		throw "shape type ellipse must be of instance ome.ol3.geom.Ellipse!";
+    if (!(geometry instanceof ome.ol3.geom.Ellipse))
+        throw "shape type ellipse must be of instance ome.ol3.geom.Ellipse!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
-
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse";
-
-	var center = geometry.getCenter();
-	ret['X'] = center[0];
-	ret['Y'] = -center[1];
-
-	var radius = geometry.getRadius();
-	ret['RadiusX'] = radius[0];
-	ret['RadiusY'] = radius[1];
-
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse";
+    var center = geometry.getCenter();
+    ret['X'] = center[0];
+    ret['Y'] = -center[1];
+    var radius = geometry.getRadius();
+    ret['RadiusX'] = radius[0];
+    ret['RadiusY'] = radius[1];
     var trans = geometry.getTransform(true);
     if (typeof trans === 'object' && trans !== null) {
         trans['@type'] =
@@ -327,7 +311,7 @@ ome.ol3.utils.Conversion.ellipseToJsonObject = function(geometry, shape_id) {
         ret['Transform'] = trans;
     }
 
-	return ret;
+    return ret;
 }
 
 /**
@@ -336,29 +320,23 @@ ome.ol3.utils.Conversion.ellipseToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ome.ol3.geom.Rectangle} geometry the rectangle instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.rectangleToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ome.ol3.geom.Rectangle))
-		throw "shape type rectangle must be of instance ome.ol3.geom.Rectangle!";
+    if (!(geometry instanceof ome.ol3.geom.Rectangle))
+        throw "shape type rectangle must be of instance ome.ol3.geom.Rectangle!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle";
+    var topLeftCorner = geometry.getUpperLeftCorner();
+    ret['X'] = topLeftCorner[0];
+    ret['Y'] = -topLeftCorner[1];
+    ret['Width'] = geometry.getWidth();
+    ret['Height'] = geometry.getHeight();
 
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle";
-
-	var topLeftCorner = geometry.getUpperLeftCorner();
-	ret['X'] = topLeftCorner[0];
-	ret['Y'] = -topLeftCorner[1];
-
-	ret['Width'] = geometry.getWidth();
-	ret['Height'] = geometry.getHeight();
-
-	return ret;
+    return ret;
 }
 
 /**
@@ -367,37 +345,30 @@ ome.ol3.utils.Conversion.rectangleToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ome.ol3.geom.Line} geometry the line instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.lineToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ome.ol3.geom.Line))
-		throw "shape type line must be of instance ome.ol3.geom.Line!";
+    if (!(geometry instanceof ome.ol3.geom.Line))
+        throw "shape type line must be of instance ome.ol3.geom.Line!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
-
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	var flatCoords = geometry.getFlatCoordinates();
-	//delegate if we happen to have turned into a polyline
-	if (geometry.isPolyline())
-		return ome.ol3.utils.Conversion.polylineToJsonObject.call(
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    var flatCoords = geometry.getFlatCoordinates();
+    //delegate if we happen to have turned into a polyline
+    if (geometry.isPolyline())
+        return ome.ol3.utils.Conversion.polylineToJsonObject.call(
             null, geometry, shape_id);
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Line";
-
-	ret['X1'] = flatCoords[0];
-	ret['X2'] = flatCoords[2];
-
-	ret['Y1'] = -flatCoords[1];
-	ret['Y2'] = -flatCoords[3];
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Line";
+    ret['X1'] = flatCoords[0];
+    ret['X2'] = flatCoords[2];
+    ret['Y1'] = -flatCoords[1];
+    ret['Y2'] = -flatCoords[3];
 
     if (geometry.has_start_arrow_) ret['MarkerStart'] = "Arrow";
     if (geometry.has_end_arrow_) ret['MarkerEnd'] = "Arrow";
 
-	return ret;
+    return ret;
 }
 
 /**
@@ -406,37 +377,32 @@ ome.ol3.utils.Conversion.lineToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ome.ol3.geom.Line} geometry the polyline instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.polylineToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ome.ol3.geom.Line))
-		throw "shape type polyline must be of instance ome.ol3.geom.Line!";
+    if (!(geometry instanceof ome.ol3.geom.Line))
+        throw "shape type polyline must be of instance ome.ol3.geom.Line!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    var flatCoords = geometry.getFlatCoordinates();
+    //delegate if we happen to have turned into a line
+    if (!geometry.isPolyline())
+        return ome.ol3.utils.Conversion.lineToJsonObject.call(
+            null, geometry, shape_id);
 
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	var flatCoords = geometry.getFlatCoordinates();
-	//delegate if we happen to have turned into a line
-	if (!geometry.isPolyline())
-		return ome.ol3.utils.Conversion.lineToJsonObject.call(null, geometry, shape_id);
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline";
-
-	ret['Points'] = "";
-	for (var i=0; i<flatCoords.length;i+= 2) {
-		if (i !== 0 && i % 2 === 0)
-			ret['Points'] += " ";
-		ret['Points'] += flatCoords[i] + "," + (-flatCoords[i+1]);
-	}
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline";
+    ret['Points'] = "";
+    for (var i=0; i<flatCoords.length;i+= 2) {
+        if (i !== 0 && i % 2 === 0) ret['Points'] += " ";
+        ret['Points'] += flatCoords[i] + "," + (-flatCoords[i+1]);
+    }
 
     if (geometry.has_start_arrow_) ret['MarkerStart'] = "Arrow";
     if (geometry.has_end_arrow_) ret['MarkerEnd'] = "Arrow";
 
-	return ret;
+    return ret;
 }
 
 /**
@@ -445,26 +411,21 @@ ome.ol3.utils.Conversion.polylineToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ome.ol3.geom.Label} geometry the label instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into a json object
  */
 ome.ol3.utils.Conversion.labelToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ome.ol3.geom.Label))
-		throw "shape type label must be of instance ome.ol3.geom.Label!";
+    if (!(geometry instanceof ome.ol3.geom.Label))
+        throw "shape type label must be of instance ome.ol3.geom.Label!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Label";
+    var topLeftCorner = geometry.getUpperLeftCorner();
+    ret['X'] = topLeftCorner[0];
+    ret['Y'] = -topLeftCorner[1];
 
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
-
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Label";
-
-	var topLeftCorner = geometry.getUpperLeftCorner();
-	ret['X'] = topLeftCorner[0];
-	ret['Y'] = -topLeftCorner[1];
-
-	return ret;
+    return ret;
 }
 
 /**
@@ -473,31 +434,25 @@ ome.ol3.utils.Conversion.labelToJsonObject = function(geometry, shape_id) {
  * @static
  * @function
  * @param {ol.geom.Polygon} geometry the polygon instance
- * @param {number=} shape_id the shape it. if shape is new, it's: -1
+ * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.polygonToJsonObject = function(geometry, shape_id) {
-	if (!(geometry instanceof ol.geom.Polygon))
-		throw "shape type polygon must be of instance ol.geom.Polygon!";
+    if (!(geometry instanceof ol.geom.Polygon))
+        throw "shape type polygon must be of instance ol.geom.Polygon!";
 
-	var shapeId = typeof(shape_id) === 'number' ? shape_id : -1;
+    var ret = {};
+    if (typeof shape_id === 'number') ret['@id'] = shape_id;
+    ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon";
+    var flatCoords = geometry.getFlatCoordinates();
 
-	var ret = {};
-	if (shapeId >= 0)
-		ret['@id'] = shapeId;
+    ret['Points'] = "";
+    for (var i=0; i<flatCoords.length;i+= 2) {
+        if (i !== 0 && i % 2 === 0) ret['Points'] += " ";
+        ret['Points'] += flatCoords[i] + "," + (-flatCoords[i+1]);
+    }
 
-	ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon";
-
-	var flatCoords = geometry.getFlatCoordinates();
-
-	ret['Points'] = "";
-	for (var i=0; i<flatCoords.length;i+= 2) {
-		if (i !== 0 && i % 2 === 0)
-			ret['Points'] += " ";
-		ret['Points'] += flatCoords[i] + "," + (-flatCoords[i+1]);
-	}
-
-	return ret;
+    return ret;
 }
 
 /**
@@ -507,13 +462,13 @@ ome.ol3.utils.Conversion.polygonToJsonObject = function(geometry, shape_id) {
  * @return {function} the conversion function for the specific shape type
  */
 ome.ol3.utils.Conversion.LOOKUP = {
-	"point" : ome.ol3.utils.Conversion.pointToJsonObject,
-	"ellipse" : ome.ol3.utils.Conversion.ellipseToJsonObject,
-	"rectangle" : ome.ol3.utils.Conversion.rectangleToJsonObject,
-	"line" : ome.ol3.utils.Conversion.lineToJsonObject,
-	"polyline" : ome.ol3.utils.Conversion.polylineToJsonObject,
-	"label" : ome.ol3.utils.Conversion.labelToJsonObject,
-	"polygon" : ome.ol3.utils.Conversion.polygonToJsonObject
+    "point" : ome.ol3.utils.Conversion.pointToJsonObject,
+    "ellipse" : ome.ol3.utils.Conversion.ellipseToJsonObject,
+    "rectangle" : ome.ol3.utils.Conversion.rectangleToJsonObject,
+    "line" : ome.ol3.utils.Conversion.lineToJsonObject,
+    "polyline" : ome.ol3.utils.Conversion.polylineToJsonObject,
+    "label" : ome.ol3.utils.Conversion.labelToJsonObject,
+    "polygon" : ome.ol3.utils.Conversion.polygonToJsonObject
 };
 
 /**
@@ -527,84 +482,81 @@ ome.ol3.utils.Conversion.LOOKUP = {
  * @param {Object} jsonObject an object containing shape information
  */
 ome.ol3.utils.Conversion.integrateStyleIntoJsonObject = function(feature, jsonObject) {
-	if (typeof(jsonObject) !== 'object' ||
-	 			typeof(jsonObject['@type']) !== 'string' ||
-				!(feature instanceof ol.Feature) ||
-				(!(feature.getStyle() instanceof ol.style.Style) &&
-				 	typeof(feature.getStyle()) !== 'function'))
-		return;
+    if (typeof(jsonObject) !== 'object' ||
+        typeof(jsonObject['@type']) !== 'string' ||
+        !(feature instanceof ol.Feature) ||
+        (!(feature.getStyle() instanceof ol.style.Style) &&
+            typeof(feature.getStyle()) !== 'function')) return;
 
     // we now have an array of styles (due to arrows)
-	var presentStyle = feature.getStyle();
-	if (typeof(presentStyle) === 'function')
-		presentStyle = presentStyle(1);
-    if (ome.ol3.utils.Misc.isArray(presentStyle))
-        presentStyle = presentStyle[0];
-	if (!(presentStyle instanceof ol.style.Style))
-		return;
+    var presentStyle = feature.getStyle();
+    if (typeof(presentStyle) === 'function') presentStyle = presentStyle(1);
+    if (ome.ol3.utils.Misc.isArray(presentStyle)) presentStyle = presentStyle[0];
+    if (!(presentStyle instanceof ol.style.Style)) return;
 
-	var isLabel =
-		jsonObject['@type'] ===
-	 		'http://www.openmicroscopy.org/Schemas/OME/2016-06#Label';
+    var isLabel =
+        jsonObject['@type'] ===
+            'http://www.openmicroscopy.org/Schemas/OME/2016-06#Label';
     var presentFillColor =
         isLabel && presentStyle.getText() && presentStyle.getText().getFill() ?
             presentStyle.getText().getFill().getColor() :
                 presentStyle.getFill() ? presentStyle.getFill().getColor() : null;
-	if (presentFillColor)
-		jsonObject['FillColor'] =
-			ome.ol3.utils.Conversion.convertColorToSignedInteger(presentFillColor);
+    if (presentFillColor)
+        jsonObject['FillColor'] =
+            ome.ol3.utils.Conversion.convertColorToSignedInteger(presentFillColor);
 
-	var presentStrokeStyle =
-		isLabel && presentStyle.getText() && presentStyle.getText().getFill() ?
-			presentStyle.getText().getFill().getColor() :
-				((typeof(feature['oldStrokeStyle']) === 'object' &&
-                    feature['oldStrokeStyle'] !== null &&
-					typeof(feature['oldStrokeStyle']['color']) !== 'undefined') ?
-						feature['oldStrokeStyle']['color'] : null);
+    var presentStrokeStyle =
+        isLabel && presentStyle.getText() && presentStyle.getText().getFill() ?
+            presentStyle.getText().getFill().getColor() :
+                ((typeof(feature['oldStrokeStyle']) === 'object' &&
+                feature['oldStrokeStyle'] !== null &&
+                typeof(feature['oldStrokeStyle']['color']) !== 'undefined') ?
+                    feature['oldStrokeStyle']['color'] : null);
 
-	if (presentStrokeStyle) { // STROKE
-			jsonObject['StrokeColor'] =
-				ome.ol3.utils.Conversion.convertColorToSignedInteger(presentStrokeStyle);
-	}
-	var presentStrokeWidth =
-		(typeof(feature['oldStrokeStyle']) === 'object' &&
-			feature['oldStrokeStyle'] !== null &&
-			typeof(feature['oldStrokeStyle']['width']) === 'number') ?
-				feature['oldStrokeStyle']['width'] : 1;
+    if (presentStrokeStyle) { // STROKE
+        jsonObject['StrokeColor'] =
+            ome.ol3.utils.Conversion.convertColorToSignedInteger(
+                presentStrokeStyle);
+    }
+    var presentStrokeWidth =
+        (typeof(feature['oldStrokeStyle']) === 'object' &&
+        feature['oldStrokeStyle'] !== null &&
+        typeof(feature['oldStrokeStyle']['width']) === 'number') ?
+            feature['oldStrokeStyle']['width'] : 1;
 
-	jsonObject['StrokeWidth'] = {
-		'@type': 'TBD#LengthI',
-		'Unit': 'PIXEL',
-		'Symbol': 'px',
-		'Value':
-			isLabel && presentStyle.getText() && presentStyle.getText().getStroke() ?
-			presentStyle.getText().getStroke().getWidth() : presentStrokeWidth
-	};
+    jsonObject['StrokeWidth'] = {
+        '@type': 'TBD#LengthI',
+        'Unit': 'PIXEL',
+        'Symbol': 'px',
+        'Value':
+            isLabel && presentStyle.getText() &&
+            presentStyle.getText().getStroke() ?
+                presentStyle.getText().getStroke().getWidth() : presentStrokeWidth
+    };
 
     var presentText = presentStyle.getText();
     if (presentText === null && feature['oldText'] instanceof ol.style.Text)
         presentText = feature['oldText'];
-	if (presentText instanceof ol.style.Text) {  // TEXT
-		if (presentText.getText())
-			jsonObject['Text'] = presentText.getText();
-		if (presentText.getFont()) {
-			var font = presentText.getFont();
-			var fontTokens = font.split(' ');
-			if (fontTokens.length == 3) {
-				try {
-					jsonObject['FontStyle'] = fontTokens[0];
-					jsonObject['FontSize'] =  {
+    if (presentText instanceof ol.style.Text) {  // TEXT
+        if (presentText.getText()) jsonObject['Text'] = presentText.getText();
+        if (presentText.getFont()) {
+            var font = presentText.getFont();
+            var fontTokens = font.split(' ');
+            if (fontTokens.length == 3) {
+                try {
+                    jsonObject['FontStyle'] = fontTokens[0];
+                    jsonObject['FontSize'] =  {
                         '@type': 'TBD#LengthI',
                         'Unit': 'PIXEL',
                         'Symbol': 'px',
                         'Value': parseInt(fontTokens[1])};
-					jsonObject['FontFamily'] = fontTokens[2];
-				} catch(notANumber) {
-					// nothing we can do
-				}
-			}
-		}
-	}
+                    jsonObject['FontFamily'] = fontTokens[2];
+                } catch(notANumber) {
+                    // nothing we can do
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -618,16 +570,15 @@ ome.ol3.utils.Conversion.integrateStyleIntoJsonObject = function(feature, jsonOb
  * @param {Object} jsonObject an object containing shape information
  */
 ome.ol3.utils.Conversion.integrateMiscInfoIntoJsonObject  = function(feature, jsonObject) {
-	if (typeof(jsonObject) !== 'object' ||
-				!(feature instanceof ol.Feature))
-		return;
+    if (typeof(jsonObject) !== 'object' || !(feature instanceof ol.Feature))
+        return;
 
-	if (typeof(feature['theT']) === 'number')
+    if (typeof(feature['theT']) === 'number')
         jsonObject['TheT'] = feature['theT'];
-	if (typeof(feature['theZ']) === 'number')
-		jsonObject['TheZ'] = feature['theZ'];
-	if (typeof(feature['theC']) === 'number')
-		jsonObject['TheC'] = feature['theC'];
+    if (typeof(feature['theZ']) === 'number')
+        jsonObject['TheZ'] = feature['theZ'];
+    if (typeof(feature['theC']) === 'number')
+        jsonObject['TheC'] = feature['theC'];
 
     if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED)
         jsonObject['markedForDeletion'] = true;
@@ -646,86 +597,75 @@ ome.ol3.utils.Conversion.integrateMiscInfoIntoJsonObject  = function(feature, js
  */
 ome.ol3.utils.Conversion.toJsonObject = function(
     features, storeNewShapesInSeparateRois,returnFlattenedArray) {
-	if (!(features instanceof ol.Collection) ||
-            features.getLength() === 0) return null;
+        if (!(features instanceof ol.Collection) || features.getLength() === 0)
+            return null;
 
-	var newRoisForEachNewShape =
-		typeof(storeNewShapesInSeparateRois) === 'boolean' ?
+    var newRoisForEachNewShape =
+        typeof(storeNewShapesInSeparateRois) === 'boolean' ?
             storeNewShapesInSeparateRois : false;
 
     if (typeof returnFlattenedArray !== 'boolean') returnFlattenedArray = false;
 
-	var currentNewId = -1;
-	var roisToBeStored = {"count" : 0};
+    var currentNewId = -1;
+    var roisToBeStored = {"count" : 0};
     var rois = {};
 
     var feats = features.getArray();
     for (var i=0;i<feats.length;i++) {
         var feature = feats[i];
 
-		// we skip if we are not a feature or have no geometry (sanity check)
-		// OR if we haven't a state or the state is unchanged
-		if (!(feature instanceof ol.Feature) || feature.getGeometry() === null ||
-					typeof(feature['state']) !== 'number' || // no state info or unchanged
-					feature['state'] === ome.ol3.REGIONS_STATE.DEFAULT)
-					continue;
+        // we skip if we are not a feature or have no geometry (sanity check)
+        // OR if we haven't a state or the state is unchanged
+        if (!(feature instanceof ol.Feature) || feature.getGeometry() === null ||
+            typeof(feature['state']) !== 'number' || // no state info or unchanged
+            feature['state'] === ome.ol3.REGIONS_STATE.DEFAULT) continue;
 
-		var roiId = -1;
-		var shapeId = -1;
-
-		// dissect id which comes in the form roiId:shapeId
-		if (typeof(feature.getId()) !== 'string' || feature.getId().length < 3)
-			continue; // we skip it, we must have at least x:x for instance
-
-		var colon = feature.getId().indexOf(":");
-		if (colon < 1) // colon cannot be before 2nd position
-			continue;
-
-		roiId = feature.getId().substring(0,colon);
-		shapeId = feature.getId().substring(colon+1)
-		try {
-			roiId = parseInt(roiId);
-			shapeId = parseInt(shapeId);
-		} catch(notAnumber) {
-			continue; // we are not a number
-		}
+        // dissect id which comes in the form roiId:shapeId
+        var roiId = -1;
+        var shapeId = -1;
+        if (typeof(feature.getId()) !== 'string' || feature.getId().length < 3)
+            continue; // we skip it, we must have at least x:x for instance
+        var colon = feature.getId().indexOf(":");
+        if (colon < 1) continue; // colon cannot be before 2nd position
+        try {
+            roiId = parseInt(feature.getId().substring(0,colon));
+            shapeId = parseInt(feature.getId().substring(colon+1));
+            if (isNaN(roiId) || isNaN(shapeId)) continue;
+        } catch(parseError) {
+            continue;
+        }
 
         // we don't want newly added but immediately deleted shapes
         if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED &&
-                roiId < 0) continue;
+            (roiId < 0 || shapeId < 0)) continue;
 
-		// now that we have the roi and shape id we check whether we have them in
-		// our associative array already or we need to create it yet
-		var roiIdToBeUsed = roiId;
-        // unless we are new we'd like to use the original roi id
-		// new shapes have by default a -1 for the roi id,
-		// we'd like to use that unless the flag is set that want to store each
-		// new shape in a roi of its own
-		if (feature['state'] === ome.ol3.REGIONS_STATE.ADDED && newRoisForEachNewShape)
-				roiIdToBeUsed = currentNewId--;
+        var roiIdToBeUsed = roiId;
+        // we decrement to have a unique roi id for each shape
+        if (feature['state'] === ome.ol3.REGIONS_STATE.ADDED &&
+            newRoisForEachNewShape) roiIdToBeUsed = currentNewId--;
 
-		var roiContainer = null;
-		// we exist already in our associative array, so lets add more to it
-		if (typeof(rois[roiIdToBeUsed]) === 'object')
-			roiContainer = rois[roiIdToBeUsed];
-		else {// we need to be created
-			rois[roiIdToBeUsed] = {
-				"@type" : 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI',
-				 "shapes" : []};
-			roiContainer = rois[roiIdToBeUsed];
-		}
+        var roiContainer = null;
+        if (typeof(rois[roiIdToBeUsed]) === 'object')
+            roiContainer = rois[roiIdToBeUsed];
+        else {
+            rois[roiIdToBeUsed] = {
+                "@type" : 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI',
+                "shapes" : []
+            };
+            roiContainer = rois[roiIdToBeUsed];
+        }
 
         var jsonObject =
-            ome.ol3.utils.Conversion.featureToJsonObject(feature, shapeId);
+            ome.ol3.utils.Conversion.featureToJsonObject(
+                feature, shapeId, roiIdToBeUsed);
         if (jsonObject === null) continue;
         // we like to keep the old id for later synchronization
         jsonObject['oldId'] = feature.getId();
         roiContainer['shapes'].push(jsonObject);
+        roisToBeStored['count']++;
+    };
 
-		roisToBeStored['count']++;
-	};
-
-	if (roisToBeStored['count'] === 0) return null;
+    if (roisToBeStored['count'] === 0) return null;
 
     if (returnFlattenedArray) {
         var flattenedArray = [];
@@ -738,7 +678,7 @@ ome.ol3.utils.Conversion.toJsonObject = function(
         roisToBeStored['rois'] =  flattenedArray;
     } else roisToBeStored['rois'] = rois;
 
-	return roisToBeStored;
+    return roisToBeStored;
 };
 
 /**
@@ -748,25 +688,31 @@ ome.ol3.utils.Conversion.toJsonObject = function(
  * @static
  * @function
  * @param {ol.Feature} feature an ol.Feature
- * @param {number} shape_id a shape_id
+ * @param {number=} shape_id an (optional) shape_id
+ * @param {number=} roi_id an (optional) roi_id
  * @return {Object|null} returns the json definition of the shape or null if an error occured
  */
-ome.ol3.utils.Conversion.featureToJsonObject = function(feature, shape_id) {
+ome.ol3.utils.Conversion.featureToJsonObject = function(feature, shape_id, roi_id) {
     var type = feature['type'];
     try {
         // extract the shape id from the feature's compound rois:shape id
-        if (typeof shape_id !== 'number' ||
-                typeof(feature.getId()) !== 'string' ||
-                feature.getId().length < 3) {
-            var colon = feature.getId().indexOf(":");
-            if (colon > 0) shape_id =
-                parseInt(feature.getId().substring(colon+1));
+        if (typeof shape_id !== 'number') {
+            try {
+                var colon = feature.getId().indexOf(":");
+                if (colon > 0) shape_id =
+                    parseInt(feature.getId().substring(colon+1));
+            } catch(parse_error) {
+                console.error(
+                    "Failed to turn feature " + type + "(" + feature.getId() +
+                    ") into json => " + parse_error);
+                return null;
+            }
         }
 
         var jsonObject = // retrieve object with 'geometry' type of properties
             ome.ol3.utils.Conversion.LOOKUP[type].call(
                 null, feature.getGeometry(),
-                feature['state'] === ome.ol3.REGIONS_STATE.ADDED ? -1 : shape_id);
+                typeof roi_id !== 'number' || roi_id > -1 ? shape_id : null);
 
         // add 'style' properties
         ome.ol3.utils.Conversion.integrateStyleIntoJsonObject(

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -284,15 +284,14 @@ ome.ol3.utils.Regions.generateRegions =
 		newFeature['type'] = prototypeFeature['type'];
 		newFeature.setStyle(
 			ome.ol3.utils.Style.cloneStyle(prototypeFeature.getStyle()));
-        // we generate an id of the form -1:uid
+        // we generate an id of the form -1:-uid
         if (typeof shape_info['shape_id'] !== 'string' ||
             shape_info['shape_id'].length === 0 ||
             shape_info['shape_id'].indexOf(":") === -1)
 		        newFeature.setId(
-                    (typeof shape_info['roi_id'] === 'number' &&
-                     shape_info['roi_id'] < 0 ?
+                    (typeof shape_info['roi_id'] === 'number' ?
                         "" + shape_info['roi_id'] + ":" : "-1:") +
-                            ol.getUid(newFeature));
+                            (-ol.getUid(newFeature)));
         else newFeature.setId(shape_info['shape_id']);
 		newFeature['state'] = ome.ol3.REGIONS_STATE.ADDED; // state: added
 

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -330,6 +330,10 @@ export default class Context {
         if (typeof image_id !== 'number' || image_id < 0)
             return null;
 
+        // reset
+        this.show_regions = false;
+        this.show_scalebar = false;
+
         // we do not keep the other configs around unless we are in MDI mode.
         if (!this.useMDI)
             for (let [id, conf] of this.image_configs)

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -553,10 +553,10 @@ thead, tbody {
     overflow: hidden;
 }
 
-.roi-id  {
+.roi-toggle  {
     width: 15px;
 }
-.shape-id {
+.roi-id, .shape-id {
     width: 50px;
 }
 

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -553,9 +553,8 @@ thead, tbody {
     overflow: hidden;
 }
 
-
-.shape-id {
-    width: 75px;
+.roi-id, .shape-id {
+    width: 50px;
 }
 
 .shape-z {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -553,7 +553,10 @@ thead, tbody {
     overflow: hidden;
 }
 
-.roi-id, .shape-id {
+.roi-id  {
+    width: 15px;
+}
+.shape-id {
     width: 50px;
 }
 

--- a/src/model/regions_history.js
+++ b/src/model/regions_history.js
@@ -186,8 +186,8 @@ export default class RegionsHistory {
         for (let i=0; i<entry.records.length;i++) {
             let rec = entry.records[i];
             if (entry.action === this.action.PROPERTIES) {
-                let shape = this.regions_info.data.get(rec.shape_id);
-                if (typeof shape === 'undefined') continue;
+                let shape = this.regions_info.getShape(rec.shape_id);
+                if (shape === null) continue;
                 this.affectHistoryPropertyChange(
                     shape, rec.diffs,
                     undo ? rec.old_vals : rec.new_vals,

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -169,6 +169,7 @@ export default class RegionsInfo extends EventSubscriber {
         let shape = this.getShape(id);
         if (typeof shape === null) return;
         let ids = Converters.extractRoiAndShapeId(id);
+        let roi = this.data.get(ids.roi_id);
 
         // if the shape shape has a property of that given name
         // set its new value
@@ -181,7 +182,11 @@ export default class RegionsInfo extends EventSubscriber {
                     (property === 'deleted' && value)) {
             let i = this.selected_shapes.indexOf(id);
             if (i !== -1) this.selected_shapes.splice(i, 1);
-        }
+
+            if (property === 'deleted' && value &&
+                typeof shape.is_new === 'boolean' && shape.is_new)
+                    roi.deleted++;
+        } else if (property === 'deleted' && !value) roi.deleted--;
     }
 
     /**
@@ -226,7 +231,8 @@ export default class RegionsInfo extends EventSubscriber {
                           this.data.set(roi.id,
                               {
                                   shapes: shapes,
-                                  show: false
+                                  show: false,
+                                  deleted: 0
                               });
                       }});
                 this.ready = true;

--- a/src/regions/regions-drawing-mode.html
+++ b/src/regions/regions-drawing-mode.html
@@ -90,14 +90,5 @@
              type="checkbox" />
              <span>&nbsp;Attach to viewed Z and T</span>
         </div>
-        <div class="drawing-mode-apply">
-            <button
-                class="${regions_info === null || regions_info.selected_shapes.length === 0 || !propagate ?
-                            'disabled-color' : ''}"
-                click.delegate="propagateSelectedShapes()"
-                disabled.bind="regions_info.selected_shapes.length === 0 || !propagate ">
-                Propagate Selected Shapes
-            </button>
-        </div>
     </div>
 </template>

--- a/src/regions/regions-drawing-mode.js
+++ b/src/regions/regions-drawing-mode.js
@@ -1,6 +1,7 @@
 // js
 import Context from '../app/context';
 import {Utils} from '../utils/regions';
+import {Converters} from '../utils/converters';
 import {REGIONS_DRAWING_MODE} from '../utils/constants';
 import {REGIONS_GENERATE_SHAPES} from '../events/events';
 import {inject, customElement, bindable} from 'aurelia-framework';
@@ -150,10 +151,6 @@ export default class RegionsDrawingMode {
      */
     propagateSelectedShapes() {
         let hist_id = this.regions_info.history.getHistoryId();
-         let roi_id = this.regions_info.getNewRegionsId();
-         // we loop over all selected shapes and propagate them individually
-         // since they could be in different t/z so that the propagation won't
-         // be the same for each of them
          this.regions_info.selected_shapes.map(
              (id) => {
                  let shape =
@@ -165,11 +162,14 @@ export default class RegionsDrawingMode {
                  if (theDims.length > 0)
                      this.context.publish(
                          REGIONS_GENERATE_SHAPES,
-                         {config_id : this.regions_info.image_info.config_id,
-                             shapes : [shape],
+                         {
+                             config_id: this.regions_info.image_info.config_id,
+                             shapes: [shape],
                              number : theDims.length, random : false,
-                             roi_id: roi_id, hist_id: hist_id,
-                             theDims : theDims, propagated: true});
+                             roi_id: Converters.extractRoiAndShapeId(id).roi_id,
+                             hist_id: hist_id,
+                             theDims : theDims
+                         });
              });
     }
 }

--- a/src/regions/regions-drawing-mode.js
+++ b/src/regions/regions-drawing-mode.js
@@ -154,7 +154,7 @@ export default class RegionsDrawingMode {
          this.regions_info.selected_shapes.map(
              (id) => {
                  let shape =
-                     Object.assign({}, this.regions_info.data.get(id));
+                     Object.assign({}, this.regions_info.getShape(id));
                  // collect dimensions for propagation
                  let theDims =
                      Utils.getDimensionsForPropagation(

--- a/src/regions/regions-drawing.js
+++ b/src/regions/regions-drawing.js
@@ -90,7 +90,9 @@ export default class RegionsDrawing extends EventSubscriber {
                 shapes = shapes.shapes;
             else {
                 shapes = new Map();
-                this.regions_info.data.set(roi_id, {shapes: shapes, show: true});
+                this.regions_info.data.set(roi_id, {
+                    shapes: shapes, show: true, deleted: 0
+                });
             }
             // add to regions data
             params.shapes.map(

--- a/src/regions/regions-drawing.js
+++ b/src/regions/regions-drawing.js
@@ -76,15 +76,23 @@ export default class RegionsDrawing extends EventSubscriber {
 
         let generatedShapes = [];
         if (Misc.isArray(params.shapes) && params.shapes.length > 0) {
+            // when entering after drawing we'll have a roi_id in the params
+            // which is not the case if we propagate
             if (roi_id === null) {
                 let ids =
                     Converters.extractRoiAndShapeId(params.shapes[0].oldId);
                 roi_id = ids.roi_id;
             }
-            let shapes =
-                params.drawn ? new Map() : this.regions_info.data.get(roi_id);
-            if (!(shapes instanceof Map)) shapes = new Map();
-            this.regions_info.data.set(roi_id, shapes);
+            // check whether we need a new shapes map:
+            // this is the case for newly drawn shapes but not propagated ones
+            let shapes = this.regions_info.data.get(roi_id);
+            if (typeof shapes !== 'undefined' && shapes.shapes instanceof Map)
+                shapes = shapes.shapes;
+            else {
+                shapes = new Map();
+                this.regions_info.data.set(roi_id, {shapes: shapes, show: true});
+            }
+            // add to regions data
             params.shapes.map(
                 (shape) => {
                     let newShape =

--- a/src/regions/regions-drawing.js
+++ b/src/regions/regions-drawing.js
@@ -139,12 +139,13 @@ export default class RegionsDrawing extends EventSubscriber {
         // trigger generation
         this.context.publish(
             REGIONS_GENERATE_SHAPES,
-            {config_id : this.regions_info.image_info.config_id,
+            {
+                config_id : this.regions_info.image_info.config_id,
                 shapes : [newShape],
                 number : theDims.length,
                 random : false, theDims : theDims,
-                hist_id : params.hist_id, roi_id: roi_id,
-                propagated: true});
+                hist_id : params.hist_id, roi_id: roi_id
+            });
     }
 
     /**

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -580,7 +580,7 @@ export default class RegionsEdit {
             REGIONS_GENERATE_SHAPES,
             {config_id : this.regions_info.image_info.config_id,
                 shapes : this.regions_info.copied_shapes,
-                number : 1, random : true, hist_id : hist_id,
-                propagated: true});
+                number : 1, random : true, hist_id : hist_id
+            });
     }
 }

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -306,7 +306,7 @@ export default class RegionsEdit {
                 this.regions_info.selected_shapes.length-1;
         this.last_selected =
             lastId === -1 ? null :
-            this.regions_info.data.get(
+            this.regions_info.getShape(
                 this.regions_info.selected_shapes[lastId]);
     }
 

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -12,26 +12,29 @@
         <table class="regions-header">
             <thead>
                 <tr>
-                    <th id="reg-col-0" class="shape-id"><div>ID</div></th>
-                    <th id="reg-col-1" class="shape-z"><div>Z</div></th>
-                    <th id="reg-col-2" class="shape-t"><div>T</div></th>
-                    <th id="reg-col-3" class="shape-type"><div>Type</div></th>
-                    <th id="reg-col-4" class="shape-comment"><div>Comment</div></th>
-                    <th id="reg-col-5" class="shape-show"><div>Show</div></th>
+                    <th id="reg-col-0" class="roi-id"><div>Roi</div></th>
+                    <th id="reg-col-1" class="shape-id"><div>ID</div></th>
+                    <th id="reg-col-2" class="shape-z"><div>Z</div></th>
+                    <th id="reg-col-3" class="shape-t"><div>T</div></th>
+                    <th id="reg-col-4" class="shape-type"><div>Type</div></th>
+                    <th id="reg-col-5" class="shape-comment"><div>Comment</div></th>
+                    <th id="reg-col-6" class="shape-show"><div>Show</div></th>
                 </tr>
             </thead>
         </table>
         <table class="regions-table">
             <tbody>
-                <tr repeat.for="[id, shape] of regions_info.data"
+                <template repeat.for="[roi_id, roi] of regions_info.data">
+                <tr repeat.for="[shape_id, shape] of roi"
                     show.bind="!(shape.deleted && shape.is_new)"
-                    id="${'roi-' + id}"
+                    id="${'roi-' + shape.shape_id}"
                     css="${shape.selected ?
                             'background-color: #d0d0ff;' : ''}
                             ${shape.deleted ? 'color: red;' :
                                 (shape.modified ? 'color: blue;' : '')}"
-                    click.delegate="selectShape(id, shape.selected, $event)">
-                    <td class="shape-id"><div>${shape.id}</div></td>
+                    click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
+                    <td class="roi-id"><div>${roi_id}</div></td>
+                    <td class="shape-id"><div>${shape_id}</div></td>
                     <td class="shape-z"><div>
                         ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
                     <td class="shape-t"><div>
@@ -41,9 +44,10 @@
                         ${shape.textValue ? shape.textValue : '&nbsp;'}</div></td>
                     <td class="shape-show">
                         <input type="checkbox" checked.bind="shape.visible"
-                            change.delegate="toggleShapeVisibility(id, shape.visible)"/>
+                            change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible)"/>
                     </td>
                 </tr>
+                </template>
             </tbody>
         </table>
     </div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -13,8 +13,8 @@
             <thead>
                 <tr>
                     <th id="reg-col-0" class="roi-toggle"><div>&nbsp;</div></th>
-                    <th id="reg-col-1" class="roi-id"><div>Roi</div></th>
-                    <th id="reg-col-2" class="shape-id"><div>ID</div></th>
+                    <th id="reg-col-1" class="roi-id"><div>ROI</div></th>
+                    <th id="reg-col-2" class="shape-id"><div>Shape</div></th>
                     <th id="reg-col-3" class="shape-z"><div>Z</div></th>
                     <th id="reg-col-4" class="shape-t"><div>T</div></th>
                     <th id="reg-col-5" class="shape-type"><div>Type</div></th>
@@ -41,24 +41,39 @@
                             <td class="shape-id"><div>&nbsp;</div></td>
                             <td class="shape-z"></td>
                             <td class="shape-t"></td>
-                            <td class="shape-type"><div>(${(roi.shapes.size - roi.deleted)})</div></td>
+                            <td class="shape-type">
+                                <div>(${(roi.shapes.size - roi.deleted)})</div>
+                            </td>
                             <td class="shape-show"></td>
                         </tr>
-                        <tr show.bind="!(shape.deleted && shape.is_new) && !(roi.shapes.size > 1 && !roi.show)"
+                        <tr show.bind="!(shape.deleted && shape.is_new) &&
+                                       !(roi.shapes.size > 1 && !roi.show)"
                             id="${'roi-' + shape.shape_id}"
                             css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
-                                 ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
+                                 ${shape.deleted ? 'color: red;' :
+                                    (shape.modified ? 'color: blue;' : '')}"
                             click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
                             <td class="roi-toggle"><div>&nbsp;</div></td>
-                            <td class="roi-id"><div>${roi_id}</div></td>
+                            <td class="roi-id">
+                                <div>
+                                    ${roi.shapes.size &lt;= 1 ||
+                                        (roi.shapes.size - roi.deleted) &lt;= 1 ?
+                                        roi_id : '&nbsp;'}
+                                </div>
+                            </td>
                             <td class="shape-id"><div>${shape_id}</div></td>
                             <td class="shape-z"><div>
                                 ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
                             <td class="shape-t"><div>
                                 ${shape.theT !== -1 ? (shape.theT + 1) : ""}</div></td>
-                            <td class="shape-type ${shape.type.toLowerCase()}-icon">&nbsp;</td>
-                            <td class="shape-comment"><div>
-                                ${shape.textValue ? shape.textValue : '&nbsp;'}</div></td>
+                            <td class="shape-type ${shape.type.toLowerCase()}-icon">
+                                <div>&nbsp;</div>
+                            </td>
+                            <td class="shape-comment">
+                                <div>
+                                    ${shape.textValue ? shape.textValue : '&nbsp;'}
+                                </div>
+                            </td>
                             <td class="shape-show">
                                 <input type="checkbox" checked.bind="shape.visible"
                                     change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible, $event)"/>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -27,12 +27,15 @@
                 <template repeat.for="[roi_id, roi] of regions_info.data">
                     <template repeat.for="[shape_id, shape] of roi.shapes">
                         <tr show.bind="(roi.shapes.size - roi.deleted) > 1 &&
-                                       roi.shapes.size > 1 && $first">
+                                       roi.shapes.size > 1 && $first"
+                            click.delegate="selectShapes(roi_id)">
                             <td class="roi-id">
-                                <div title="Click to show/hide shapes"
-                                     style="text-decoration: underline;cursor: pointer"
-                                     click.delegate="expandOrCollapseRoi(roi_id, $event)">
-                                     ${roi_id}
+                                <div>${roi_id}
+                                    <span title="Click to show/hide shapes"
+                                         style="cursor: pointer"
+                                         click.delegate="expandOrCollapseRoi(roi_id, $event)">
+                                         ${roi.show ? '&#9652;' : '&#9662;'}
+                                     </span>
                                 </div>
                             </td>
                         </tr>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -12,7 +12,7 @@
         <table class="regions-header">
             <thead>
                 <tr>
-                    <th id="reg-col-0" class="roi-id"><div>Roi</div></th>
+                    <th id="reg-col-0" class="roi-id"><div>&nbsp;</div></th>
                     <th id="reg-col-1" class="shape-id"><div>ID</div></th>
                     <th id="reg-col-2" class="shape-z"><div>Z</div></th>
                     <th id="reg-col-3" class="shape-t"><div>T</div></th>
@@ -29,27 +29,32 @@
                         <tr show.bind="(roi.shapes.size - roi.deleted) > 1 &&
                                        roi.shapes.size > 1 && $first"
                             click.delegate="selectShapes(roi_id, $event)">
-                            <td class="roi-id">
-                                <div>${roi_id}
-                                    <span title="Click to show/hide shapes"
-                                         style="cursor: pointer"
-                                         click.delegate="expandOrCollapseRoi(roi_id, $event)">
-                                         ${roi.show ? '&#9652;' : '&#9662;'}
-                                     </span>
+                            <td class="roi-id" title="Click to show/hide shapes">
+                                <div title="Click to show/hide shapes"
+                                     style="cursor: pointer"
+                                     click.delegate="expandOrCollapseRoi(roi_id, $event)">
+                                     ${roi.show ? '&#9660;' : '&#9658;'}
                                 </div>
                             </td>
+                            <td class="shape-id"><div>${roi_id}</div></td>
+                            <td class="shape-z"></td>
+                            <td class="shape-t"></td>
+                            <td class="shape-type"><div>(${(roi.shapes.size - roi.deleted)})</div></td>
+                            <td class="shape-show"></td>
                         </tr>
                         <tr show.bind="!(shape.deleted && shape.is_new) && !(roi.shapes.size > 1 && !roi.show)"
                             id="${'roi-' + shape.shape_id}"
                             css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
                                  ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
                             click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
-                            <td class="roi-id">
-                                <div>${roi.shapes.size &lt;= 1 ||
-                                       (roi.shapes.size - roi.deleted) &lt;= 1 ? roi_id : ''}
-                                </div>
-                            </td>
-                            <td class="shape-id"><div>${shape_id}</div></td>
+                            <td class="roi-id"></td>
+                            <td class="shape-id">
+                                <div>
+                                    ${roi.shapes.size &lt;= 1 ||
+                                        (roi.shapes.size - roi.deleted) &lt;= 1 ?
+                                        roi_id : shape_id}
+                               </div>
+                           </td>
                             <td class="shape-z"><div>
                                 ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
                             <td class="shape-t"><div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -12,13 +12,14 @@
         <table class="regions-header">
             <thead>
                 <tr>
-                    <th id="reg-col-0" class="roi-id"><div>&nbsp;</div></th>
-                    <th id="reg-col-1" class="shape-id"><div>ID</div></th>
-                    <th id="reg-col-2" class="shape-z"><div>Z</div></th>
-                    <th id="reg-col-3" class="shape-t"><div>T</div></th>
-                    <th id="reg-col-4" class="shape-type"><div>Type</div></th>
-                    <th id="reg-col-5" class="shape-comment"><div>Comment</div></th>
-                    <th id="reg-col-6" class="shape-show"><div>Show</div></th>
+                    <th id="reg-col-0" class="roi-toggle"><div>&nbsp;</div></th>
+                    <th id="reg-col-1" class="roi-id"><div>Roi</div></th>
+                    <th id="reg-col-2" class="shape-id"><div>ID</div></th>
+                    <th id="reg-col-3" class="shape-z"><div>Z</div></th>
+                    <th id="reg-col-4" class="shape-t"><div>T</div></th>
+                    <th id="reg-col-5" class="shape-type"><div>Type</div></th>
+                    <th id="reg-col-6" class="shape-comment"><div>Comment</div></th>
+                    <th id="reg-col-7" class="shape-show"><div>Show</div></th>
                 </tr>
             </thead>
         </table>
@@ -29,14 +30,15 @@
                         <tr show.bind="(roi.shapes.size - roi.deleted) > 1 &&
                                        roi.shapes.size > 1 && $first"
                             click.delegate="selectShapes(roi_id, $event)">
-                            <td class="roi-id" title="Click to show/hide shapes">
+                            <td class="roi-toggle">
                                 <div title="Click to show/hide shapes"
                                      style="cursor: pointer"
                                      click.delegate="expandOrCollapseRoi(roi_id, $event)">
                                      ${roi.show ? '&#9660;' : '&#9658;'}
-                                </div>
-                            </td>
-                            <td class="shape-id"><div>${roi_id}</div></td>
+                                 </div>
+                             </td>
+                            <td class="roi-id"><div>${roi_id}</div></td>
+                            <td class="shape-id"><div>&nbsp;</div></td>
                             <td class="shape-z"></td>
                             <td class="shape-t"></td>
                             <td class="shape-type"><div>(${(roi.shapes.size - roi.deleted)})</div></td>
@@ -47,14 +49,9 @@
                             css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
                                  ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
                             click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
-                            <td class="roi-id"></td>
-                            <td class="shape-id">
-                                <div>
-                                    ${roi.shapes.size &lt;= 1 ||
-                                        (roi.shapes.size - roi.deleted) &lt;= 1 ?
-                                        roi_id : shape_id}
-                               </div>
-                           </td>
+                            <td class="roi-toggle"><div>&nbsp;</div></td>
+                            <td class="roi-id"><div>${roi_id}</div></td>
+                            <td class="shape-id"><div>${shape_id}</div></td>
                             <td class="shape-z"><div>
                                 ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
                             <td class="shape-t"><div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -25,33 +25,42 @@
         <table class="regions-table">
             <tbody>
                 <template repeat.for="[roi_id, roi] of regions_info.data">
-                <tr repeat.for="[shape_id, shape] of roi.shapes"
-                    show.bind="!(shape.deleted && shape.is_new) && ($first || roi.show)"
-                    id="${'roi-' + shape.shape_id}"
-                    css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
-                         ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
-                    click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
-                    <td class="roi-id">
-                        <div css="${roi.shapes.size > 1 && $first ?
-                            'color: blue;text-decoration: underline;cursor: pointer' :
-                            'color: none;text-decoration: none;cursor: default'}"
-                            click.delegate="expandOrCollapseRoi(roi.shapes.size > 1 && $first, roi_id, $event)">
-                            ${roi_id}
-                        </div>
-                    </td>
-                    <td class="shape-id"><div>${shape_id}</div></td>
-                    <td class="shape-z"><div>
-                        ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
-                    <td class="shape-t"><div>
-                        ${shape.theT !== -1 ? (shape.theT + 1) : ""}</div></td>
-                    <td class="shape-type ${shape.type.toLowerCase()}-icon">&nbsp;</td>
-                    <td class="shape-comment"><div>
-                        ${shape.textValue ? shape.textValue : '&nbsp;'}</div></td>
-                    <td class="shape-show">
-                        <input type="checkbox" checked.bind="shape.visible"
-                            change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible)"/>
-                    </td>
-                </tr>
+                    <template repeat.for="[shape_id, shape] of roi.shapes">
+                        <tr show.bind="(roi.shapes.size - roi.deleted) > 1 &&
+                                       roi.shapes.size > 1 && $first">
+                            <td class="roi-id">
+                                <div title="Click to show/hide shapes"
+                                     style="text-decoration: underline;cursor: pointer"
+                                     click.delegate="expandOrCollapseRoi(roi_id, $event)">
+                                     ${roi_id}
+                                </div>
+                            </td>
+                        </tr>
+                        <tr show.bind="!(shape.deleted && shape.is_new) && !(roi.shapes.size > 1 && !roi.show)"
+                            id="${'roi-' + shape.shape_id}"
+                            css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
+                                 ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
+                            click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
+                            <td class="roi-id">
+                                <div>${(roi.shapes.size <= 1 ||
+                                       (roi.shapes.size - roi.deleted <= 1)) ?
+                                            roi_id : ''}
+                                </div>
+                            </td>
+                            <td class="shape-id"><div>${shape_id}</div></td>
+                            <td class="shape-z"><div>
+                                ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>
+                            <td class="shape-t"><div>
+                                ${shape.theT !== -1 ? (shape.theT + 1) : ""}</div></td>
+                            <td class="shape-type ${shape.type.toLowerCase()}-icon">&nbsp;</td>
+                            <td class="shape-comment"><div>
+                                ${shape.textValue ? shape.textValue : '&nbsp;'}</div></td>
+                            <td class="shape-show">
+                                <input type="checkbox" checked.bind="shape.visible"
+                                    change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible)"/>
+                            </td>
+                        </tr>
+                    </template>
                 </template>
             </tbody>
         </table>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -28,7 +28,7 @@
                     <template repeat.for="[shape_id, shape] of roi.shapes">
                         <tr show.bind="(roi.shapes.size - roi.deleted) > 1 &&
                                        roi.shapes.size > 1 && $first"
-                            click.delegate="selectShapes(roi_id)">
+                            click.delegate="selectShapes(roi_id, $event)">
                             <td class="roi-id">
                                 <div>${roi_id}
                                     <span title="Click to show/hide shapes"
@@ -59,7 +59,7 @@
                                 ${shape.textValue ? shape.textValue : '&nbsp;'}</div></td>
                             <td class="shape-show">
                                 <input type="checkbox" checked.bind="shape.visible"
-                                    change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible)"/>
+                                    change.delegate="toggleShapeVisibility(shape.shape_id, shape.visible, $event)"/>
                             </td>
                         </tr>
                     </template>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -45,9 +45,8 @@
                                  ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
                             click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
                             <td class="roi-id">
-                                <div>${(roi.shapes.size <= 1 ||
-                                       (roi.shapes.size - roi.deleted <= 1)) ?
-                                            roi_id : ''}
+                                <div>${roi.shapes.size &lt;= 1 ||
+                                       (roi.shapes.size - roi.deleted) &lt;= 1 ? roi_id : ''}
                                 </div>
                             </td>
                             <td class="shape-id"><div>${shape_id}</div></td>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -25,15 +25,20 @@
         <table class="regions-table">
             <tbody>
                 <template repeat.for="[roi_id, roi] of regions_info.data">
-                <tr repeat.for="[shape_id, shape] of roi"
-                    show.bind="!(shape.deleted && shape.is_new)"
+                <tr repeat.for="[shape_id, shape] of roi.shapes"
+                    show.bind="!(shape.deleted && shape.is_new) && ($first || roi.show)"
                     id="${'roi-' + shape.shape_id}"
-                    css="${shape.selected ?
-                            'background-color: #d0d0ff;' : ''}
-                            ${shape.deleted ? 'color: red;' :
-                                (shape.modified ? 'color: blue;' : '')}"
+                    css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
+                         ${shape.deleted ? 'color: red;' : (shape.modified ? 'color: blue;' : '')}"
                     click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
-                    <td class="roi-id"><div>${roi_id}</div></td>
+                    <td class="roi-id">
+                        <div css="${roi.shapes.size > 1 && $first ?
+                            'color: blue;text-decoration: underline;cursor: pointer' :
+                            'color: none;text-decoration: none;cursor: default'}"
+                            click.delegate="expandOrCollapseRoi(roi.shapes.size > 1 && $first, roi_id, $event)">
+                            ${roi_id}
+                        </div>
+                    </td>
                     <td class="shape-id"><div>${shape_id}</div></td>
                     <td class="shape-z"><div>
                         ${shape.theZ !== -1 ? (shape.theZ + 1) : ""}</div></td>

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -32,6 +32,12 @@ export default class RegionsList {
     dragging_start = null;
 
     /**
+     * @memberof RegionsList
+     * @type {boolean}
+     */
+    initial_load = true;
+
+    /**
      * @constructor
      * @param {Context} context the application context (injected)
      */
@@ -233,5 +239,13 @@ export default class RegionsList {
                config_id: this.regions_info.image_info.config_id,
                property : "visible",
                shapes : [id], value : visible});
+    }
+
+    expandOrCollapseRoi(enabled, roi_id, event) {
+        if (!enabled) return;
+        event.stopPropagation();
+
+        let roi = this.regions_info.data.get(roi_id);
+        roi.show = !roi.show;
     }
 }

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -252,9 +252,11 @@ export default class RegionsList extends EventSubscriber {
      *
      * @param {number} id the shape id
      * @param {boolean} selected the selected state
+     * @param {Event} event the browser's event object
      * @memberof RegionsList
      */
-    selectShape(id, selected) {
+    selectShape(id, selected, event) {
+        if (event.target.tagName.toUpperCase() === 'INPUT') return true;
         let multipleSelection =
             typeof event.ctrlKey === 'boolean' && event.ctrlKey;
         let deselect = multipleSelection && selected;
@@ -271,9 +273,14 @@ export default class RegionsList extends EventSubscriber {
      * Select shapes for roi
      *
      * @param {number} roi_id the roi id
+     * @param {Event} event the browser's event object
      * @memberof RegionsList
      */
-    selectShapes(roi_id) {
+    selectShapes(roi_id, event) {
+        if (event.target.className.indexOf("roi_id") !== -1 ||
+            event.target.parentNode.className.indexOf("roi_id") !== -1 )
+                return true;
+
         let roi = this.regions_info.data.get(roi_id);
         if (typeof roi === 'undefined') return;
 
@@ -291,9 +298,11 @@ export default class RegionsList extends EventSubscriber {
      *
      * @param {number} id the shape id
      * @param {boolean} visible the visible state
+     * @param {Event} event the browser's event object
      * @memberof RegionsList
      */
-    toggleShapeVisibility(id, visible) {
+    toggleShapeVisibility(id, visible, event) {
+        event.stopPropagation();
         this.context.publish(
            REGIONS_SET_PROPERTY, {
                config_id: this.regions_info.image_info.config_id,

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -86,7 +86,14 @@ export default class RegionsList extends EventSubscriber {
 
          let id = params.shapes[0];
          let el = document.getElementById('roi-' + id);
-         let scroll = () => $('.regions-table').scrollTop(el.offsetTop);
+         let regTable = $('.regions-table');
+         let scrollTop = regTable.scrollTop();
+         let scrollBottom = scrollTop + regTable.outerHeight();
+         let elTop = el.offsetTop;
+         let elBottom = elTop + el.offsetHeight;
+         if (elTop > scrollTop && elBottom < scrollBottom) return;
+
+         let scroll = () => regTable.scrollTop(el.offsetTop);
          setTimeout(scroll,
              el.className.indexOf("aurelia-hide") !== -1 ? 100 : 0);
      }

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -206,14 +206,9 @@ export default class RegionsList {
      *
      * @param {number} id the shape id
      * @param {boolean} selected the selected state
-     * @param {Object} event event object with additional info
      * @memberof RegionsList
      */
-    selectShape(id, selected, event) {
-        let t = $(event.target);
-        if (t.hasClass("shape-show") || t.parent().hasClass("shape-show"))
-            return true;
-
+    selectShape(id, selected) {
         let multipleSelection =
             typeof event.ctrlKey === 'boolean' && event.ctrlKey;
         let deselect = multipleSelection && selected;
@@ -224,6 +219,25 @@ export default class RegionsList {
                property: 'selected',
                shapes : [id], clear: !multipleSelection,
                value : !deselect, center : !multipleSelection});
+    }
+
+    /**
+     * Select shapes for roi
+     *
+     * @param {number} roi_id the roi id
+     * @memberof RegionsList
+     */
+    selectShapes(roi_id) {
+        let roi = this.regions_info.data.get(roi_id);
+        if (typeof roi === 'undefined') return;
+
+        let ids = [];
+        roi.shapes.forEach((s) => ids.push(s.shape_id));
+        this.context.publish(
+           REGIONS_SET_PROPERTY, {
+               config_id: this.regions_info.image_info.config_id,
+               property: 'selected',
+               shapes : ids, clear: true, value : true, center : true});
     }
 
     /**
@@ -241,6 +255,13 @@ export default class RegionsList {
                shapes : [id], value : visible});
     }
 
+    /**
+     * Show/Hide shapes within roi
+     *
+     * @param {number} roi_id the roi id
+     * @param {Event} event the browser's event object
+     * @memberof RegionsList
+     */
     expandOrCollapseRoi(roi_id, event) {
         event.stopPropagation();
 

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -85,8 +85,10 @@ export default class RegionsList extends EventSubscriber {
              typeof params.values !== 'boolean' || !params.values) return;
 
          let id = params.shapes[0];
-         let offsetTop = document.getElementById("roi-" + id).offsetTop;
-            $('.regions-table').scrollTop(offsetTop);
+         let el = document.getElementById('roi-' + id);
+         let scroll = () => $('.regions-table').scrollTop(el.offsetTop);
+         setTimeout(scroll,
+             el.className.indexOf("aurelia-hide") !== -1 ? 100 : 0);
      }
 
     /**
@@ -310,9 +312,10 @@ export default class RegionsList extends EventSubscriber {
         event.stopPropagation();
 
         let roi = this.regions_info.data.get(roi_id);
+        if (typeof roi === 'undefined') return;
         roi.show = !roi.show;
     }
-    
+
     /*
      * Overridden aurelia lifecycle method:
      * called whenever the view is unbound within aurelia

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -241,8 +241,7 @@ export default class RegionsList {
                shapes : [id], value : visible});
     }
 
-    expandOrCollapseRoi(enabled, roi_id, event) {
-        if (!enabled) return;
+    expandOrCollapseRoi(roi_id, event) {
         event.stopPropagation();
 
         let roi = this.regions_info.data.get(roi_id);

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -60,9 +60,7 @@
         <hr />
         <regions-drawing regions_info.bind="regions_info"></regions-drawing>
 
-        <regions-list
-            class="${regions_info.shape_to_be_drawn !== null ? 'disabled-color' : ''}"
-            regions_info.bind="regions_info"></regions-list>
+        <regions-list regions_info.bind="regions_info"></regions-list>
 
         <regions-drawing-mode regions_info.bind="regions_info"></regions-drawing-mode>
     </div>

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -124,6 +124,33 @@ export class Converters {
     }
 
     /**
+     * Extracts the individual roi and shape id from a combined id (roi:shape)
+     *
+     * @static
+     * @param {string} id the id in the format roi_id:shape_id, e.g. 2:4
+     * @return {Object} an object containing the properties roi_id and shape_id
+     */
+     static extractRoiAndShapeId(id) {
+        let ret = {
+            roi_id: null,
+            shape_id: null
+        };
+        if (typeof id !== 'string' || id.length < 3) return ret;
+
+        // dissect roi:shape id
+        let colon = id.indexOf(':');
+        if (colon < 1) return ret;
+
+        // check for numeric
+        let roi_id = parseInt(id.substring(0, colon));
+        if (!isNaN(roi_id)) ret.roi_id = roi_id;
+        let shape_id = parseInt(id.substring(colon+1));
+        if (!isNaN(shape_id)) ret.shape_id = shape_id;
+
+        return ret;
+    }
+
+    /**
      * Makes omero marshal generated objects backwards compatible
      *
      * @static
@@ -140,12 +167,10 @@ export class Converters {
 
         // create shape copy in 'webgateway format'
         let compatibleShape = {type : type}; // type
-        if (typeof shape.oldId === 'string' && shape.oldId.indexOf(":") > 0) {
-            compatibleShape.shape_id = shape.oldId; // dissect id
-            compatibleShape.id =
-                parseInt(
-                    compatibleShape.shape_id.substring(
-                        compatibleShape.shape_id.indexOf(":") + 1));
+        let ids = Converters.extractRoiAndShapeId(shape.oldId);
+        if (ids.shape_id !== null) {
+            compatibleShape.shape_id = shape.oldId;
+            compatibleShape.id = ids.shape_id;
         }
 
         // loop over individual properties

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -176,7 +176,7 @@ export class Converters {
         // loop over individual properties
         for (let p in shape) {
             // we skip those
-            if (p === '@type' || p === 'oldId') continue;
+            if (p === '@type' || p === 'oldId' || p === '@id') continue;
             // first letter will be lower case converted
             let pComp = p[0].toLowerCase() + p.substring(1);
             let value = shape[p];

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -299,7 +299,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 let shape = params.shapes[i];
                 let refOrCopy =
                     this.image_config.regions_info.data ?
-                        this.image_config.regions_info.data.get(shape) : null;
+                        this.image_config.regions_info.getShape(shape) : null;
                 let prop = Misc.isArray(params.properties) ?
                                 params.properties[i] : params.properties;
                 let value = Misc.isArray(params.values) ?
@@ -424,7 +424,7 @@ export default class Ol3Viewer extends EventSubscriber {
             let viewerT = this.viewer.getDimensionIndex('t');
             let viewerZ = this.viewer.getDimensionIndex('z');
             let shape =
-                this.image_config.regions_info.data.get(params.shapes[0]);
+                this.image_config.regions_info.getShape(params.shapes[0]);
             let shapeT = typeof shape.theT === 'number' ? shape.theT : -1;
             if (shapeT !== -1 && shapeT !== viewerT) {
                 this.image_config.image_info.dimensions.t = shapeT;
@@ -624,25 +624,41 @@ export default class Ol3Viewer extends EventSubscriber {
         params.shapes = null;
         // we iterate over the ids given and reset states accordingly
         for (let id in ids) {
-            let shape = this.image_config.regions_info.data.get(id);
+            let shape = this.image_config.regions_info.getShape(id);
             if (shape) {
+                let oldRoiAndShapeId = Converters.extractRoiAndShapeId(id);
+                let newRoiAndShapeId = Converters.extractRoiAndShapeId(ids[id]);
                 // we reset modifed
                 shape.modified = false;
                 // new ones are stored under their newly created ids
                 if (typeof shape.is_new === 'boolean') {
+                    let newRoi =
+                        this.image_config.regions_info.data.get(
+                            newRoiAndShapeId.roi_id);
+                    if (typeof newRoi === 'undefined') {
+                        newRoi = new Map();
+                        this.image_config.regions_info.data.set(
+                            newRoiAndShapeId.roi_id, newRoi);
+                    }
                     delete shape['is_new'];
                     let newShape = Object.assign({}, shape);
                     newShape.shape_id = ids[id];
-                    newShape.id =
-                      parseInt(newShape.shape_id.substring(
-                                newShape.shape_id.indexOf(":") + 1));
-                    this.image_config.regions_info.data.set(
-                        newShape.shape_id, newShape);
+                    newShape.id = newRoiAndShapeId.shape_id;
+                    newRoi.set(newRoiAndShapeId.shape_id, newShape);
                     shape.deleted = true; // take out old entry
                 }
-                // we remove deleted
-                if (shape.deleted)
-                    this.image_config.regions_info.data.delete(id);
+                // we remove shapes flagged deleted=true
+                if (shape.deleted) {
+                    let oldRoi =
+                        this.image_config.regions_info.data.get(
+                                oldRoiAndShapeId.roi_id);
+                    if (oldRoi instanceof Map)
+                        oldRoi.delete(oldRoiAndShapeId.shape_id);
+                    // remove empty roi as well
+                    if (oldRoi.size === 0)
+                        this.image_config.regions_info.data.delete(
+                            oldRoiAndShapeId.roi_id);
+                }
             }
         }
         // for now let's just clear the history
@@ -719,7 +735,7 @@ export default class Ol3Viewer extends EventSubscriber {
             (id) => {
                 let deepCopy =
                     Object.assign({},
-                    this.image_config.regions_info.data.get(id));
+                    this.image_config.regions_info.getShape(id));
                 // if we have been modified we get an up-to-date def
                 // from the viewer
                 if (deepCopy.modified) {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -636,7 +636,10 @@ export default class Ol3Viewer extends EventSubscriber {
                         this.image_config.regions_info.data.get(
                             newRoiAndShapeId.roi_id);
                     if (typeof newRoi === 'undefined') {
-                        newRoi = new Map();
+                        newRoi = {
+                            shapes: new Map(),
+                            show: false
+                        };
                         this.image_config.regions_info.data.set(
                             newRoiAndShapeId.roi_id, newRoi);
                     }
@@ -644,7 +647,7 @@ export default class Ol3Viewer extends EventSubscriber {
                     let newShape = Object.assign({}, shape);
                     newShape.shape_id = ids[id];
                     newShape.id = newRoiAndShapeId.shape_id;
-                    newRoi.set(newRoiAndShapeId.shape_id, newShape);
+                    newRoi.shapes.set(newRoiAndShapeId.shape_id, newShape);
                     shape.deleted = true; // take out old entry
                 }
                 // we remove shapes flagged deleted=true
@@ -652,8 +655,9 @@ export default class Ol3Viewer extends EventSubscriber {
                     let oldRoi =
                         this.image_config.regions_info.data.get(
                                 oldRoiAndShapeId.roi_id);
-                    if (oldRoi instanceof Map)
-                        oldRoi.delete(oldRoiAndShapeId.shape_id);
+                    if (typeof oldRoi !== 'undefined' &&
+                        oldRoi.shapes instanceof Map)
+                        oldRoi.shapes.delete(oldRoiAndShapeId.shape_id);
                     // remove empty roi as well
                     if (oldRoi.size === 0)
                         this.image_config.regions_info.data.delete(

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -354,8 +354,8 @@ export default class Ol3Viewer extends EventSubscriber {
           let extent = this.viewer.getSmallestViewExtent();
           if (typeof params.random !== 'boolean') params.random = false;
           if (typeof params.number !== 'number') params.number = 1;
-          if (typeof params.roi_id !== 'number' || params.roi_id > 0)
-            params.roi_id = this.image_config.regions_info.getNewRegionsId();
+          if (typeof params.roi_id !== 'number')
+              params.roi_id = this.image_config.regions_info.getNewRegionsId();
           let theDims =
             Misc.isArray(params.theDims) && params.theDims.length !== 0 ?
                 params.theDims : null;
@@ -374,9 +374,7 @@ export default class Ol3Viewer extends EventSubscriber {
                                 deepCopy =
                                     Converters.makeShapeBackwardsCompatible(upToDateDef);
                           }
-                          // for any generated shape we don't want an id
-                          // it will receive its own, new id
-                          if (params.propagated) delete deepCopy['shape_id'];
+                          delete deepCopy['shape_id'];
                           deepCopy['roi_id'] = params.roi_id;
                           this.viewer.generateShapes(deepCopy,
                               params.number, params.random, extent, theDims,
@@ -667,7 +665,7 @@ export default class Ol3Viewer extends EventSubscriber {
                         oldRoi.shapes instanceof Map)
                         oldRoi.shapes.delete(oldRoiAndShapeId.shape_id);
                     // remove empty roi as well
-                    if (oldRoi.size === 0)
+                    if (oldRoi.shapes.size === 0)
                         this.image_config.regions_info.data.delete(
                             oldRoiAndShapeId.roi_id);
                 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -638,7 +638,8 @@ export default class Ol3Viewer extends EventSubscriber {
                     if (typeof newRoi === 'undefined') {
                         newRoi = {
                             shapes: new Map(),
-                            show: false
+                            show: false,
+                            deleted: 0
                         };
                         this.image_config.regions_info.data.set(
                             newRoiAndShapeId.roi_id, newRoi);


### PR DESCRIPTION
see: https://trello.com/c/yyI19Pus/6-shapes-handling

While there is probably going to be a redesign of the region listing/table in the future it makes sense to address the shortcoming of not showing hierarchy/relationship of rois/shapes now with this PR, especially with drawing and propagating shapes which creates such a relationships (see: https://github.com/ome/omero-iviewer/pull/48).


TEST: http://web-dev-merge.openmicroscopy.org/webclient/ (unless cowfish is back online)

Either choose an image that has a roi with more than 1 shapes in it already, or, use the iviewer to create one by  selecting one of the options in the section "drawing mode & propagation" such as "Attach to all Z and/or T", then drawing a shape. (Note on the side: don't expect the propagation button to be a 1:1 equivalent of what Insight does...)

Check ~~that the table includes the roi id as the first column and, more importantly,~~ that with multiple shapes in one roi you see a triangle icon ~~next to its id~~ which collapses/expands the shape rows (on click). 

UPDATE: the layout looks now closer to what is in the web at the moment, in that it has a first column with a toggle for collapse/expand only. I use the ID column then for the roi/shape id, on top I display the number of shapes in the "type" column. That should help with the "clickability" of the toggle icon.
Also I took out the propagation button.