### PR TITLE
T slider with visibility: hidden blocks scalebar and birdeye view interaction

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -540,11 +540,9 @@ ome.ol3.Viewer.prototype.bootstrapOpenLayers = function(postSuccessHook, initHoo
        view: view
     });
 
-    // expand bird's eye view for tiles sources
-    if (source.use_tiled_retrieval_ && this.viewerState_["birdseye"] &&
-       this.viewerState_["birdseye"]['ref']
-           instanceof ome.ol3.controls.BirdsEye)
-               this.viewerState_["birdseye"]['ref'].setCollapsed(false);
+    // collapse/expand bird's eye view depending on whether we have tile sources
+    this.viewerState_["birdseye"]['ref'].setCollapsed(
+        !source.use_tiled_retrieval_);
     // enable scalebar by default
     this.toggleScaleBar(true);
 
@@ -1838,7 +1836,13 @@ ome.ol3.Viewer.prototype.redraw = function(delay) {
     if (this.viewer_) {
         var update =
             function() {
-                if (this.viewer_) this.viewer_.updateSize();
+                if (this.viewer_) {
+                    this.viewer_.updateSize();
+                    if (this.viewerState_["birdseye"] &&
+                        this.viewerState_["birdseye"]['ref']
+                           instanceof ome.ol3.controls.BirdsEye)
+                                this.viewerState_["birdseye"]['ref'].ovmap_.updateSize();
+                }
             }.bind(this);
 
         if (typeof delay !== 'number' || delay <= 0) {

--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -124,7 +124,7 @@ ome.ol3.AVAILABLE_VIEWER_CONTROLS = {
          "links" : []},
     "birdseye" :
         {"clazz" : ome.ol3.controls.BirdsEye,
-        "options": {collapsed : true, collapseLabel : "»", label: "«"},
+        "options": {collapsed : false, collapseLabel : "»", label: "«"},
         "defaults": true,
         "enabled": true,
         "links" : []},

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -130,29 +130,7 @@ export default class DimensionSlider extends EventSubscriber {
             // get rid of slider
             $(this.elSelector).slider( "destroy" );
         } catch (ignored) {}
-        this.hide();
-    }
-
-    /**
-     * Shows slider using display or visibility css
-     *
-     * @memberof DimensionSlider
-     * @param {boolean} use_display use css display instead of visibility
-     */
-    show(use_display=false) {
-        if (use_display) $(this.element).show();
-        else $(this.element).css('visibility', 'visible');
-    }
-
-    /**
-     * Hides slider using display or visibility css
-     *
-     * @memberof DimensionSlider
-     * @param {boolean} use_display use css display instead of visibility
-     */
-    hide(use_display=false) {
-        if (use_display) $(this.element).hide();
-        else $(this.element).css('visibility', 'hidden');
+        $(this.element).hide()
     }
 
     /**
@@ -298,7 +276,7 @@ export default class DimensionSlider extends EventSubscriber {
             change: (event, ui) => this.onChange(ui.value,
                 event.originalEvent ? true : false)
         });
-        this.show();
+        $(this.element).show();
     }
 
     /**

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -255,7 +255,7 @@ export default class DimensionSlider extends EventSubscriber {
                 let newDimVal = Math.round(ui.value);
                 let sliderTip =
                     this.dim.toUpperCase() + ":" + (newDimVal+1);
-                if (imgInf.image_delta_t.length > 0 &&
+                if (this.dim === 't' && imgInf.image_delta_t.length > 0 &&
                     newDimVal < imgInf.image_delta_t.length)
                         sliderTip += " [" + imgInf.image_delta_t[newDimVal] + "]";
                 sliderValueSpan.text(sliderTip);

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -210,6 +210,9 @@ a.ui-button:active,
     margin-top: -35px;
     position: relative;
 }
+.center-row2-hidden {
+    display: none;
+}
 
 .slider-value {
     position: relative;
@@ -221,7 +224,7 @@ a.ui-button:active,
 
 /* Z/T sliders */
 .plane-slider, .time-slider {
-    visibility: hidden;
+    display: none;
     position: absolute;
 }
 

--- a/src/css/ol3-viewer.css
+++ b/src/css/ol3-viewer.css
@@ -233,6 +233,7 @@
     border: 1px solid #ccc;
 }
 .ol-overviewmap:not(.ol-collapsed) button {
+    background-color: #fff;
     bottom: 1px;
     right: 1px;
     position: absolute;

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -34,8 +34,10 @@
         </div>
     </div>
 
-    <div class="center-row2
-                ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}">
+    <div class="${image_config.image_info.dimensions.max_t > 1 ?
+                    'center-row2' : 'center-row2-hidden'}
+                ${image_config.image_info.dimensions.max_z > 1 ?
+                    'show-zSlider' : ''}">
             <dimension-slider
                 config_id.bind="config_id"
                 dim="t"


### PR DESCRIPTION
see: https://trello.com/c/GqokGSWB/31-feedback

Due to the hidden t slider being in the dom layout still with absolute placement it 'obscured' the ui controls underneath (in terms of mouse events). Using css 'display' instead of 'visibility' should fix that.

TEST: Check that the birdeye collapse (toggle) button in the bottom right hand corner of the viewport can be clicked and toggles the birdeye visibility. Check that the scalbar can be grabbed and dragged anywhere in the viewport (before it was only moveable under the t-slider element)
Note: This problem actually only showed in images that had no t-slider/time points but it's recommended that you check all 3 possiblilies: no sliders (z/t), one z slider (no t), one 1-slider (no z), just to confirma that there are no layout side-effects.