### PR TITLE
Update docs links in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,6 @@ For further options type ``ant -p``.
 
 More detailed resources on how to create a web app and development setup can be found at:
 
-1. `CreateApp <https://www.openmicroscopy.org/site/support/omero5.2/developers/Web/CreateApp.html>`_
-2. `Deployment <https://www.openmicroscopy.org/site/support/omero5.2/developers/Web/Deployment.html>`_
+1. `CreateApp <https://www.openmicroscopy.org/site/support/omero5/developers/Web/CreateApp.html>`_
+2. `Deployment <https://www.openmicroscopy.org/site/support/omero5/developers/Web/Deployment.html>`_
 


### PR DESCRIPTION
Using 5.2 link was incorrect as this is 5.3.x supported, general omero5 links mean we won't have to keep updating them.