### PR TITLE
delete rois with dialog popup in case there are deleted

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1571,10 +1571,10 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
   }
 
 /**
- * Persists modified/added shapes
+ * Persists modified/added/deleted shapes
  * see: {@link ome.ol3.source.Regions.storeRegions}
  *
- * @param {boolean} selectedOnly if true only selected regions are considered
+ * @param {Array.<string>} selected an array of selected ids (of the form: roi_id:shape_id)
  * @param {boolean} useSeparateRoiForEachNewShape if false all new shapes are combined within one roi
  * @param {string} uri a server uri to post to for persistance
  * @param {boolean} omit_client_update an optional flag that's handed back to the client
@@ -1582,32 +1582,58 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * @return {boolean} true if a storage request was made, false otherwise
  */
 ome.ol3.Viewer.prototype.storeRegions =
-    function(selectedOnly,useSeparateRoiForEachNewShape, uri, omit_client_update) {
+    function(selected, useSeparateRoiForEachNewShape, uri, omit_client_update) {
 
         if (!(this.regions_ instanceof ome.ol3.source.Regions))
             return false; // no regions, nothing to persist...
 
-        selectedOnly =
-            typeof(selectedOnly) === 'boolean' ? selectedOnly : false;
+        omit_client_update =
+            typeof omit_client_update === 'boolean' && omit_client_update;
+        selected = ome.ol3.utils.Misc.isArray(selected) ? selected : [];
         useSeparateRoiForEachNewShape =
             typeof(useSeparateRoiForEachNewShape) === 'boolean' ?
                 useSeparateRoiForEachNewShape : true;
         if (typeof uri !== 'string' || uri.length === 0) uri = '/persist_rois';
 
+        var len = selected.length;
         var collectionOfFeatures =
-            (selectedOnly &&
-             this.regions_.select_) ? this.regions_.select_.getFeatures() :
-                new ol.Collection(this.regions_.getFeatures());
+            new ol.Collection(len > 0 ? selected : this.regions_.getFeatures());
+        for (var i=0;i<len;i++) {
+            var id = selected[i];
+            if (typeof this.regions_.idIndex_[id] === 'object')
+                collectionOfFeatures.push(this.regions_.idIndex_[id]);
+        };
 
         var roisAsJsonObject =
         ome.ol3.utils.Conversion.toJsonObject(
             collectionOfFeatures, useSeparateRoiForEachNewShape);
-
-        // either something happened or we don't have anything to persist
-        if (roisAsJsonObject === null || roisAsJsonObject['count'] === 0)
+        // check if we have nothing to persist, i.e. to send to the back-end
+        if (roisAsJsonObject['count'] === 0) {
+            // we may still want to clean up new but deleted shapes
+            if (!omit_client_update &&
+                roisAsJsonObject['new_and_deleted'].length > 0) {
+                    var ids = {};
+                    for (var i in roisAsJsonObject['new_and_deleted']) {
+                        var id = roisAsJsonObject['new_and_deleted'][i];
+                        if (typeof this.regions_.idIndex_[id] === 'object') {
+                            this.regions_.removeFeature(
+                                this.regions_.idIndex_[id]);
+                            ids[id] = id;
+                        }
+                    }
+                    if (this.eventbus_) {
+                        this.eventbus_.publish(
+                            "REGIONS_STORED_SHAPES", {
+                                'config_id': this.getTargetId(),
+                                'shapes': ids
+                            });
+                    }
+            }
             return false;
+        }
 
-        return this.regions_.storeRegions(roisAsJsonObject, uri, omit_client_update);
+        return this.regions_.storeRegions(
+                    roisAsJsonObject, uri, omit_client_update);
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1574,7 +1574,7 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * Persists modified/added/deleted shapes
  * see: {@link ome.ol3.source.Regions.storeRegions}
  *
- * @param {Array.<string>} selected an array of selected ids (of the form: roi_id:shape_id)
+ * @param {Array.<string>} deleted an array of ids for deletion (of the form: roi_id:shape_id)
  * @param {boolean} useSeparateRoiForEachNewShape if false all new shapes are combined within one roi
  * @param {string} uri a server uri to post to for persistance
  * @param {boolean} omit_client_update an optional flag that's handed back to the client
@@ -1582,27 +1582,30 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * @return {boolean} true if a storage request was made, false otherwise
  */
 ome.ol3.Viewer.prototype.storeRegions =
-    function(selected, useSeparateRoiForEachNewShape, uri, omit_client_update) {
+    function(deleted, useSeparateRoiForEachNewShape, uri, omit_client_update) {
 
         if (!(this.regions_ instanceof ome.ol3.source.Regions))
             return false; // no regions, nothing to persist...
 
         omit_client_update =
             typeof omit_client_update === 'boolean' && omit_client_update;
-        selected = ome.ol3.utils.Misc.isArray(selected) ? selected : [];
         useSeparateRoiForEachNewShape =
             typeof(useSeparateRoiForEachNewShape) === 'boolean' ?
                 useSeparateRoiForEachNewShape : true;
         if (typeof uri !== 'string' || uri.length === 0) uri = '/persist_rois';
 
-        var len = selected.length;
-        var collectionOfFeatures =
-            new ol.Collection(len > 0 ? selected : this.regions_.getFeatures());
-        for (var i=0;i<len;i++) {
-            var id = selected[i];
-            if (typeof this.regions_.idIndex_[id] === 'object')
-                collectionOfFeatures.push(this.regions_.idIndex_[id]);
-        };
+        var isDeleteRequest =
+            ome.ol3.utils.Misc.isArray(deleted) && deleted.length > 0;
+        var collectionOfFeatures = null;
+        if (isDeleteRequest) {
+            collectionOfFeatures = new ol.Collection();
+            for (var i=0;i<deleted.length;i++) {
+                var id = deleted[i];
+                if (typeof this.regions_.idIndex_[id] === 'object')
+                    collectionOfFeatures.push(this.regions_.idIndex_[id]);
+            };
+        } else collectionOfFeatures =
+                    new ol.Collection(this.regions_.getFeatures());
 
         var roisAsJsonObject =
         ome.ol3.utils.Conversion.toJsonObject(
@@ -1625,13 +1628,16 @@ ome.ol3.Viewer.prototype.storeRegions =
                         this.eventbus_.publish(
                             "REGIONS_STORED_SHAPES", {
                                 'config_id': this.getTargetId(),
-                                'shapes': ids
+                                'shapes': ids,
+                                'is_delete': isDeleteRequest
                             });
                     }
             }
             return false;
         }
 
+        // remember deleted ids for history removal
+        roisAsJsonObject['is_delete'] = isDeleteRequest;
         return this.regions_.storeRegions(
                     roisAsJsonObject, uri, omit_client_update);
 }

--- a/ol3-viewer/src/ome/ol3/interaction/BoxSelect.js
+++ b/ol3-viewer/src/ome/ol3/interaction/BoxSelect.js
@@ -79,7 +79,7 @@ ome.ol3.interaction.BoxSelect = function(regions_reference) {
                 if (feature.getGeometry().intersectsExtent(extent))
                     ids.push(feature.getId());
             });
-        this.regions_.setProperty(ids, "selected", true);
+        if (ids.length > 0) this.regions_.setProperty(ids, "selected", true);
     };
     this.boxEndListener_ = null;
 

--- a/ol3-viewer/src/ome/ol3/interaction/Modify.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Modify.js
@@ -76,9 +76,13 @@ ome.ol3.interaction.Modify = function(regions_reference) {
         function(event) {
             // complete history entry
             if (this.hist_id_ >= 0) {
+                var featId = event.features.array_[0].getId();
                 this.regions_.addHistory(
                     event.features.array_, false, this.hist_id_);
-                this.regions_.sendHistoryNotification(this.hist_id_);
+                this.regions_.sendHistoryNotification(
+                    this.hist_id_, [featId]);
+                this.regions_.setProperty(
+                    [featId], "state", ome.ol3.REGIONS_STATE.MODIFIED);
             }
         },this);
 };
@@ -344,8 +348,6 @@ ome.ol3.interaction.Modify.handleUpEvent_ = function(mapBrowserEvent) {
         id = segmentData.feature.getId();
     }
 
-    if (id) this.regions_.setProperty(
-        [id], "state", ome.ol3.REGIONS_STATE.MODIFIED);
     if (this.modified_) {
         this.dispatchEvent(
             new ol.interaction.Modify.Event(
@@ -353,7 +355,6 @@ ome.ol3.interaction.Modify.handleUpEvent_ = function(mapBrowserEvent) {
                 this.features_, mapBrowserEvent));
         this.modified_ = false;
     }
-    this.hist_id_ = -1; // reset
 
     return false;
 };

--- a/ol3-viewer/src/ome/ol3/interaction/Select.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Select.js
@@ -110,7 +110,7 @@ ome.ol3.interaction.Select.prototype.clearSelection = function() {
         function(feature) {
             ids.push(feature.getId());
     }, this);
-    this.regions_.setProperty(ids, "selected", false);
+    if (ids.length > 0) this.regions_.setProperty(ids, "selected", false);
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/interaction/Translate.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Translate.js
@@ -137,7 +137,7 @@ ome.ol3.interaction.Translate.prototype.handleTranslateEnd = function(event) {
 
     // complete history entry
     this.regions_.addHistory(filtered, false, this.hist_id_);
-    this.regions_.sendHistoryNotification(this.hist_id_);
+    this.regions_.sendHistoryNotification(this.hist_id_, ids);
     this.hist_id_ = -1; // reset
 
     // set modified flag

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -594,7 +594,17 @@ ome.ol3.source.Regions.prototype.storeRegions =
                             f.setId(data['ids'][id]);
                         }
                     }
+                    // tag on the newly but immediately deleted shapes
+                    for (var i in roisAsJsonObject['new_and_deleted']) {
+                        var id = roisAsJsonObject['new_and_deleted'][i];
+                        if (typeof capturedRegionsReference.idIndex_[id] === 'object') {
+                            capturedRegionsReference.removeFeature(
+                                capturedRegionsReference.idIndex_[id]);
+                                data['ids'][id] = id;
+                            }
+                    };
                 }
+
                 if (typeof data['error'] === 'string') error = data['error'];
             } catch(err) {
                 error = err;

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -573,6 +573,7 @@ ome.ol3.source.Regions.prototype.storeRegions =
             var eventbus = viewer.eventbus_;
             if (config_id && eventbus) {
                 params['config_id'] = config_id;
+                params['is_delete'] = roisAsJsonObject['is_delete'];
                 eventbus.publish("REGIONS_STORED_SHAPES", params);
             }
         }
@@ -653,6 +654,7 @@ ome.ol3.source.Regions.prototype.setProperty =
     function(roi_shape_ids, property, value, callback) {
 
     if (!ome.ol3.utils.Misc.isArray(roi_shape_ids) ||
+        roi_shape_ids.length === 0 ||
         typeof property !== 'string' ||
         typeof value === 'undefined' ||
         typeof this.idIndex_ !== 'object') return;
@@ -712,7 +714,7 @@ ome.ol3.source.Regions.prototype.setProperty =
                         !f['permissions']['canDelete']) continue;
                     eventProperty = "rollback";
                 }
-            }
+            } else eventProperty = property;
 
             // set new value
             f[property] =
@@ -726,7 +728,9 @@ ome.ol3.source.Regions.prototype.setProperty =
             if (eventProperty === 'rollback') {
                 eventProperty = 'deleted';
                 val = false;
-            } else if (eventProperty === 'deleted') val = true;
+            } else if (eventProperty === 'deleted' ||
+                       (property === 'state' && eventProperty === 'modified'))
+                            val = true;
             else val = value;
             changedProperties.push(eventProperty);
             changedValues.push(val);
@@ -773,7 +777,10 @@ ome.ol3.source.Regions.prototype.addHistory =
         var f = features[i];
         // we have a record per feature id for convenient lookup
         // if we don't have one yet, we ar going to create and add it
-        var hist_record = { old_value : null, new_value : null};
+        var hist_record = {
+            old_state: f['state'],
+            new_state: ome.ol3.REGIONS_STATE.MODIFIED,
+            old_value : null, new_value : null};
         if (typeof hist_entry[f.getId()] === 'object')
             hist_record = hist_entry[f.getId()];
         else hist_entry[f.getId()] = hist_record;
@@ -803,9 +810,17 @@ ome.ol3.source.Regions.prototype.doHistory = function(hist_id, undo) {
     for (var f in hist_entry) {
         var hist_record = hist_entry[f];
         // check if we have such as feature
-        if (this.idIndex_[f] instanceof ol.Feature)
+        if (this.idIndex_[f] instanceof ol.Feature) {
             this.idIndex_[f].setGeometry(
                 undo ? hist_record.old_value : hist_record.new_value);
+            var newState = undo ? hist_record.old_state : hist_record.new_state;
+            if (newState !== this.idIndex_[f]['state']) {
+                this.idIndex_[f]['state'] = newState;
+                this.setProperty(
+                    [this.idIndex_[f].getId()], "modified",
+                    newState !== ome.ol3.REGIONS_STATE.DEFAULT);
+            }
+        }
     }
 }
 
@@ -813,14 +828,15 @@ ome.ol3.source.Regions.prototype.doHistory = function(hist_id, undo) {
  * Sends out an event notification with the associated history id
  *
  * @param {number} hist_id the id for the history entry we like to un/redo
+ * @param {Array.<string>} ids the ids of the shapes in the history entry
  */
-ome.ol3.source.Regions.prototype.sendHistoryNotification = function(hist_id) {
+ome.ol3.source.Regions.prototype.sendHistoryNotification = function(hist_id, ids) {
     // send out notification with shape ids
     var config_id = this.viewer_.getTargetId();
     var eventbus = this.viewer_.eventbus_;
     if (config_id && eventbus) // publish
         eventbus.publish("REGIONS_HISTORY_ENTRY",
-                {"config_id": config_id, "hist_id": hist_id});
+                {"config_id": config_id, "hist_id": hist_id, "shape_ids": ids});
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -660,7 +660,7 @@ ome.ol3.utils.Conversion.toJsonObject = function(
     if (typeof returnFlattenedArray !== 'boolean') returnFlattenedArray = false;
 
     var currentNewId = -1;
-    var roisToBeStored = {"count" : 0};
+    var roisToBeStored = {"count": 0, "new_and_deleted": []};
     var rois = {};
 
     var feats = features.getArray();
@@ -696,7 +696,10 @@ ome.ol3.utils.Conversion.toJsonObject = function(
                 (typeof feature['permissions'] === 'object' &&
                  feature['permissions'] !== null &&
                  typeof feature['permissions']['canDelete'] === 'boolean' &&
-                 !feature['permissions']['canDelete'])) continue;
+                 !feature['permissions']['canDelete'])) {
+                     roisToBeStored['new_and_deleted'].push(feature.getId());
+                     continue;
+                 }
         } else if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED &&
                    typeof feature['permissions'] === 'object' &&
                    feature['permissions'] !== null &&
@@ -726,8 +729,6 @@ ome.ol3.utils.Conversion.toJsonObject = function(
         roiContainer['shapes'].push(jsonObject);
         roisToBeStored['count']++;
     };
-
-    if (roisToBeStored['count'] === 0) return null;
 
     if (returnFlattenedArray) {
         var flattenedArray = [];

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -37,7 +37,8 @@
             </div>
         </div>
     </div>
-    <div class="confirmation-dialog modal" tabindex="-1" role="dialog">
+    <div class="confirmation-dialog modal" tabindex="-1" role="dialog"
+         data-backdrop="static" data-keyboard="false">
         <div class="modal-dialog modal-sm" role="document">
             <div class="modal-content">
                 <div class="modal-header">

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -408,11 +408,12 @@ export default class ThumbnailSlider extends EventSubscriber {
                         REGIONS_STORED_SHAPES,
                         (params={}) => {
                             tmpSub.dispose();
-                            navigateToNewImage();
+                            if (params.omit_client_update) navigateToNewImage();
                     });
-                this.context.publish(
-                    REGIONS_STORE_SHAPES,
-                    {config_id : conf.id, omit_client_update: true});
+                setTimeout(()=>
+                    this.context.publish(
+                        REGIONS_STORE_SHAPES,
+                        {config_id : conf.id, omit_client_update: true}), 20);
             };
 
             UI.showConfirmationDialog(

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -412,7 +412,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                     });
                 this.context.publish(
                     REGIONS_STORE_SHAPES,
-                    {config_id : conf.id, selected: false, omit_client_update: true});
+                    {config_id : conf.id, omit_client_update: true});
             };
 
             UI.showConfirmationDialog(

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -868,8 +868,8 @@ thumbnail-slider img {
     background-position: center!important;
 }
 .arrow-button .dropdown-menu {
-    left: -13px;
-    min-width: 62px;
+    left: -15px;
+    min-width: 70px;
 }
 .arrow-button .dropdown-menu span {
     display: inline-block;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -969,18 +969,11 @@ thumbnail-slider img {
 .modal-message .ok {
     width: 50px;
 }
-.confirmation_dialog .modal-title {
-    margin: 5px;
-}
-.confirmation_dialog .close {
-    margin-top: 5px;
-    margin-right: 8px;
-}
-.confirmation_dialog .modal-header {
-    padding: 2px;
-}
 .modal-footer {
     padding: 4px;
+}
+.modal-open .modal {
+    overflow-y: hidden;
 }
 
 .text-weight-bold {

--- a/src/model/regions_history.js
+++ b/src/model/regions_history.js
@@ -165,14 +165,17 @@ export default class RegionsHistory {
 
     /**
      * Undoes the last action
+     * @param {boolean} remove delete history entry after action (default: false)
      * @memberof History
      */
-    undoHistory() {
+    undoHistory(remove=false) {
         if (!this.canUndo()) return;
 
         let entry = this.history[this.historyPointer];
         // converge
         this.doHistory(entry, true);
+        if (typeof remove === 'boolean' && remove)
+            this.history.splice(this.historyPointer, 1);
         //adjust pointer
         this.historyPointer--;
     }

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -483,4 +483,14 @@ export default class RegionsInfo extends EventSubscriber {
                 !shape['permissions'][permission]);
     }
 
+    /**
+     * Returns the number of deleted shapes
+     *
+     * @return {number} the number of deleted shapes
+     * @memberof RegionsEdit
+     */
+    getNumberOfDeletedShapes() {
+        return this.unsophisticatedShapeFilter(
+            ["deleted"], [true], ['canDelete']).length;
+    }
 }

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -249,8 +249,8 @@ export default class RegionsEdit extends EventSubscriber {
                 shape.FontFamily : 'sans-serif';
         deltaProps.FontSize = {
             '@type': 'TBD#LengthI',
-            'Unit': 'PIXEL',
-            'Symbol': 'pixel',
+            'Unit': 'POINT',
+            'Symbol': 'pt',
             'Value': size
         };
 
@@ -465,17 +465,19 @@ export default class RegionsEdit extends EventSubscriber {
      */
     adjustCommentEdit(canDo=false, showDisabled=true) {
         let editComment = $(this.element).find(".shape-edit-comment input");
-        editComment.off('input');
+        editComment.off();
         editComment.val('Comment');
         editComment.attr('title',"");
         if (this.last_selected) {
             editComment.val(
                 typeof this.last_selected.Text === 'string' ?
                     this.last_selected.Text : '');
-            editComment.on('input',
-                (event) =>
+            editComment.on('change keyup',
+                (event) => {
+                    if (event.type === 'keyup' && event.keyCode !== 13) return;
                     this.onCommentChange(
-                        event.target.value, this.last_selected));
+                        event.target.value, this.last_selected)
+                });
             editComment.prop("disabled", showDisabled);
             if (showDisabled)
                 editComment.attr('title', PERMISSION_TOOLTIPS.CANNOT_EDIT);
@@ -488,11 +490,14 @@ export default class RegionsEdit extends EventSubscriber {
                  typeof this.last_selected.FontSize.Value === 'number' ?
                 this.last_selected.FontSize.Value : 10) : 10;
         let fontSizeSpinner = $(this.element).find(".shape-font-size input");
-        fontSizeSpinner.off("input spinstop");
+        fontSizeSpinner.off();
         fontSizeSpinner.spinner("value", fontSize);
-        fontSizeSpinner.on("input spinstop",
-           (event, ui) => this.onFontSizeChange(
-               parseInt(event.target.value), this.last_selected));
+        fontSizeSpinner.on("change keyup spinstop",
+            (event, ui) => {
+               if (event.type === 'keyup' && event.keyCode !== 13) return;
+               this.onFontSizeChange(
+                   parseInt(event.target.value), this.last_selected)
+            });
         fontSizeSpinner.spinner(canDo ? "enable" : "disable");
         fontSizeSpinner.attr(
             'title', showDisabled ? PERMISSION_TOOLTIPS.CANNOT_EDIT : "");
@@ -655,7 +660,7 @@ export default class RegionsEdit extends EventSubscriber {
 
         let strokeWidthSpinner =
             $(this.element).find(".shape-stroke-width input");
-        strokeWidthSpinner.off("input spinstop");
+        strokeWidthSpinner.off();
         strokeWidthSpinner.attr("title", "");
         strokeWidthSpinner.spinner("enable");
         if (type === 'label') {
@@ -663,9 +668,12 @@ export default class RegionsEdit extends EventSubscriber {
             strokeWidthSpinner.spinner("disable");
         } else {
             strokeWidthSpinner.spinner("value", strokeWidth);
-            strokeWidthSpinner.on("input spinstop",
-               (event, ui) => this.onStrokeWidthChange(
-                   parseInt(event.target.value), this.last_selected));
+            strokeWidthSpinner.on("change keyup spinstop",
+               (event, ui) => {
+                   if (event.type === 'keyup' && event.keyCode !== 13) return;
+                   this.onStrokeWidthChange(
+                       parseInt(event.target.value), this.last_selected)
+               });
         }
         this.setDrawColors(strokeOptions.color, false);
         if (showDisabled) {
@@ -935,7 +943,7 @@ export default class RegionsEdit extends EventSubscriber {
             () => this.context.publish( // trigger storage routine
                 REGIONS_STORE_SHAPES,
                 {config_id : this.regions_info.image_info.config_id,
-                 selected: ids}),
+                 deleted: ids}),
             () => {
                 history.undoHistory(true);
                 this.context.publish(

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -26,9 +26,9 @@ import {
     REGIONS_MODE, REGIONS_DRAWING_MODE, PERMISSION_TOOLTIPS
 } from '../utils/constants';
 import {
-    EventSubscriber,
-    IMAGE_CONFIG_UPDATE, IMAGE_DIMENSION_CHANGE, REGIONS_COPY_SHAPES,
-    REGIONS_GENERATE_SHAPES, REGIONS_MODIFY_SHAPES, REGIONS_SET_PROPERTY
+    EventSubscriber, IMAGE_CONFIG_UPDATE, IMAGE_DIMENSION_CHANGE,
+    REGIONS_COPY_SHAPES, REGIONS_GENERATE_SHAPES, REGIONS_MODIFY_SHAPES,
+    REGIONS_SET_PROPERTY, REGIONS_STORE_SHAPES
 } from '../events/events';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {spectrum} from 'spectrum-colorpicker';
@@ -926,8 +926,24 @@ export default class RegionsEdit extends EventSubscriber {
                     old_vals: true, new_vals: false});
             this.adjustEditWidgets();
         };
-
         this.context.publish(REGIONS_SET_PROPERTY, opts);
-    }
 
+        // ask if we should delete immediately
+        Ui.showConfirmationDialog(
+            "Delete Selected Rois",
+            "Do you really want to delete?",
+            () => this.context.publish( // trigger storage routine
+                REGIONS_STORE_SHAPES,
+                {config_id : this.regions_info.image_info.config_id,
+                 selected: ids}),
+            () => {
+                history.undoHistory(true);
+                this.context.publish(
+                   REGIONS_SET_PROPERTY, {
+                       config_id: this.regions_info.image_info.config_id,
+                       property: 'selected', shapes : ids,
+                    clear: false, value : true, center : false
+                });
+            }, false);
+    }
 }

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -28,7 +28,7 @@ import {
 import {
     EventSubscriber, IMAGE_CONFIG_UPDATE, IMAGE_DIMENSION_CHANGE,
     REGIONS_COPY_SHAPES, REGIONS_GENERATE_SHAPES, REGIONS_MODIFY_SHAPES,
-    REGIONS_SET_PROPERTY, REGIONS_STORE_SHAPES
+    REGIONS_SET_PROPERTY
 } from '../events/events';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {spectrum} from 'spectrum-colorpicker';

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -935,23 +935,5 @@ export default class RegionsEdit extends EventSubscriber {
             this.adjustEditWidgets();
         };
         this.context.publish(REGIONS_SET_PROPERTY, opts);
-
-        // ask if we should delete immediately
-        Ui.showConfirmationDialog(
-            "Delete Selected Rois",
-            "Do you really want to delete?",
-            () => this.context.publish( // trigger storage routine
-                REGIONS_STORE_SHAPES,
-                {config_id : this.regions_info.image_info.config_id,
-                 deleted: ids}),
-            () => {
-                history.undoHistory(true);
-                this.context.publish(
-                   REGIONS_SET_PROPERTY, {
-                       config_id: this.regions_info.image_info.config_id,
-                       property: 'selected', shapes : ids,
-                    clear: false, value : true, center : false
-                });
-            }, false);
     }
 }

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -130,8 +130,7 @@ export default class Regions {
 
         this.context.publish(
             REGIONS_STORE_SHAPES,
-            {config_id : this.regions_info.image_info.config_id,
-                selected: false});
+            {config_id : this.regions_info.image_info.config_id});
     }
 
     /**

--- a/src/utils/regions.js
+++ b/src/utils/regions.js
@@ -160,7 +160,7 @@ export class Utils {
              !Misc.isArray(updates.values) ||
              updates.values.length !== updates.properties.length) return null;
 
-        let callback = (shape) => {
+        let callback = (shape, hasBeenModified) => {
             if (typeof shape !== 'object' || shape === null) return;
 
             let oldVals = [];
@@ -169,11 +169,24 @@ export class Utils {
                 let prop = updates.properties[i];
                 let old_value =
                     typeof shape[prop] !== 'undefined' ? shape[prop] : null;
-                if (old_value !== updates.values[i]) allPropertiesEqual = false;
+                if (typeof old_value === 'object' &&
+                    typeof updates.values[i] === 'object' &&
+                    old_value !== null && updates.values[i] !== null) {
+                    for (let p in old_value)
+                        if (typeof updates.values[i][p] === undefined ||
+                            old_value[p] !== updates.values[i][p])
+                                allPropertiesEqual = false;
+                } else if (old_value !== updates.values[i])
+                    allPropertiesEqual = false;
                 oldVals.push(old_value);
                 shape[prop] = updates.values[i];
             };
             if (history.hist instanceof RegionsHistory && !allPropertiesEqual) {
+                if (typeof hasBeenModified === 'boolean') {
+                    updates.properties.push("modified");
+                    oldVals.push(hasBeenModified);
+                    updates.values.push(shape.modified);
+                }
                 if (typeof history.hist_id !== 'number') history.hist_id = -1;
                 history.hist.addHistory(
                     history.hist_id, history.hist.action.PROPERTIES,

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -256,23 +256,30 @@ export default class Ui {
      * @param {string} content goes into the body of the dialog
      * @param {function} yes a handler that's executed on clicking yes
      * @param {function} no an optional handler that's executed on clicking no
+     * @param {boolean} can_close if true we allow closing by esc key and X click
      * @static
      */
-     static showConfirmationDialog(title='', content='', yes = null, no = null) {
+     static showConfirmationDialog(
+         title='', content='', yes = null, no = null, can_close = true) {
          if (typeof title !== 'string') title = 'Confirmation';
          if (typeof content !== 'string') content = '';
          if (typeof yes !== 'function') yes = null;
          if (typeof no !== 'function') no = null;
+         if (typeof can_close !== 'boolean') can_close = true;
 
          let dialog = $('.confirmation-dialog');
          if (dialog.length === 0) return;
+
+         if (can_close) dialog.find('.modal-header .close').show();
+         else dialog.find('.modal-header .close').hide();
+
          dialog.find('.modal-title').html(title);
          dialog.find('.modal-body').html(content);
 
          // set up handlers and reset routine on close
-         dialog.on('hidden.bs.modal', () => Ui.resetConfirmationDialog());
          let handlers = [".yes", ".no"];
          handlers.map((h) => {
+             dialog.find(h).off();
              dialog.find(h).on('click', () => {
                  if (h === '.yes' && yes) yes();
                  if (h === '.no' && no) no();
@@ -282,23 +289,6 @@ export default class Ui {
 
          dialog.modal();
      }
-
-     /**
-      * Resets the bootstrap modal confirmation dialog
-      *
-      * @static
-      */
-      static resetConfirmationDialog() {
-          let dialog = $('.confirmation_dialog');
-          if (dialog.length === 0) return;
-
-          dialog.find('.modal-title').html("Confirmation");
-          dialog.find('.modal-body').html("");
-
-          dialog.find('.yes').off();
-          dialog.find('.no').off();
-          dialog.off('hidden.bs.modal');
-      }
 
       /**
        * Scrolls the regions table to the row with the given id

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -587,15 +587,12 @@ export default class Ol3Viewer extends EventSubscriber {
         // the event doesn't concern us
         if (params.config_id !== this.config_id) return;
 
-        // should we only persist the selected ones
-        let selectedOnly =
-            typeof params.selected === 'boolean' && params.selected;
-
         let requestMade =
             this.viewer.storeRegions(
-                selectedOnly, false,
+                Misc.isArray(params.selected) ? params.selected : [], false,
                 this.context.getPrefixedURI(IVIEWER) + '/persist_rois',
                 params.omit_client_update);
+                
         if (requestMade) Ui.showModalMessage("Saving Regions. Please wait...");
         else if (params.omit_client_update)
             this.context.eventbus.publish(

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -588,16 +588,32 @@ export default class Ol3Viewer extends EventSubscriber {
         // the event doesn't concern us
         if (params.config_id !== this.config_id) return;
 
-        let requestMade =
-            this.viewer.storeRegions(
-                Misc.isArray(params.deleted) ? params.deleted : [], false,
-                this.context.getPrefixedURI(IVIEWER) + '/persist_rois',
-                params.omit_client_update);
+        let numberOfdeletedShapes =
+            this.image_config.regions_info.getNumberOfDeletedShapes(true);
+        let storeRois = () => {
+            let requestMade =
+                this.viewer.storeRegions(
+                    Misc.isArray(params.deleted) ? params.deleted : [], false,
+                    this.context.getPrefixedURI(IVIEWER) + '/persist_rois',
+                    params.omit_client_update);
 
-        if (requestMade) Ui.showModalMessage("Saving Regions. Please wait...");
-        else if (params.omit_client_update)
-            this.context.eventbus.publish(
-                "REGIONS_STORED_SHAPES", { omit_client_update: true});
+            if (requestMade) Ui.showModalMessage("Saving Regions. Please wait...");
+            else if (params.omit_client_update)
+                this.context.eventbus.publish(
+                    "REGIONS_STORED_SHAPES", { omit_client_update: true});
+        };
+
+        if (numberOfdeletedShapes > 0) {
+            Ui.showConfirmationDialog(
+                'Save ROIS?',
+                'Saving your changes includes the deletion of ' +
+                numberOfdeletedShapes + ' ROIs. Do you want to continue?',
+                storeRois, () => {
+                    if (params.omit_client_update)
+                        this.context.eventbus.publish(
+                            "REGIONS_STORED_SHAPES", { omit_client_update: false});
+                });
+        } else storeRois();
     }
 
     /**


### PR DESCRIPTION
UPDATE: It's been decided to revert to the old behavior of deletion with the need to save explicitly to persist them. No persistence request is sent when clicking delete on selected shapes !!!!!!

~~Instead of persisting the removal of shapes on explicit save a dialog they can now be deleted straight away.~~ When clicking save a dialog is displayed asking for confirmation of action if the action includes deleted rois. If confirmed the save continues, otherwise aborted to give the user a chance to undo their actions via the history (undo/redo).

_It was necessary to make the following changes to the history:_
- _with other shapes in an unsaved state a clearing of history cannot happen after delete (as does after save)_
- _any shape before deletion could have been modified (style,attachment or position/geometry) which would have led to a history entry for undo/redo. with the shape gone these entries had to be removed as well._

_NOTE: the changes above (done for the original purpose of immediate persistence of deletion) have no bearing on the reverted behavior since immediate delete is not used any more._

while working on the above changes I also came across other things that needed improving/fixing:
- the blue color in the rois table to indicate that these shapes have been modified did not revert after undoing all changes
- the input field behavior was not the same as with attachment input and the channel settings inputs in so far as that it worked on the event 'input' (which also generated unnecessary history entries for comment changes on every key press for example) instead of 'change' or hitting enter/return/tab. 
- the dropdown menu for editing arrow heads was too narrow