### PR TITLE
paste of copied shapes will get their own roi folder

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1458,7 +1458,7 @@ ome.ol3.Viewer.prototype.generateShapes =
             setTimeout(function() {
                 var newRegionsObject =
                     ome.ol3.utils.Conversion.toJsonObject(
-                        new ol.Collection(generatedShapes), false, true);
+                        new ol.Collection(generatedShapes), true, true);
                 if (typeof newRegionsObject !== 'object' ||
                     !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
                     newRegionsObject['rois'].length === 0) return;

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -899,7 +899,7 @@ export default class RegionsEdit extends EventSubscriber {
             REGIONS_GENERATE_SHAPES,
             {config_id : this.regions_info.image_info.config_id,
                 shapes : this.regions_info.copied_shapes,
-                number : 1, random : true, hist_id : hist_id
+                number : 1, random : true, hist_id : hist_id, paste: true
             });
     }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -387,7 +387,10 @@ export default class Ol3Viewer extends EventSubscriber {
                                     Converters.amendShapeDefinition(upToDateDef);
                           }
                           delete deepCopy['shape_id'];
-                          deepCopy['roi_id'] = params.roi_id;
+                          if (typeof params.paste === 'boolean' && params.paste)
+                            deepCopy['roi_id'] =
+                                this.image_config.regions_info.getNewRegionsId();
+                          else deepCopy['roi_id'] = params.roi_id;
                           this.viewer.generateShapes(deepCopy,
                               params.number, params.random, extent, theDims,
                               params.add_history, params.hist_id);


### PR DESCRIPTION
So far if more than one shape was generated shapes were assigned their own roi container, this has been changed now to 1 shape per roi.

Requested in: https://trello.com/c/GqokGSWB/31-feedback