### PR TITLE
increase untiled retrieval limit

### DIFF
--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -351,7 +351,7 @@ ome.ol3.RENDER_STATUS = {
 };
 
 /**
- * Limit for untiled image retrieval: 2K^2
+ * Limit for untiled image retrieval: 1K^2
  * @const
  * @enum {number}
  */

--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -355,7 +355,7 @@ ome.ol3.RENDER_STATUS = {
  * @const
  * @enum {number}
  */
-ome.ol3.UNTILED_RETRIEVAL_LIMIT = 4000000;
+ome.ol3.UNTILED_RETRIEVAL_LIMIT = 1000000;
 
 goog.exportSymbol(
     'ome.ol3.REGIONS_MODE',

--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -350,6 +350,13 @@ ome.ol3.RENDER_STATUS = {
     "ERROR" : 3
 };
 
+/**
+ * Limit for untiled image retrieval: 2K^2
+ * @const
+ * @enum {number}
+ */
+ome.ol3.UNTILED_RETRIEVAL_LIMIT = 4000000;
+
 goog.exportSymbol(
     'ome.ol3.REGIONS_MODE',
     ome.ol3.REGIONS_MODE,

--- a/ol3-viewer/src/ome/ol3/source/Image.js
+++ b/ol3-viewer/src/ome/ol3/source/Image.js
@@ -171,7 +171,8 @@ ome.ol3.source.Image = function(options) {
      */
     this.use_tiled_retrieval_ =
         !this.split_ &&
-            (this.tiled_ || (this.width_* this.height_) > (1000 * 1000));
+            (this.tiled_ ||
+                (this.width_* this.height_) > ome.ol3.UNTILED_RETRIEVAL_LIMIT);
     if (!this.use_tiled_retrieval_) // 1 tile with image dimensions
         opts.tile_size = { width: this.width_, height: this.height_};
 


### PR DESCRIPTION
see: https://trello.com/c/stAlbSTI/32-bug-middle-sized-images-do-not-render-correctly

The new limit for retrieving images in an untiled fashion (unless they are tiled to begin with) is: 2K^2