### PR TITLE
Projection interval

### DIFF
--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -436,9 +436,17 @@ export default class DimensionSlider {
         if (this.player_info.handle !== null) return;
 
         let imgInf = this.image_config.image_info;
-        imgInf.projection_opts.start = imgInf.dimensions[this.dim];
-        imgInf.projection_opts.end = imgInf.dimensions['max_' + this.dim]-1;
-
+        imgInf.projection_opts.start = 0;
+        let diff = 0;
+        imgInf.projection_opts.end = imgInf.dimensions['max_' + this.dim] - 1;
+        diff = imgInf.dimensions[this.dim]-5;
+        if (diff > 0) {
+            imgInf.projection_opts.start = diff;
+        }
+        diff =  imgInf.dimensions[this.dim]+5;
+        if (diff < imgInf.dimensions['max_' + this.dim] - 1) {
+            imgInf.projection_opts.end = diff;
+        }
         this.add_projection_history = true;
         imgInf.projection =
             imgInf.projection === PROJECTION.NORMAL ?

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -348,17 +348,29 @@ export default class ImageInfo {
                     initialProjection.toLowerCase() :
                     response.rdefs.projection);
         this.projection = initialProjection.projection;
-        this.projection_opts = {
-            start:
-                typeof initialProjection.start === 'number' &&
+
+        let v_s = 0, diff = 0, v_e = this.dimensions.max_z - 1;
+        if (typeof initialProjection.start === 'number' &&
                 initialProjection.start >= 0 &&
-                initialProjection.start < this.dimensions.max_z ?
-                    initialProjection.start : this.dimensions.z,
-            end:
-                typeof initialProjection.end === 'number' &&
+                initialProjection.start < this.dimensions.max_z) {
+            v_s = initialProjection.start;
+        } else {
+            diff = this.dimensions.z-5;
+            if (diff > 0) v_s = diff;
+        }
+            
+        if (typeof initialProjection.end === 'number' &&
                 initialProjection.end >= 0 &&
-                initialProjection.end < this.dimensions.max_z ?
-                    initialProjection.end : this.dimensions.max_z - 1
+                initialProjection.end < this.dimensions.max_z) {
+                v_e = initialProjection.end;
+        } else {
+            diff =  this.dimensions.z+5;
+            if (diff < this.dimensions.max_z - 1)
+                v_e = diff;
+        }
+        this.projection_opts = {
+            start: v_s,
+            end: v_e
         };
         if (this.dimensions.max_z > 1 &&
             this.projection_opts.start >= this.projection_opts.end)


### PR DESCRIPTION
Change the way the projection interval is set
The approach matches the one in figure

To test:

Test 1
 * Open an image with more than 10 z-sections
 * move the slider in the middle of example
 * Click the Projection button
 * The interval should be set to value-5, value+5

Test 2:
 * Move the slider to a value < 5
 * The interval should be 0, value+5

Test 3:
 * Move the slider to a value > max-5
 * The interval should be value-5,  max

https://trello.com/c/DxUKov4y/7-intensity-projection-range-selection
cc @pwalczysko 