### PR TITLE
Bump the size

### DIFF
--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -351,11 +351,11 @@ ome.ol3.RENDER_STATUS = {
 };
 
 /**
- * Limit for untiled image retrieval: 1K^2
+ * Limit for untiled image retrieval: 2K^2
  * @const
  * @enum {number}
  */
-ome.ol3.UNTILED_RETRIEVAL_LIMIT = 1000000;
+ome.ol3.UNTILED_RETRIEVAL_LIMIT = 4000000;
 
 goog.exportSymbol(
     'ome.ol3.REGIONS_MODE',


### PR DESCRIPTION
still being torn with size
We will look into improving the data loading speed in the next version e.g. load image details using new API instead of webgateway
Those changes have already been tested see https://github.com/ome/omero-iviewer/pull/75