### PR TITLE
iviewer plugin view requests missing prefix

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -294,7 +294,7 @@ export default class Context {
             typeof params[URI_PREFIX] === 'string' ?
                 Misc.prepareURI(params[URI_PREFIX]) : "";
         this.prefixed_uris.set(URI_PREFIX, prefix);
-        this.prefixed_uris.set(IVIEWER, APP_NAME);
+        this.prefixed_uris.set(IVIEWER, prefix + "/" + APP_NAME);
         this.prefixed_uris.set(PLUGIN_PREFIX, prefix + "/" + PLUGIN_NAME);
         [WEB_API_BASE, WEBGATEWAY, WEBCLIENT].map(
             (key) =>


### PR DESCRIPTION
Fixes a regression bug introduced in: https://github.com/ome/omero-iviewer/pull/63

With webtrial unavailable this can only be tested locally which is how it was missed initially since the initial image data request was made to the webgateway at that point in time but then changed to be a view method of the plugin.