### PR TITLE
upgrade ol3 to 4.2.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 
     <property name="version.major" value="1" />
     <property name="version.minor" value="0" />
-    <property name="ol3-version" value="4.1.0" />
+    <property name="ol3-version" value="4.2.0" />
 
     <property name="closure-compiler.jar" value="${basedir}/closure/compiler.jar" />
     <property name="closure-calcdeps.py" value="${basedir}/closure/calcdeps.py" />

--- a/src/css/ol3-viewer.css
+++ b/src/css/ol3-viewer.css
@@ -53,11 +53,29 @@
 .ol-viewport .ol-unselectable {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
-    -khtml-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
     -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+.ol-selectable {
+    -webkit-touch-callout: default;
+    -webkit-user-select: auto;
+    -moz-user-select: auto;
+    -ms-user-select: auto;
+    user-select: auto;
+ }
+ 
+.ol-grabbing {
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
+  cursor: grabbing;
+}
+.ol-grab {
+  cursor: move;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
 }
 
 .ol-control {


### PR DESCRIPTION
see: https://trello.com/c/fnbGgght/15-openlayers-upgrade

Note: Node version 6 is now a must. It's already been declared as a requirement in the README so no further action is necessary unless your local setup included a version < 6.