### PR TITLE
calculate length and area measures in ol3

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1461,6 +1461,8 @@ ome.ol3.Viewer.prototype.generateShapes = function(shape_info, options) {
                 !this.getRegions().rotate_text_)
             f.getGeometry().rotate(-rot);
             ome.ol3.utils.Style.updateStyleFunction(f, this.regions_, true);
+        // calculate measurements
+        this.getRegions().getLengthAndAreaForShape(f, true);
     }
     this.getRegions().addFeatures(generatedShapes);
 
@@ -2023,6 +2025,32 @@ ome.ol3.Viewer.prototype.enableSmoothing = function(smoothing) {
     this.viewer_.updateSize();
 }
 
+/**
+ * Returns the area and length values for given shapes
+ * @param {Array.<string>} ids the shape ids in the format roi_id:shape_id
+ * @param {boolean} recalculate flag: if true we redo the measurement (default: false)
+ * @return {Array.<Object>} an array of objects containing shape id, area and length
+ */
+ome.ol3.Viewer.prototype.getLengthAndAreaForShapes = function(ids, recalculate) {
+    var regions = this.getRegions();
+    if (regions === null || !ome.ol3.utils.Misc.isArray(ids) ||
+        ids.length === 0) return [];
+
+    var ret = [];
+    for (var x=0;x<ids.length;x++) {
+        if (typeof ids[x] !== 'string' ||
+            typeof regions.idIndex_ !== 'object' ||
+            !(regions.idIndex_[ids[x]] instanceof ol.Feature)) continue;
+        // delegate
+        var measurement =
+            regions.getLengthAndAreaForShape(regions.idIndex_[ids[x]], recalculate);
+        if (measurement !== null) ret.push(measurement);
+    }
+
+    return ret;
+}
+
+
 /*
  * This section determines which methods are exposed and usable after compilation
  */
@@ -2215,3 +2243,8 @@ goog.exportProperty(
     ome.ol3.Viewer.prototype,
     'enableSmoothing',
     ome.ol3.Viewer.prototype.enableSmoothing);
+
+goog.exportProperty(
+    ome.ol3.Viewer.prototype,
+    'getLengthAndAreaForShapes',
+    ome.ol3.Viewer.prototype.getLengthAndAreaForShapes);

--- a/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
+++ b/ol3-viewer/src/ome/ol3/controls/ScaleBar.js
@@ -31,27 +31,6 @@ ome.ol3.controls.ScaleBar = function(opt_options) {
     if (typeof(opt_options) !== 'object') opt_options = {};
 
     /**
-     * list available units for display incl. symbol, threshold for usage
-     * and micron multiplication factor
-     *
-     * @type {Array.<objects>}
-     * @private
-     */
-    this.UNITS = [
-        { unit: 'angstrom',
-          threshold: 0.1, multiplier: 10000, symbol: '\u212B'},
-        { unit: 'nanometer',
-          threshold: 1, multiplier: 1000, symbol: 'nm'},
-        { unit: 'micron',
-          threshold: 1000, multiplier: 1, symbol:  '\u00B5m'},
-        { unit: 'millimeter',
-          threshold: 100000, multiplier: 0.001, symbol: 'mm'},
-        { unit: 'centimeter',
-          threshold: 1000000, multiplier: 0.0001, symbol: 'cm'},
-        { unit: 'meter',
-          threshold: 100000000, multiplier: 0.000001, symbol: 'm'}];
-
-    /**
      * default scale bar width in pixels
      * @type {number}
      * @private
@@ -121,8 +100,8 @@ ome.ol3.controls.ScaleBar.prototype.updateElement_ = function() {
   var resolution = viewState.resolution;
   var scaleBarLengthInUnits = micronsPerPixel * this.bar_width_ * resolution;
   var symbol = '\u00B5m';
-  for (var u=0;u<this.UNITS.length;u++) {
-      var unit = this.UNITS[u];
+  for (var u=0;u<ome.ol3.UNITS_LENGTH.length;u++) {
+      var unit = ome.ol3.UNITS_LENGTH[u];
       if (scaleBarLengthInUnits < unit.threshold) {
           scaleBarLengthInUnits *= unit.multiplier;
           symbol = unit.symbol;

--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -69,6 +69,132 @@ ome.ol3.PREFIXED_URIS =
     [ome.ol3.WEB_API_BASE, ome.ol3.WEBCLIENT, ome.ol3.WEBGATEWAY];
 
 /**
+ * Limit for untiled image retrieval: 2K^2
+ * @const
+ * @type {number}
+ */
+ome.ol3.UNTILED_RETRIEVAL_LIMIT = 4000000;
+
+/**
+ * Enum for RequestParams.
+ * @static
+ * @enum {string}
+ */
+ome.ol3.REQUEST_PARAMS = {
+    CHANNELS: 'C',
+    CENTER_X: 'X',
+    CENTER_Y: 'Y',
+    IMAGE_ID : 'IMAGE_ID',
+    MAPS: 'MAPS',
+    MODEL: 'M',
+    PLANE: 'Z',
+    PROJECTION: 'P',
+    SERVER: 'SERVER',
+    TIME: 'T',
+    ZOOM: 'ZM'
+};
+
+/**
+ * Enum for RegionsState.
+ * @static
+ * @enum {number}
+ */
+ome.ol3.REGIONS_STATE = {
+    /** the original state */
+    "DEFAULT" : 0,
+    /** the changed state */
+    "MODIFIED" : 1,
+    /** the new state */
+    "ADDED" : 2,
+    /** the deleted state */
+    "REMOVED" : 3,
+    /** a state used for rollback */
+    "ROLLBACK" : 4
+};
+
+/**
+ * Enum for RegionsMode.
+ * Depending on the mode, various interactions will be active.
+ * <p>
+ * Note, however, that some modes are inclusive and others mutually exclusive!
+ * </p>
+ * <ul>
+ * <li>DEFAULT: means no interaction at all. Takes precendence over any other and is mutually exclusive with any others</li>
+ * <li>SELECT: means that features can be selected via click but nothing more</li>
+ * <li>TRANSLATE: means features can be translates. Implies: SELECT</li>
+ * <li>MODIFY: features can be modified. Implies: SELECT. Can be combined with TRANSLATE but NEVER DRAW</li>
+ * <li>DRAW: features can be drawn. Mutually exclusive with all others</li>
+ *</ul>
+ *
+ * @static
+ * @enum {number}
+ */
+ome.ol3.REGIONS_MODE = {
+    /** the original state i.e. no interaction possible, only display */
+    "DEFAULT" : 0,
+    /** select interaction */
+    "SELECT" : 1,
+    /** translate interaction */
+    "TRANSLATE" : 2,
+    /** modify interaction */
+    "MODIFY" : 3,
+    /** draw interaction */
+    "DRAW" : 4
+};
+
+/**
+ * Enum for Render Status.
+ * @static
+ * @enum {number}
+ */
+ome.ol3.RENDER_STATUS = {
+    /** we did no render watching */
+    "NOT_WATCHED" : 0,
+    /** we are watching and in progress */
+    "IN_PROGRESS" : 1,
+    /** we watched and are fininshed rendering */
+    "RENDERED" : 2,
+    /** we watched and got tile load errors  */
+    "ERROR" : 3
+};
+
+/**
+ * Enum for Projection.
+ * @static
+ * @enum {string}
+ */
+ome.ol3.PROJECTION = {
+    /** normal **/
+    "NORMAL" : 'normal',
+    /** intmax **/
+    "INTMAX" : 'intmax',
+    /** split  **/
+    "SPLIT" : 'split'
+};
+
+/**
+ * list of length units incl. symbol, threshold for usage
+ * and micron multiplication factor
+ *
+ * @const
+ * @type {Object}
+ */
+ome.ol3.UNITS_LENGTH = [
+    { unit: 'angstrom',
+      threshold: 0.1, multiplier: 10000, symbol: '\u212B'},
+    { unit: 'nanometer',
+      threshold: 1, multiplier: 1000, symbol: 'nm'},
+    { unit: 'micron',
+      threshold: 1000, multiplier: 1, symbol:  '\u00B5m'},
+    { unit: 'millimeter',
+      threshold: 100000, multiplier: 0.001, symbol: 'mm'},
+    { unit: 'centimeter',
+      threshold: 1000000, multiplier: 0.0001, symbol: 'cm'},
+    { unit: 'meter',
+      threshold: 100000000, multiplier: 0.000001, symbol: 'm'}
+ ];
+
+/**
  * A lookup table to get or set dimension indices
  *
  * @const
@@ -274,109 +400,6 @@ ome.ol3.defaultInteractions = function() {
     return ret;
 };
 
-/**
- * Enum for RequestParams.
- * @static
- * @enum {string}
- */
-ome.ol3.REQUEST_PARAMS = {
-    CHANNELS: 'C',
-    CENTER_X: 'X',
-    CENTER_Y: 'Y',
-    IMAGE_ID : 'IMAGE_ID',
-    MAPS: 'MAPS',
-    MODEL: 'M',
-    PLANE: 'Z',
-    PROJECTION: 'P',
-    SERVER: 'SERVER',
-    TIME: 'T',
-    ZOOM: 'ZM'
-};
-
-/**
- * Enum for RegionsState.
- * @static
- * @enum {number}
- */
-ome.ol3.REGIONS_STATE = {
-    /** the original state */
-    "DEFAULT" : 0,
-    /** the changed state */
-    "MODIFIED" : 1,
-    /** the new state */
-    "ADDED" : 2,
-    /** the deleted state */
-    "REMOVED" : 3,
-    /** a state used for rollback */
-    "ROLLBACK" : 4
-};
-
-/**
- * Enum for RegionsMode.
- * Depending on the mode, various interactions will be active.
- * <p>
- * Note, however, that some modes are inclusive and others mutually exclusive!
- * </p>
- * <ul>
- * <li>DEFAULT: means no interaction at all. Takes precendence over any other and is mutually exclusive with any others</li>
- * <li>SELECT: means that features can be selected via click but nothing more</li>
- * <li>TRANSLATE: means features can be translates. Implies: SELECT</li>
- * <li>MODIFY: features can be modified. Implies: SELECT. Can be combined with TRANSLATE but NEVER DRAW</li>
- * <li>DRAW: features can be drawn. Mutually exclusive with all others</li>
- *</ul>
- *
- * @static
- * @enum {number}
- */
-ome.ol3.REGIONS_MODE = {
-    /** the original state i.e. no interaction possible, only display */
-    "DEFAULT" : 0,
-    /** select interaction */
-    "SELECT" : 1,
-    /** translate interaction */
-    "TRANSLATE" : 2,
-    /** modify interaction */
-    "MODIFY" : 3,
-    /** draw interaction */
-    "DRAW" : 4
-};
-
-/**
- * Enum for Render Status.
- * @static
- * @enum {number}
- */
-ome.ol3.RENDER_STATUS = {
-    /** we did no render watching */
-    "NOT_WATCHED" : 0,
-    /** we are watching and in progress */
-    "IN_PROGRESS" : 1,
-    /** we watched and are fininshed rendering */
-    "RENDERED" : 2,
-    /** we watched and got tile load errors  */
-    "ERROR" : 3
-};
-
-/**
- * Enum for Projection.
- * @static
- * @enum {string}
- */
-ome.ol3.PROJECTION = {
-    /** normal **/
-    "NORMAL" : 'normal',
-    /** intmax **/
-    "INTMAX" : 'intmax',
-    /** split  **/
-    "SPLIT" : 'split'
-};
-
-/**
- * Limit for untiled image retrieval: 2K^2
- * @const
- * @type {number}
- */
-ome.ol3.UNTILED_RETRIEVAL_LIMIT = 4000000;
 
 goog.exportSymbol(
     'ome.ol3.REGIONS_MODE',

--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -156,27 +156,27 @@ ome.ol3.interaction.Draw.prototype.drawShapeCommonCode_ =
                 if (add) this.regions_.addFeature(event.feature);
 
                 var eventbus = this.regions_.viewer_.eventbus_;
-                var config_id = this.regions_.viewer_.getTargetId();
-                var hist_id = this.history_id_;
-                if (this.roi_id_ < 0) event.feature['roi_id'] = this.roi_id_;
-                if (eventbus)
-                    setTimeout(function() {
-                        var newRegionsObject =
-                            ome.ol3.utils.Conversion.toJsonObject(
-                                new ol.Collection([event.feature]), false, true);
-                        if (typeof newRegionsObject !== 'object' ||
-                            !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
-                            newRegionsObject['rois'].length === 0) return;
-                        var opts = {
-                            "config_id": config_id,
-                            "shapes": newRegionsObject['rois'],
-                            "drawn" : true, "add": add
-                        };
-                        if (typeof hist_id === 'number') opts['hist_id'] = hist_id;
-                        if (typeof event.feature['roi_id'] === 'number')
-                            opts['roi_id'] = event.feature['roi_id'];
-                        eventbus.publish("REGIONS_SHAPE_GENERATED", opts);
-                    },25);
+                if (this.regions_.viewer_.eventbus_) {
+                    var hist_id = this.history_id_;
+                    if (this.roi_id_ < 0) event.feature['roi_id'] = this.roi_id_;
+                    var newRegionsObject =
+                        ome.ol3.utils.Conversion.toJsonObject(
+                            new ol.Collection([event.feature]), false, true);
+                    if (typeof newRegionsObject !== 'object' ||
+                        !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
+                        newRegionsObject['rois'].length === 0) return;
+                    var opts = {
+                        "shapes": newRegionsObject['rois'],
+                        "drawn" : true, "add": add
+                    };
+                    if (typeof hist_id === 'number') opts['hist_id'] = hist_id;
+                    if (typeof event.feature['roi_id'] === 'number')
+                        opts['roi_id'] = event.feature['roi_id'];
+
+                    ome.ol3.utils.Misc.sendEventNotification(
+                        this.regions_.viewer_, "REGIONS_SHAPE_GENERATED",
+                        opts, 25);
+                }
                 this.history_id_ = null;
                 this.rois_id_ = 0;
             }

--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -148,6 +148,8 @@ ome.ol3.interaction.Draw.prototype.drawShapeCommonCode_ =
                 event.feature.setStyle(this.default_style_);
                 ome.ol3.utils.Style.updateStyleFunction(
                     event.feature, this.regions_, true);
+                // calculate measurements
+                this.regions_.getLengthAndAreaForShape(event.feature, true);
 
                 var add =
                     typeof this.opts_['add'] !== 'boolean' || this.opts_['add'];

--- a/ol3-viewer/src/ome/ol3/interaction/Modify.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Modify.js
@@ -79,8 +79,10 @@ ome.ol3.interaction.Modify = function(regions_reference) {
                 var featId = event.features.array_[0].getId();
                 this.regions_.addHistory(
                     event.features.array_, false, this.hist_id_);
-                this.regions_.sendHistoryNotification(
-                    this.hist_id_, [featId]);
+                ome.ol3.utils.Misc.sendEventNotification(
+                    this.regions_.viewer_,
+                    "REGIONS_HISTORY_ENTRY",
+                    {"hist_id": this.hist_id_, "shape_ids": [featId]});
                 this.regions_.setProperty(
                     [featId], "state", ome.ol3.REGIONS_STATE.MODIFIED);
             }

--- a/ol3-viewer/src/ome/ol3/interaction/Translate.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Translate.js
@@ -137,7 +137,9 @@ ome.ol3.interaction.Translate.prototype.handleTranslateEnd = function(event) {
 
     // complete history entry
     this.regions_.addHistory(filtered, false, this.hist_id_);
-    this.regions_.sendHistoryNotification(this.hist_id_, ids);
+    ome.ol3.utils.Misc.sendEventNotification(
+        this.regions_.viewer_,
+        "REGIONS_HISTORY_ENTRY", {"hist_id": this.hist_id_, "shape_ids": ids});
     this.hist_id_ = -1; // reset
 
     // set modified flag

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -875,40 +875,9 @@ ome.ol3.source.Regions.prototype.getLengthAndAreaForShape =
 
         if (typeof recalculate !== 'boolean') recalculate = false;
 
-        var pixel_size =
-            this.viewer_.viewer_.getView().getProjection().getMetersPerUnit();
-        if (typeof pixel_size !== 'number') pixel_size = 1;
-
-        var geom = feature.getGeometry();
-        // we represent points as circles
-        var hasArea =
-            !(geom instanceof ol.geom.Circle) &&
-            !(geom instanceof ome.ol3.geom.Line) &&
-            !(geom instanceof ome.ol3.geom.Label);
-        var hasLength =
-            !(geom instanceof ol.geom.Circle) &&
-            !(geom instanceof ome.ol3.geom.Label);
-        // we recalculate regardless if we don't have a length/area yet
-        if (typeof feature['Area'] !== 'number' || recalculate)
-            feature['Area'] = hasArea ?
-                geom.getArea() * (pixel_size * pixel_size) : -1;
-        if (typeof feature['Length'] !== 'number' || recalculate)
-            feature['Length'] = hasLength ?
-                ol.geom.flat.length.lineString(
-                    geom.flatCoordinates, 0,
-                    geom.flatCoordinates.length, geom.stride) * pixel_size : -1;
-
-        var roundAfterThreeDecimals = function(value) {
-            if (value < 0) return value;
-
-            return Number(Math.round(value +'e3') + 'e-3');
-        };
-
-        return {
-            'id' : feature.getId(),
-            'Area': roundAfterThreeDecimals(feature['Area']),
-            'Length': roundAfterThreeDecimals(feature['Length'])
-        };
+        return ome.ol3.utils.Regions.calculateLengthAndArea(
+            feature,
+            this.viewer_.viewer_.getView().getProjection().getMetersPerUnit());
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -849,7 +849,9 @@ ome.ol3.source.Regions.prototype.getLengthAndAreaForShape =
 
         return ome.ol3.utils.Regions.calculateLengthAndArea(
             feature, recalculate,
-            this.viewer_.viewer_.getView().getProjection().getMetersPerUnit());
+            this.viewer_.viewer_.getView().getProjection().getMetersPerUnit(),
+            this.viewer_.image_info_['pixel_size']['symbol_x'] || '\u00B5m'
+        );
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -614,7 +614,7 @@ ome.ol3.utils.Conversion.integrateStyleIntoJsonObject = function(feature, jsonOb
 }
 
 /**
- * Adds miscellanous information linked to the shape that wants to be persisted.
+ * Adds miscellanous information related to the shape.
  * see: {@link ome.ol3.utils.Conversion.toJsonObject}
  *
  * @static
@@ -635,6 +635,11 @@ ome.ol3.utils.Conversion.integrateMiscInfoIntoJsonObject  = function(feature, js
 
     if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED)
         jsonObject['markedForDeletion'] = true;
+
+    if (typeof feature['Area'] === 'number')
+        jsonObject['Area'] = feature['Area'];
+    if (typeof feature['Length'] === 'number')
+        jsonObject['Length'] = feature['Length'];
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/utils/Misc.js
+++ b/ol3-viewer/src/ome/ol3/utils/Misc.js
@@ -349,3 +349,31 @@ ome.ol3.utils.Misc.parseProjectionParameter = function(projection_info) {
 
     return ret;
 }
+
+/**
+ * Sends out an event notification
+ *
+ * @static
+ * @param {ome.ol3.Viewer} viewer an instance of the ome.ol3.Viewer
+ * @param {string} type the event type
+ * @param {Object=} content the event content as an object (optional)
+ * @param {number=} delay delay for sending (optional)
+ */
+ome.ol3.utils.Misc.sendEventNotification = function(viewer, type, content, delay) {
+    if (!(viewer instanceof ome.ol3.Viewer) ||
+        typeof type !== 'string' ||
+        type.length === 0) return;
+
+    var config_id = viewer.getTargetId();
+    var eventbus = viewer.eventbus_;
+    if (config_id && eventbus) { // publish
+        if (typeof content !== 'object' || content === null) content = {};
+        content['config_id'] = config_id;
+        var triggerEvent = function() {
+            eventbus.publish(type, content);
+        };
+        if (typeof delay === 'number' && delay > 0)
+            setTimeout(triggerEvent, delay);
+        else triggerEvent();
+    }
+}

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -552,10 +552,11 @@ ome.ol3.utils.Regions.addMask = function(regions, shape_info) {
  * @param {ol.Feature} feature the feature containing the geometry
  * @param {boolean} recalculate flag: if true we redo the measurement (default: false)
  * @param {number} pixel_size the pixel_size
+ * @param {string} pixel_symbol the pixel_symbol
  * @return {Object} an object containing shape id, area and length
  */
 ome.ol3.utils.Regions.calculateLengthAndArea =
-    function(feature, recalculate, pixel_size) {
+    function(feature, recalculate, pixel_size, pixel_symbol) {
         if (typeof pixel_size !== 'number') pixel_size = 1;
 
         var geom = feature.getGeometry();
@@ -567,6 +568,18 @@ ome.ol3.utils.Regions.calculateLengthAndArea =
         var hasLength =
             !(geom instanceof ol.geom.Circle) &&
             !(geom instanceof ome.ol3.geom.Label);
+
+        // if we are not micron we convert
+        if (typeof pixel_symbol !== 'string' ||
+            pixel_symbol.localeCompare('\u00B5m') !== 0) {
+            for (var u=0;u<ome.ol3.UNITS_LENGTH.length;u++) {
+                var unit = ome.ol3.UNITS_LENGTH[u];
+                if (unit.symbol.localeCompare(pixel_symbol) === 0) {
+                    pixel_size *= unit.multiplier;
+                    break;
+                }
+            }
+        }
 
         // rounding helper
         var roundAfterThreeDecimals = function(value) {

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -567,25 +567,30 @@ ome.ol3.utils.Regions.calculateLengthAndArea =
         var hasLength =
             !(geom instanceof ol.geom.Circle) &&
             !(geom instanceof ome.ol3.geom.Label);
-        // we recalculate regardless if we don't have a length/area yet
-        if (typeof feature['Area'] !== 'number' || recalculate)
-            feature['Area'] = hasArea ?
-                geom.getArea() * (pixel_size * pixel_size) : -1;
-        if (typeof feature['Length'] !== 'number' || recalculate)
-            feature['Length'] = hasLength ?
-                ol.geom.flat.length.lineString(
-                    geom.flatCoordinates, 0,
-                    geom.flatCoordinates.length, geom.stride) * pixel_size : -1;
 
+        // rounding helper
         var roundAfterThreeDecimals = function(value) {
             if (value < 0) return value;
 
             return Number(Math.round(value +'e3') + 'e-3');
         };
 
+        // we recalculate regardless if we don't have a length/area yet
+        if (typeof feature['Area'] !== 'number' || recalculate)
+            feature['Area'] = hasArea ?
+                roundAfterThreeDecimals(
+                    geom.getArea() * (pixel_size * pixel_size)) : -1;
+        if (typeof feature['Length'] !== 'number' || recalculate)
+            feature['Length'] = hasLength ?
+                roundAfterThreeDecimals(
+                    ol.geom.flat.length.lineString(
+                        geom.flatCoordinates, 0,
+                        geom.flatCoordinates.length, geom.stride)
+                            * pixel_size) : -1;
+
         return {
             'id' : feature.getId(),
-            'Area': roundAfterThreeDecimals(feature['Area']),
-            'Length': roundAfterThreeDecimals(feature['Length'])
+            'Area': feature['Area'],
+            'Length': feature['Length']
         };
 }

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -367,6 +367,7 @@ ome.ol3.utils.Regions.getRandomCoordinateWithinExtent = function(extent) {
  * see: {@link ome.ol3.REGIONS_STATE}
  *
  * @private
+ * @static
  * @param {ome.ol3.source.Regions} regions an instance of the Regions
  * @param {boolean=} include_new_features should new, unsaved features be included?
  * @return {Array.<ol.Feature>|null} an array of converted shapes or null
@@ -504,6 +505,7 @@ ome.ol3.utils.Regions.createFeaturesFromRegionsResponse =
  * and prior to the rois.
  *
  * @private
+ * @static
  * @param {ome.ol3.source.Regions} regions an instance of the OmeroRegions
  * @param {Object} shape_info the shape info object (from json)
  */
@@ -539,4 +541,47 @@ ome.ol3.utils.Regions.addMask = function(regions, shape_info) {
                     shape_info['x'] + shape_info['width'], -shape_info['y']
                 ]
         })}));
+}
+
+/**
+ * Uses the respective ol3 code to get the length and area of a geometry
+ *
+ * @static
+ * @param {ol.Feature} feature the feature containing the geometry
+ * @param {number} pixel_size the pixel_size
+ * @return {Object} an object containing shape id, area and length
+ */
+ome.ol3.utils.Regions.calculateLengthAndArea = function(feature, pixel_size) {
+    if (typeof pixel_size !== 'number') pixel_size = 1;
+
+    var geom = feature.getGeometry();
+    // we represent points as circles
+    var hasArea =
+        !(geom instanceof ol.geom.Circle) &&
+        !(geom instanceof ome.ol3.geom.Line) &&
+        !(geom instanceof ome.ol3.geom.Label);
+    var hasLength =
+        !(geom instanceof ol.geom.Circle) &&
+        !(geom instanceof ome.ol3.geom.Label);
+    // we recalculate regardless if we don't have a length/area yet
+    if (typeof feature['Area'] !== 'number' || recalculate)
+        feature['Area'] = hasArea ?
+            geom.getArea() * (pixel_size * pixel_size) : -1;
+    if (typeof feature['Length'] !== 'number' || recalculate)
+        feature['Length'] = hasLength ?
+            ol.geom.flat.length.lineString(
+                geom.flatCoordinates, 0,
+                geom.flatCoordinates.length, geom.stride) * pixel_size : -1;
+
+    var roundAfterThreeDecimals = function(value) {
+        if (value < 0) return value;
+
+        return Number(Math.round(value +'e3') + 'e-3');
+    };
+
+    return {
+        'id' : feature.getId(),
+        'Area': roundAfterThreeDecimals(feature['Area']),
+        'Length': roundAfterThreeDecimals(feature['Length'])
+    };
 }

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -474,6 +474,8 @@ ome.ol3.utils.Regions.createFeaturesFromRegionsResponse =
                 actualFeature['owner'] = owner;
                 actualFeature['permissions'] =
                     shape['omero:details']['permissions'];
+                // calculate area/length
+                regions.getLengthAndAreaForShape(actualFeature, true);
                 // add us to the return array
                 ret.push(actualFeature);
             }
@@ -548,40 +550,42 @@ ome.ol3.utils.Regions.addMask = function(regions, shape_info) {
  *
  * @static
  * @param {ol.Feature} feature the feature containing the geometry
+ * @param {boolean} recalculate flag: if true we redo the measurement (default: false)
  * @param {number} pixel_size the pixel_size
  * @return {Object} an object containing shape id, area and length
  */
-ome.ol3.utils.Regions.calculateLengthAndArea = function(feature, pixel_size) {
-    if (typeof pixel_size !== 'number') pixel_size = 1;
+ome.ol3.utils.Regions.calculateLengthAndArea =
+    function(feature, recalculate, pixel_size) {
+        if (typeof pixel_size !== 'number') pixel_size = 1;
 
-    var geom = feature.getGeometry();
-    // we represent points as circles
-    var hasArea =
-        !(geom instanceof ol.geom.Circle) &&
-        !(geom instanceof ome.ol3.geom.Line) &&
-        !(geom instanceof ome.ol3.geom.Label);
-    var hasLength =
-        !(geom instanceof ol.geom.Circle) &&
-        !(geom instanceof ome.ol3.geom.Label);
-    // we recalculate regardless if we don't have a length/area yet
-    if (typeof feature['Area'] !== 'number' || recalculate)
-        feature['Area'] = hasArea ?
-            geom.getArea() * (pixel_size * pixel_size) : -1;
-    if (typeof feature['Length'] !== 'number' || recalculate)
-        feature['Length'] = hasLength ?
-            ol.geom.flat.length.lineString(
-                geom.flatCoordinates, 0,
-                geom.flatCoordinates.length, geom.stride) * pixel_size : -1;
+        var geom = feature.getGeometry();
+        // we represent points as circles
+        var hasArea =
+            !(geom instanceof ol.geom.Circle) &&
+            !(geom instanceof ome.ol3.geom.Line) &&
+            !(geom instanceof ome.ol3.geom.Label);
+        var hasLength =
+            !(geom instanceof ol.geom.Circle) &&
+            !(geom instanceof ome.ol3.geom.Label);
+        // we recalculate regardless if we don't have a length/area yet
+        if (typeof feature['Area'] !== 'number' || recalculate)
+            feature['Area'] = hasArea ?
+                geom.getArea() * (pixel_size * pixel_size) : -1;
+        if (typeof feature['Length'] !== 'number' || recalculate)
+            feature['Length'] = hasLength ?
+                ol.geom.flat.length.lineString(
+                    geom.flatCoordinates, 0,
+                    geom.flatCoordinates.length, geom.stride) * pixel_size : -1;
 
-    var roundAfterThreeDecimals = function(value) {
-        if (value < 0) return value;
+        var roundAfterThreeDecimals = function(value) {
+            if (value < 0) return value;
 
-        return Number(Math.round(value +'e3') + 'e-3');
-    };
+            return Number(Math.round(value +'e3') + 'e-3');
+        };
 
-    return {
-        'id' : feature.getId(),
-        'Area': roundAfterThreeDecimals(feature['Area']),
-        'Length': roundAfterThreeDecimals(feature['Length'])
-    };
+        return {
+            'id' : feature.getId(),
+            'Area': roundAfterThreeDecimals(feature['Area']),
+            'Length': roundAfterThreeDecimals(feature['Length'])
+        };
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -495,7 +495,7 @@ thumbnail-slider img {
 }
 
 .tab-pane {
-    padding: 10px;
+    padding: 5px;
 }
 
 .right-hand-panel .row {
@@ -738,7 +738,11 @@ thumbnail-slider img {
     min-width: 50%;
     max-width: 50%;
 }
-.shape-area,.shape-length {
+.shape-area {
+    min-width: 20%;
+    max-width: 20%;
+}
+.shape-length {
     min-width: 25%;
     max-width: 25%;
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1076,7 +1076,7 @@ thumbnail-slider img {
 }
 .columns-dropdown .dropdown-menu {
     right: 0px;
-    left: initial;
+    left: auto;
 }
 .columns-dropdown .dropdown-menu span {
     display: inline-block;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -738,6 +738,10 @@ thumbnail-slider img {
     min-width: 45%;
     max-width: 45%;
 }
+.shape-area,.shape-length {
+    min-width: 22.5%;
+    max-width: 22.5%;
+}
 .shape-show {
     min-width: 20%;
     max-width: 20%;
@@ -1058,4 +1062,24 @@ thumbnail-slider img {
     background-size: 100% 30px;
     background-repeat: no-repeat;
     background-position: center;
+}
+
+.columns-dropdown {
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    z-index: 1000;
+}
+.columns-dropdown .dropdown-menu {
+    right: 0px;
+    left: initial;
+}
+.columns-dropdown .dropdown-menu span {
+    display: inline-block;
+    margin-left: 2px;
+    width: 12px;
+}
+.columns-dropdown .dropdown-menu a {
+    display: inline-block;
+    padding-left: 0px;
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -735,16 +735,16 @@ thumbnail-slider img {
     background-position: center;
 }
 .shape-comment {
-    min-width: 45%;
-    max-width: 45%;
+    min-width: 50%;
+    max-width: 50%;
 }
 .shape-area,.shape-length {
-    min-width: 22.5%;
-    max-width: 22.5%;
+    min-width: 25%;
+    max-width: 25%;
 }
 .shape-show {
-    min-width: 20%;
-    max-width: 20%;
+    min-width: 15%;
+    max-width: 15%;
 }
 
 .rectangle-icon {

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -34,6 +34,13 @@ import {
 @noView
 export default class RegionsInfo  {
     /**
+     * roi request limit
+     * @memberof RegionsInfo
+     * @type {number}
+     */
+    REQUEST_LIMIT = 5000;
+
+    /**
      * true if a backend request is pending
      * @memberof RegionsInfo
      * @type {boolean}
@@ -252,7 +259,8 @@ export default class RegionsInfo  {
         $.ajax({
             url : this.image_info.context.server +
                   this.image_info.context.getPrefixedURI(WEB_API_BASE) +
-                  REGIONS_REQUEST_URL + '/?image=' + this.image_info.image_id,
+                  REGIONS_REQUEST_URL + '/?image=' + this.image_info.image_id +
+                  '&limit=' + this.REQUEST_LIMIT,
             success : (response) => {
                 this.is_pending = false;
                 try {
@@ -294,7 +302,7 @@ export default class RegionsInfo  {
                         }
                     });
                     this.number_of_shapes = count;
-                    this.tmp_data = response;
+                    this.tmp_data = response.data;
                     this.ready = true;
                 } catch(err) {
                     console.error("Failed to load Rois: " + err);

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -294,8 +294,8 @@ export default class RegionsInfo  {
                         }
                     });
                     this.number_of_shapes = count;
-                    this.ready = true;
                     this.tmp_data = response;
+                    this.ready = true;
                 } catch(err) {
                     console.error("Failed to load Rois: " + err);
                 }

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -60,9 +60,15 @@
                      show.bind="active_column === 'comments'">Comment
                  </div>
                 <div class="regions-table-col shape-area"
-                     show.bind="active_column === 'measurements'">Area (&#181;m)</div>
+                     show.bind="active_column === 'measurements'">
+                     Area (${regions_info.image_info.image_pixels_size.symbol_x ||
+                             '&#181;m'})
+                 </div>
                 <div class="regions-table-col shape-length"
-                     show.bind="active_column === 'measurements'">Length (&#181;m)</div>
+                     show.bind="active_column === 'measurements'">
+                     Length (${regions_info.image_info.image_pixels_size.symbol_x ||
+                               '&#181;m'})
+                 </div>
             </div>
 
             <div class="regions-table-row regions-table-first-row"></div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -18,39 +18,40 @@
 <template>
     <div class="regions-list">
         <div class="regions-table">
-            <div class="columns-dropdown dropdown">
-                <button type="button"
-                    class="btn btn-default btn-sm dropdown-toggle
-                           glyphicon glyphicon-option-vertical"
-                    style="padding: 0px;"
-                    data-toggle="dropdown">
-                </button>
-                <ul class="dropdown-menu">
-                    <li click.delegate="showColumn('comments')">
-                        <span class="show_comments">
-                            ${active_column === 'comments' ? '&#10003;' : '&nbsp;'}
-                        </span>
-                        <a href="#">Show Comments</a>
-                    </li>
-                    <li click.delegate="showColumn('measurements')">
-                        <span class="show_measurements">
-                            ${active_column === 'measurements' ? '&#10003;' : '&nbsp;'}
-                        </span>
-                        <a href="#">Show Area/Length</a>
-                    </li>
-                </ul>
-            </div>
             <div class="regions-header">
-                <div class="regions-table-col roi-toggle">&nbsp;</div>
-                <div class="regions-table-col shape-show">
-                    <label for="shapes_visibility_toggler"
-                           show.bind="regions_info.number_of_shapes > 0">Show</label>
+                <div class="columns-dropdown dropdown">
+                    <button type="button"
+                        class="btn btn-default btn-sm dropdown-toggle
+                               glyphicon glyphicon-option-vertical"
+                        style="padding: 0px; top: -2px; right: 2px;"
+                        data-toggle="dropdown">
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li click.delegate="showColumn('comments')">
+                            <span class="show_comments">
+                                ${active_column === 'comments' ? '&#10003;' : '&nbsp;'}
+                            </span>
+                            <a href="#">Show Comments</a>
+                        </li>
+                        <li click.delegate="showColumn('measurements')">
+                            <span class="show_measurements">
+                                ${active_column === 'measurements' ? '&#10003;' : '&nbsp;'}
+                            </span>
+                            <a href="#">Show Area/Length</a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="regions-table-col roi-toggle">
                     <input id="shapes_visibility_toggler"
                            title="Show/Hide all rois"
                            checked
                            show.bind="regions_info.number_of_shapes > 0"
                            change.delegate="toggleAllShapesVisibility($event)"
                            type="checkbox" />
+                </div>
+                <div class="regions-table-col shape-show">
+                    <label for="shapes_visibility_toggler"
+                           show.bind="regions_info.number_of_shapes > 0">Show</label>
                 </div>
                 <div class="regions-table-col shape-type">&nbsp;</div>
                 <div class="regions-table-col shape-z">Z</div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -62,7 +62,7 @@
                 <div class="regions-table-col shape-area"
                      show.bind="active_column === 'measurements'">
                      Area (${regions_info.image_info.image_pixels_size.symbol_x ||
-                             '&#181;m'})
+                             '&#181;m'}&#178;)
                  </div>
                 <div class="regions-table-col shape-length"
                      show.bind="active_column === 'measurements'">
@@ -126,11 +126,13 @@
                                 ${shape.Text ? shape.Text : ''}
                         </div>
                         <div class="regions-table-col shape-area"
-                             show.bind="active_column === 'measurements'">
+                             show.bind="active_column === 'measurements'"
+                             title="${shape.Area && shape.Area > 0 ? shape.Area : ''}">
                                 ${shape.Area && shape.Area > 0 ? shape.Area : ''}
                         </div>
                         <div class="regions-table-col shape-length"
-                             show.bind="active_column === 'measurements'">
+                             show.bind="active_column === 'measurements'"
+                             title="${shape.Length && shape.Length > 0 ? shape.Length : ''}">
                                 ${shape.Length && shape.Length > 0 ? shape.Length : ''}
                         </div>
                     </div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -18,12 +18,30 @@
 <template>
     <div class="regions-list">
         <div class="regions-table">
+            <div class="columns-dropdown dropdown">
+                <button type="button"
+                    class="btn btn-default btn-sm dropdown-toggle
+                           glyphicon glyphicon-option-vertical"
+                    style="padding: 0px;"
+                    data-toggle="dropdown">
+                </button>
+                <ul class="dropdown-menu">
+                    <li click.delegate="showColumn('comments')">
+                        <span class="show_comments">
+                            ${active_column === 'comments' ? '&#10003;' : '&nbsp;'}
+                        </span>
+                        <a href="#">Show Comments</a>
+                    </li>
+                    <li click.delegate="showColumn('measurements')">
+                        <span class="show_measurements">
+                            ${active_column === 'measurements' ? '&#10003;' : '&nbsp;'}
+                        </span>
+                        <a href="#">Show Area/Length</a>
+                    </li>
+                </ul>
+            </div>
             <div class="regions-header">
                 <div class="regions-table-col roi-toggle">&nbsp;</div>
-                <div class="regions-table-col shape-type">&nbsp;</div>
-                <div class="regions-table-col shape-z">Z</div>
-                <div class="regions-table-col shape-t">T</div>
-                <div class="regions-table-col shape-comment">Comment</div>
                 <div class="regions-table-col shape-show">
                     <label for="shapes_visibility_toggler"
                            show.bind="regions_info.number_of_shapes > 0">Show</label>
@@ -34,6 +52,16 @@
                            change.delegate="toggleAllShapesVisibility($event)"
                            type="checkbox" />
                 </div>
+                <div class="regions-table-col shape-type">&nbsp;</div>
+                <div class="regions-table-col shape-z">Z</div>
+                <div class="regions-table-col shape-t">T</div>
+                <div class="regions-table-col shape-comment"
+                     show.bind="active_column === 'comments'">Comment
+                 </div>
+                <div class="regions-table-col shape-area"
+                     show.bind="active_column === 'measurements'">Area</div>
+                <div class="regions-table-col shape-length"
+                     show.bind="active_column === 'measurements'">Length</div>
             </div>
 
             <div class="regions-table-row regions-table-first-row"></div>
@@ -52,13 +80,17 @@
                                  ${roi.show ? '&#9660;' : '&#9658;'}
                              </div>
                          </div>
+                         <div class="regions-table-col shape-show"></div>
                          <div class="regions-table-col shape-type">
                              (${(roi.shapes.size - roi.deleted)})
                          </div>
                         <div class="regions-table-col shape-z"></div>
                         <div class="regions-table-col shape-t"></div>
-                        <div class="regions-table-col shape-comment"></div>
-                        <div class="regions-table-col shape-show"></div>
+                        <div class="regions-table-col shape-comment"
+                             style="display: none">
+                        </div>
+                        <div class="regions-table-col shape-area"></div>
+                        <div class="regions-table-col shape-length"></div>
                     </div>
                     <div if.bind="!(shape.deleted && shape.is_new) &&
                                    !(roi.shapes.size > 1 && !roi.show)"
@@ -70,6 +102,11 @@
                                 (shape.modified ? 'color: blue;' : '')}"
                         click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
                         <div class="regions-table-col roi-toggle"></div>
+                        <div class="regions-table-col shape-show">
+                            <input type="checkbox"
+                                title="Show/Hide shape" checked.one-way="shape.visible"
+                                change.delegate="toggleShapeVisibility(shape.shape_id, $event)"/>
+                        </div>
                         <div class="regions-table-col shape-type ${shape.type.toLowerCase()}-icon"></div>
                         <div class="regions-table-col shape-z">
                             ${shape.TheZ !== -1 ? (shape.TheZ + 1) : ""}
@@ -77,13 +114,17 @@
                         <div class="regions-table-col shape-t">
                             ${shape.TheT !== -1 ? (shape.TheT + 1) : ""}
                         </div>
-                        <div class="regions-table-col shape-comment">
+                        <div class="regions-table-col shape-comment"
+                             show.bind="active_column === 'comments'">
                                 ${shape.Text ? shape.Text : ''}
                         </div>
-                        <div class="regions-table-col shape-show">
-                            <input type="checkbox"
-                                title="Show/Hide shape" checked.one-way="shape.visible"
-                                change.delegate="toggleShapeVisibility(shape.shape_id, $event)"/>
+                        <div class="regions-table-col shape-area"
+                             show.bind="active_column === 'measurements'">
+                                ${shape.Area && shape.Area > 0 ? shape.Area : ''}
+                        </div>
+                        <div class="regions-table-col shape-length"
+                             show.bind="active_column === 'measurements'">
+                                ${shape.Length && shape.Length > 0 ? shape.Length : ''}
                         </div>
                     </div>
                 </template>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -60,9 +60,9 @@
                      show.bind="active_column === 'comments'">Comment
                  </div>
                 <div class="regions-table-col shape-area"
-                     show.bind="active_column === 'measurements'">Area</div>
+                     show.bind="active_column === 'measurements'">Area (&#181;m)</div>
                 <div class="regions-table-col shape-length"
-                     show.bind="active_column === 'measurements'">Length</div>
+                     show.bind="active_column === 'measurements'">Length (&#181;m)</div>
             </div>
 
             <div class="regions-table-row regions-table-first-row"></div>

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -44,6 +44,13 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
+     * the column showing (only one - mutually exclusive for now)
+     * @memberof RegionsList
+     * @type {number}
+     */
+     active_column = 'comments';
+
+    /**
      * the list of property observers
      * @memberof RegionsList
      * @type {Array.<Object>}
@@ -333,6 +340,18 @@ export default class RegionsList extends EventSubscriber {
                config_id: this.regions_info.image_info.config_id,
                property : "visible",
                shapes : ids, value : show});
+    }
+
+    /**
+     * Selects column (mutally exclusive for now)
+     *
+     * @param {string} which the column name
+     * @memberof RegionsList
+     */
+    showColumn(which) {
+        if (typeof which !== 'string' || which.length === 0 ||
+            which === this.active_column) return;
+        this.active_column = which;
     }
 
     /**

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -173,6 +173,10 @@ export class Converters {
         if (typeof shape[d] !== 'number') shape[d] = -1;
       });
 
+      // initialize area/length info (if not there)
+      if (typeof shape.Length !== 'number') shape.Length = -1;
+      if (typeof shape.Area !== 'number') shape.Area = -1;
+
       return shape;
     }
 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -547,6 +547,26 @@ export default class Ol3Viewer extends EventSubscriber {
         delete this.image_config.regions_info.tmp_data;
         this.changeRegionsModes(
             { modes: this.image_config.regions_info.regions_modes});
+
+        let updateMeasurements = () => {
+            if (this.viewer === null) return;
+            let ids =
+                this.image_config.regions_info.unsophisticatedShapeFilter();
+            let measurements = this.viewer.getLengthAndAreaForShapes(ids);
+            for (let i=0;i<measurements.length;i++) {
+                let measurement = measurements[i];
+                if (typeof measurement !== 'object' ||
+                    measurement === null || typeof measurement.id !== 'string')
+                        continue;
+                let shape =
+                    this.image_config.regions_info.getShape(measurement.id);
+                if (shape !== null) {
+                    shape.Area = measurement.Area;
+                    shape.Length = measurement.Length;
+                }
+            }
+        };
+        setTimeout(updateMeasurements, 50);
     }
 
     /**

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -342,6 +342,17 @@ export default class Ol3Viewer extends EventSubscriber {
                     refOrCopy = Object.assign({}, refOrCopy);
                 if (typeof params.callback === 'function')
                     params.callback(refOrCopy, hasBeenModified);
+                // update measurement info (if shape was modified)
+                if (prop === 'modified') {
+                    let measurements =
+                        this.viewer.getLengthAndAreaForShapes([shape], true);
+                    if (Misc.isArray(measurements) &&
+                        measurements.length > 0 &&
+                        measurements[0].id === shape) {
+                            refOrCopy.Area = measurements[0].Area;
+                            refOrCopy.Length = measurements[0].Length;
+                    }
+                }
             }
      }
 

--- a/test/unit/utils/regions.js
+++ b/test/unit/utils/regions.js
@@ -133,4 +133,31 @@ describe("Regions", function() {
         }
     });
 
+    it('measureRegions', function() {
+        var feature = ome.ol3.utils.Regions.featureFactory(rectangle_info);
+        var measurement =
+            ome.ol3.utils.Regions.calculateLengthAndArea(feature);
+
+        assert.instanceOf(measurement, Object);
+        expect(measurement.Area).to.eql(180);
+        expect(measurement.Length).to.eql(54);
+
+        feature = ome.ol3.utils.Regions.featureFactory(line_info);
+        measurement =
+            ome.ol3.utils.Regions.calculateLengthAndArea(feature);
+
+        assert.instanceOf(measurement, Object);
+        expect(measurement.Area).to.eql(-1);
+        expect(measurement.Length).to.eql(81.394);
+
+        feature = ome.ol3.utils.Regions.featureFactory(point_info);
+        measurement =
+            ome.ol3.utils.Regions.calculateLengthAndArea(feature);
+
+        assert.instanceOf(measurement, Object);
+        expect(measurement.Area).to.eql(-1);
+        expect(measurement.Length).to.eql(-1);
+
+    });
+
 });


### PR DESCRIPTION
see https://trello.com/c/iBe0GYo0/12-analysis-of-shapes

this is the js/ol3/front-end approach of calculating area/length for shapes. it won't give more than that.
the info is shown in the roi table in the right panel. note that for now the display of area/length or comments is mutually exclusive and can be chosen by clicking on the 3 dot icon in the table header.

This can be tested now on web-dev-merge. 
There is very likely to be a follow up soon that tries to address the layout dilemma to achieve a flexible column selection...