### PR TITLE
scalebar - increase spectrum (finer unit differentiation)

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -476,6 +476,8 @@ ome.ol3.Viewer = function(id, options) {
                 scope.viewerState_["birdseye"]['ref']
                     instanceof ome.ol3.controls.BirdsEye)
                         scope.viewerState_["birdseye"]['ref'].setCollapsed(false);
+            // enable scalebar by default
+            scope.toggleScaleBar(true);
 
             // listens to resolution changes
             scope.onViewResolutionListener =
@@ -486,8 +488,17 @@ ome.ol3.Viewer = function(id, options) {
                     }, scope);
             scope.displayResolutionInPercent();
 
-            // an endMove listener to publish move events
-            if (scope.eventbus_)
+            // this is for work that needs to be done after,
+            // e.g we have just switched images
+            // because of the asynchronious nature of the initialization
+            // we need to do this here
+            if (typeof(postSuccessHook) === 'function')
+                postSuccessHook.call(scope);
+
+            if (scope.tried_regions) scope.addRegions();
+
+            if (scope.eventbus_) {
+                // an endMove listener to publish move events
                 scope.onEndMoveListener =
                     ol.events.listen(
                         scope.viewer_, ol.MapEventType.MOVEEND,
@@ -500,15 +511,10 @@ ome.ol3.Viewer = function(id, options) {
                                  "c": this.getDimensionIndex('c'),
                                  "center": this.viewer_.getView().getCenter()});
                         }, scope);
-
-            // this is for work that needs to be done after,
-            // e.g we have just switched images
-            // because of the asynchronious nature of the initialization
-            // we need to do this here
-            if (typeof(postSuccessHook) === 'function')
-                postSuccessHook.call(scope);
-
-            if (scope.tried_regions) scope.addRegions();
+                // announce that we are finished
+                scope.eventbus_.publish(
+                    "IMAGE_VIEWER_INIT", {"config_id": scope.getTargetId()});
+            }
         };
 
         // define request settings
@@ -1742,20 +1748,33 @@ ome.ol3.Viewer.prototype.changeImageModel = function(value) {
  * Enables/disabled scale bar
  *
  * @param {boolean} show if true we show the scale bar, otherwise not
+ * @return {boolean} true if the toggle was successfully done, otherwise false
  */
  ome.ol3.Viewer.prototype.toggleScaleBar = function(show) {
     // check if we have an image and a pixel size specified
     if (this.getImage() === null ||
         typeof this.image_info_['pixel_size'] !== "object" ||
-        typeof this.image_info_['pixel_size']['x'] !== "number") return;
+        typeof this.image_info_['pixel_size']['x'] !== "number") return false;
 
     if (typeof show !== 'boolean') show = false;
 
-    if (show) {
-        this.addControl("scalebar");
-        return;
+    // check if we have an instance of the control already
+    // and create one if we don't
+    var scalebarControlExists =
+        typeof this.viewerState_['scalebar'] === 'object';
+    if (!scalebarControlExists) {
+        if (show) this.addControl("scalebar");
+        return true;
     }
-    this.removeInteractionOrControl("scalebar");
+
+    // toggle visibility now
+    try {
+        var scalebarControl = this.viewerState_["scalebar"]['ref'];
+        scalebarControl.element_.style.display = show ? "" : "none";
+    } catch(ex) {
+        return false;
+    }
+    return true;
  }
 
 /**

--- a/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
+++ b/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
@@ -14,15 +14,25 @@ ome.ol3.controls.ScaleBar = function(opt_options) {
     if (typeof(opt_options) !== 'object') opt_options = {};
 
     /**
-	 * list available units for display incl. symbol and
-     * micron multiplicator
+	 * list available units for display incl. symbol, threshold for usage
+     * and micron multiplication factor
 	 *
 	 * @type {Array.<objects>}
 	 * @private
 	 */
     this.UNITS = [
-        { unit: 'micron', multiplier: 1, symbol: 'µm'},
-        { unit: 'millimeter', multiplier: 1000, symbol: 'mm'}];
+        { unit: 'angstrom',
+          threshold: 0.1, multiplier: 10000, symbol: '\u212B'},
+        { unit: 'nanometer',
+          threshold: 1, multiplier: 1000, symbol: 'nm'},
+        { unit: 'micron',
+          threshold: 1000, multiplier: 1, symbol:  '\u00B5m'},
+        { unit: 'millimeter',
+          threshold: 100000, multiplier: 0.001, symbol: 'mm'},
+        { unit: 'centimeter',
+          threshold: 1000000, multiplier: 0.0001, symbol: 'cm'},
+        { unit: 'meter',
+          threshold: 100000000, multiplier: 0.000001, symbol: 'm'}];
 
     /**
 	 * default scale bar width in pixels
@@ -51,26 +61,21 @@ ome.ol3.controls.ScaleBar.prototype.updateElement_ = function() {
     return;
   }
 
-  var micronsPerUnit = viewState.projection.getMetersPerUnit();
+  var micronsPerPixel = viewState.projection.getMetersPerUnit();
   var resolution = viewState.resolution;
-
-  var totalMicronsForBarWidth =
-    micronsPerUnit * this.bar_width_ * resolution;
-  var choosenUnit = this.UNITS[0];
+  var scaleBarLengthInUnits = micronsPerPixel * this.bar_width_ * resolution;
+  var symbol = '\u00B5m';
   for (var u=0;u<this.UNITS.length;u++) {
-      if (u+1 === this.UNITS.length) break;
-
-      var nextUnit = this.UNITS[u+1];
-      if (totalMicronsForBarWidth / nextUnit.multiplier > 1) {
-          choosenUnit = nextUnit;
-          totalMicronsForBarWidth /= nextUnit.multiplier;
-          continue;
+      var unit = this.UNITS[u];
+      if (scaleBarLengthInUnits < unit.threshold) {
+          scaleBarLengthInUnits *= unit.multiplier;
+          symbol = unit.symbol;
+          break;
       }
-      break;
   }
 
-  var html = totalMicronsForBarWidth.toFixed(5) + ' ' + choosenUnit.symbol;
-  if (this.renderedHTML_ != html) {
+  var html = scaleBarLengthInUnits.toFixed(5) + ' ' + symbol;
+  if (this.renderedHTML_ !== html) {
     this.innerElement_.innerHTML = html;
     this.renderedHTML_ = html;
   }

--- a/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
+++ b/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
@@ -41,7 +41,46 @@ ome.ol3.controls.ScaleBar = function(opt_options) {
      */
     this.bar_width_ = 100;
 
+    /**
+     * the scalebar 'drag' listener
+     * @type {number}
+     * @private
+     */
+    this.drag_listener_ = null;
+
     goog.base(this, opt_options);
+
+    // give element a tooltip
+    this.element_.title = "Click and drag to move scalebar";
+
+    // register 'drag' listener
+    ol.events.listen(
+        this.element_, "mousedown",
+        function(start) {
+            if (!(this.map_ instanceof ol.Map)) return;
+            if (this.drag_listener_ !== null) {
+                ol.events.unlistenByKey(this.drag_listener_);
+                this.drag_listener_ = null;
+            }
+            var offsetX = -start.offsetX;
+            var offsetY = -start.offsetY;
+            this.drag_listener_ =
+                ol.events.listen(this.map_, "pointermove",
+                    function(move) {
+                        var e = move.originalEvent;
+                        if (!((typeof e.buttons === 'undefined' &&
+                            e.which === 1) || e.buttons === 1)) {
+                                ol.events.unlistenByKey(this.drag_listener_);
+                                this.drag_listener_ = null;
+                                return;
+                            }
+                        this.element_.style.bottom = "auto";
+                        this.element_.style.left =
+                            (move.pixel[0] + offsetX) + "px";
+                        this.element_.style.top =
+                            (move.pixel[1] + offsetY) + "px";
+                    }, this);
+     }, this);
 }
 goog.inherits(ome.ol3.controls.ScaleBar, ol.control.ScaleLine);
 

--- a/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
+++ b/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
@@ -14,12 +14,12 @@ ome.ol3.controls.ScaleBar = function(opt_options) {
     if (typeof(opt_options) !== 'object') opt_options = {};
 
     /**
-	 * list available units for display incl. symbol, threshold for usage
+     * list available units for display incl. symbol, threshold for usage
      * and micron multiplication factor
-	 *
-	 * @type {Array.<objects>}
-	 * @private
-	 */
+     *
+     * @type {Array.<objects>}
+     * @private
+     */
     this.UNITS = [
         { unit: 'angstrom',
           threshold: 0.1, multiplier: 10000, symbol: '\u212B'},
@@ -35,10 +35,10 @@ ome.ol3.controls.ScaleBar = function(opt_options) {
           threshold: 100000000, multiplier: 0.000001, symbol: 'm'}];
 
     /**
-	 * default scale bar width in pixels
-	 * @type {number}
-	 * @private
-	 */
+     * default scale bar width in pixels
+     * @type {number}
+     * @private
+     */
     this.bar_width_ = 100;
 
     goog.base(this, opt_options);

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -81,9 +81,9 @@ export default class Context {
 
     /**
      * the global flag for showing the scalebar
-     * @type {boolean}
+     * @type {boolean|null}
      */
-     show_scalebar = false;
+     show_scalebar = null;
 
      /**
       * application wide keyhandlers.
@@ -335,7 +335,7 @@ export default class Context {
 
         // reset
         this.show_regions = false;
-        this.show_scalebar = false;
+        this.show_scalebar = null;
 
         // we do not keep the other configs around unless we are in MDI mode.
         if (!this.useMDI)

--- a/src/css/ol3-viewer.css
+++ b/src/css/ol3-viewer.css
@@ -17,6 +17,7 @@
     left: 8px;
     padding: 2px;
     position: absolute;
+    cursor: pointer;
 }
 .ol-scale-line-inner {
     border: 1px solid #eee;

--- a/src/css/ol3-viewer.css
+++ b/src/css/ol3-viewer.css
@@ -11,7 +11,7 @@
 }
 
 .ol-scale-line {
-    background: rgba(0,60,136,0.3);
+    background: rgba(0,60,136,0.5);
     border-radius: 4px;
     bottom: 8px;
     left: 8px;

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -1,5 +1,7 @@
 /** whenever an image config has been updated */
 export const IMAGE_CONFIG_UPDATE = "IMAGE_CONFIG_UPDATE";
+/** after the image viewer has been created */
+export const IMAGE_VIEWER_INIT = "IMAGE_VIEWER_INIT";
 /** whenever an image config has been selected */
 export const IMAGE_CONFIG_SELECT = "IMAGE_CONFIG_SELECT";
 /** whenever the image viewer needs to be resized */

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -34,13 +34,6 @@ export default class ImageInfo {
     tiled = false;
 
     /**
-     * a flag that signals whether we a pixe_size and hence a scalebar
-     * @memberof ImageInfo
-     * @type {boolean}
-     */
-    has_scalebar = false;
-
-    /**
      * a flag that signals whether the histogram is enabled or not
      * this will be set accordingly by the histogram but due to its
      * more global nature we want the flag here.
@@ -268,10 +261,6 @@ export default class ImageInfo {
                 (parseInt(initialPlane)-1) : response.rdefs.defaultZ,
             max_z : response.size.z
         };
-        // do we have a scalebar
-        if (typeof response.pixel_size === 'object' &&
-            typeof response.pixel_size.x === 'number')
-            this.has_scalebar = true;
 
         // store projection and model
         this.projection =

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -10,9 +10,9 @@ import {inject, customElement, bindable} from 'aurelia-framework';
 import {ol3} from '../../libs/ol3-viewer.js';
 import {IVIEWER, REGIONS_DRAWING_MODE, RENDER_STATUS} from '../utils/constants';
 import {
-    IMAGE_CONFIG_UPDATE, IMAGE_VIEWER_RESIZE, IMAGE_VIEWER_SCALEBAR,
-    IMAGE_DIMENSION_CHANGE, IMAGE_DIMENSION_PLAY, IMAGE_SETTINGS_CHANGE,
-    REGIONS_SET_PROPERTY, REGIONS_PROPERTY_CHANGED,
+    IMAGE_CONFIG_UPDATE, IMAGE_VIEWER_INIT, IMAGE_VIEWER_RESIZE,
+    IMAGE_VIEWER_SCALEBAR, IMAGE_DIMENSION_CHANGE, IMAGE_DIMENSION_PLAY,
+    IMAGE_SETTINGS_CHANGE, REGIONS_SET_PROPERTY, REGIONS_PROPERTY_CHANGED,
     VIEWER_IMAGE_SETTINGS, IMAGE_VIEWER_SPLIT_VIEW,
     REGIONS_DRAW_SHAPE, REGIONS_CHANGE_MODES, REGIONS_SHOW_COMMENTS,
     REGIONS_GENERATE_SHAPES, REGIONS_STORED_SHAPES, REGIONS_STORE_SHAPES,
@@ -64,7 +64,9 @@ export default class Ol3Viewer extends EventSubscriber {
      */
     sub_list = [
         [IMAGE_CONFIG_UPDATE,
-             (params={}) => this.updateViewer(params)],
+            (params={}) => this.updateViewer(params)],
+        [IMAGE_VIEWER_INIT,
+            (params={}) => this.initViewer(params)],
         [IMAGE_VIEWER_RESIZE,
             (params={}) => this.resizeViewer(params)],
         [IMAGE_VIEWER_SCALEBAR,
@@ -182,7 +184,15 @@ export default class Ol3Viewer extends EventSubscriber {
         // the event doesn't concern us
         if (params.config_id !== this.config_id) return;
 
-        this.initViewer();
+        // create viewer instance
+        this.viewer =
+            new ol3.Viewer(
+                this.image_config.image_info.image_id,
+                { eventbus : this.context.eventbus,
+                  server : this.context.server,
+                  initParams :  this.context.initParams,
+                  container: this.container
+        });
         this.resizeViewer({window_resize: true});
     }
 
@@ -228,23 +238,17 @@ export default class Ol3Viewer extends EventSubscriber {
     }
 
     /**
-     * Initializes the viewer to have the actual dimensions and channels
+     * Perform initialization task for the viewer
      *
+     * @param {Object} params the event notification parameters
      * @memberof Ol3Viewer
      */
-    initViewer()  {
-        // create viewer instance
-        this.viewer =
-            new ol3.Viewer(
-                this.image_config.image_info.image_id,
-                { eventbus : this.context.eventbus,
-                  server : this.context.server,
-                  initParams :  this.context.initParams,
-                  container: this.container
-        });
+    initViewer(params = {})  {
+        // the event doesn't concern us
+        if (params.config_id !== this.config_id) return;
 
-        // should we display the scale bar
-        this.showScalebar(this.context.show_scalebar);
+        // try and display the scale bar by default
+        this.showScalebar(true);
         // whould we display regions...
         this.showRegions(this.context.show_regions);
 
@@ -521,10 +525,9 @@ export default class Ol3Viewer extends EventSubscriber {
      * @memberof Ol3Viewer
      */
     showScalebar(flag) {
-        let delayedCall = function() {
-            if (this.viewer) this.viewer.toggleScaleBar(flag);
-        }.bind(this);
-        setTimeout(delayedCall, 200);
+        if (this.viewer) // if toggle fails we use null (for disable)
+            this.context.show_scalebar =
+                this.viewer.toggleScaleBar(flag) ? flag : null;
     }
 
     /**


### PR DESCRIPTION
So far the scalebar showed a lesser degree of differentiation. It now covers -like the present web- from angstrom to meters.

see also: https://trello.com/c/jzBkvdaC/24-units-of-pixels-size-missing-from-json