### PR TITLE
Thumbnails size 96

### DIFF
--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -53,13 +53,6 @@ export default class ThumbnailSlider extends EventSubscriber {
     thumbnails = [];
 
     /**
-     * the default thumbnail length
-     * @memberof ThumbnailSlider
-     * @type {Array.<Object>}
-     */
-    thumbnail_length = 96;
-
-    /**
      * the number of thumnails we request in one go
      * @memberof ThumbnailSlider
      * @type {number}
@@ -321,7 +314,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             let id = item['@id'];
             let entry = {
                 id: id,
-                url: thumbPrefix + id + "/" + this.thumbnail_length + "/",
+                url: thumbPrefix + id + "/",
                 title: typeof item.Name === 'string' ? item.Name : id,
                 revision : 0
             }

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -57,7 +57,7 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @memberof ThumbnailSlider
      * @type {Array.<Object>}
      */
-    thumbnail_length = 80;
+    thumbnail_length = 96;
 
     /**
      * the number of thumnails we request in one go

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -87,7 +87,7 @@
             <div repeat.for="rdef of rdefs"
                 class="user-settings"
                 click.delegate="applyUserSetting($index)">
-                <img src.bind="getRdefThumbUrl() + '/90/?rdefId=' + rdef.id + '&' + revision" />
+                <img src.bind="getRdefThumbUrl() + '/96/?rdefId=' + rdef.id + '&' + revision" />
                 <div>${rdef.owner.firstName + ' ' + rdef.owner.lastName}</div>
             </div>
         <div>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -87,7 +87,7 @@
             <div repeat.for="rdef of rdefs"
                 class="user-settings"
                 click.delegate="applyUserSetting($index)">
-                <img src.bind="getRdefThumbUrl() + '/96/?rdefId=' + rdef.id + '&' + revision" />
+                <img src.bind="getRdefThumbUrl() + '/?rdefId=' + rdef.id + '&' + revision" />
                 <div>${rdef.owner.firstName + ' ' + rdef.owner.lastName}</div>
             </div>
         <div>


### PR DESCRIPTION
We now use thumbnails of size ```96``` for the thumbnail slider and for rdef settings thumbnails.

This means that after saving rendering settings, or save-to-all, new thumbnails of size 96 will be requested from the server. These are cached, allowing other users in a read-only group to access thumbnails (when they can't generate their own).

See: https://trello.com/c/I6XeC3Xz/33-bug-iviewer-does-not-refresh-thumbnails

cc @pwalczysko 

To test: save settings in iviewer and check that another user in read-only group can still get thumbnails for the image. Should work for Save-To-All when Dataset thumbnails are shown on the left, and also for SPW images (no Dataset thumbnails) using Save / Save To All (Save-To-All doesn't save to Plate).