### PR TITLE
transformation adaptations 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -114,6 +114,7 @@
             <fileset file="${src}/ome/ol3/geom/Ellipse.js"/>
             <fileset file="${src}/ome/ol3/geom/LabelRectangle.js"/>
             <fileset file="${src}/ome/ol3/geom/Line.js"/>
+            <fileset file="${src}/ome/ol3/geom/Polygon.js"/>
             <fileset file="${src}/ome/ol3/interaction/interaction.js"/>
             <fileset file="${src}/ome/ol3/interaction/Rotate.js"/>
             <fileset file="${src}/ome/ol3/interaction/BoxSelect.js"/>

--- a/build.xml
+++ b/build.xml
@@ -105,6 +105,7 @@
             <fileset file="${src}/ome/ome.js"/>
             <fileset file="${src}/ome/ol3/ol3.js"/>
             <fileset file="${src}/ome/ol3/utils/utils.js"/>
+            <fileset file="${src}/ome/ol3/utils/Transform.js"/>
             <fileset file="${src}/ome/ol3/utils/Conversion.js"/>
             <fileset file="${src}/ome/ol3/utils/Net.js"/>
             <fileset file="${src}/ome/ol3/utils/Misc.js"/>

--- a/build.xml
+++ b/build.xml
@@ -115,6 +115,7 @@
             <fileset file="${src}/ome/ol3/geom/LabelRectangle.js"/>
             <fileset file="${src}/ome/ol3/geom/Line.js"/>
             <fileset file="${src}/ome/ol3/geom/Polygon.js"/>
+            <fileset file="${src}/ome/ol3/geom/Point.js"/>
             <fileset file="${src}/ome/ol3/interaction/interaction.js"/>
             <fileset file="${src}/ome/ol3/interaction/Rotate.js"/>
             <fileset file="${src}/ome/ol3/interaction/BoxSelect.js"/>

--- a/ol3-viewer/src/ome/ol3/geom/Ellipse.js
+++ b/ol3-viewer/src/ome/ol3/geom/Ellipse.js
@@ -93,7 +93,7 @@ ome.ol3.geom.Ellipse = function(cx, cy, rx, ry, transform) {
         ome.ol3.utils.Transform.convertAffineTransformIntoMatrix(transform);
 
     /**
-     * step the step size for plotting
+     * the step size for plotting
      * @type {number}
      * @private
      */

--- a/ol3-viewer/src/ome/ol3/geom/Ellipse.js
+++ b/ol3-viewer/src/ome/ol3/geom/Ellipse.js
@@ -48,12 +48,9 @@ goog.require('ol.geom.Polygon');
  * @param {number} cy the center y coordinate of the ellipse
  * @param {number} rx the radius x distance of the ellipse
  * @param {number} ry the radius y distance of the ellipse
- * @param {string=} transform a string of 6 numeric entries wrapped in a matrix( ... )
- * @param {number=} theta the (optional) angle for rotation (def: 0 - no rotation)
- * @param {number=} step the (optional) step size for tracing out the ellipse (def: 0.1)
+ * @param {Object=} transform an AffineTransform object according to omero marshal
  */
-ome.ol3.geom.Ellipse = function(cx, cy, rx, ry, transform, theta, step) {
-
+ome.ol3.geom.Ellipse = function(cx, cy, rx, ry, transform) {
     // preliminary checks: are all mandatory paramters numeric
     if (typeof cx !== 'number' || typeof cy !== 'number' ||
             typeof rx !== 'number' || typeof ry !== 'number')
@@ -88,45 +85,19 @@ ome.ol3.geom.Ellipse = function(cx, cy, rx, ry, transform, theta, step) {
     this.ry_ = ry;
 
     /**
-     * a 3x3 transformation matrix
+     * the transformation matrix of length 6
      * @type {Array.<number>|null}
      * @private
      */
-    this.transform_ = null;
-    this.setTransform(transform);
-
-    // look at the optional params
-    var opt = { "theta" : (theta || 0), "step" : step || 0.1};
-    for (var o in opt) {
-        // see if the string can be made a number
-        if (typeof(opt[o]) === 'string') {
-            try {
-                opt[o] = parseInt(opt[o]);
-            } catch(oopsie) {}
-        }
-        //final sanity checks, nonsense turns to default
-        if (typeof(opt[o]) !== 'number') {
-            if (o === 'theta') opt[o] = 0;
-            if (o === 'step') opt[o] = 0.1;
-            if (opt[o] < 0)
-                console.error(
-                    "Optional Ellipse parameters cannot be negative numbers!");
-        }
-    }
-
-    /**
-     * theta the angle of rotation
-     * @type {number}
-     * @private
-     */
-    this.theta_ = opt['theta'];
+    this.transform_ =
+        ome.ol3.utils.Transform.convertAffineTransformIntoMatrix(transform);
 
     /**
      * step the step size for plotting
      * @type {number}
      * @private
      */
-    this.step_ = opt['step'];
+    this.step_ = 0.1;
 
     // call super and hand in our coordinate array
     goog.base(this, [this.getPolygonCoords()]);
@@ -141,15 +112,10 @@ ome.ol3.geom.Ellipse.prototype.getPolygonCoords = function() {
     // trace ellipse now and store coordinates
     var coords = [];
     for (var i = 0 * Math.PI, ii=2*Math.PI; i < ii; i += this.step_) {
-        var x = this.cx_ -
-            (this.ry_ * Math.sin(i)) * Math.sin(this.theta_ * Math.PI) +
-            (this.rx_ * Math.cos(i)) * Math.cos(this.theta_ * Math.PI);
-        var y = this.cy_ +
-            (this.rx_ * Math.cos(i)) * Math.sin(this.theta_ * Math.PI) +
-            (this.ry_ * Math.sin(i)) * Math.cos(this.theta_ * Math.PI);
-
+        var x = this.cx_ + this.rx_ * Math.cos(i);
+        var y = this.cy_ + this.ry_ * Math.sin(i);
         coords.push(
-            this.applyTransform([x, y]));
+            ome.ol3.utils.Transform.applyTransform(this.transform_, [x, y]));
     }
     if (coords.length > 0) coords.push(coords[0]); // close polygon
 
@@ -157,128 +123,12 @@ ome.ol3.geom.Ellipse.prototype.getPolygonCoords = function() {
 }
 
 /**
- * Sets the transformation matrix from a transformation object
- * @param {Object} transform a transformation object with properties A00-A12
+ * Gets the transformation associated with the ellipse
+ * @return {Object|null} the AffineTransform object (omero marshal) or null
  */
-ome.ol3.geom.Ellipse.prototype.setTransform = function(transform) {
-    if (typeof transform !== 'object' ||
-        transform === null || typeof transform['@type'] !== 'string' ||
-        transform['@type'].indexOf("#AffineTransform") === -1) {
-        this.transform_ = null;
-        return;
-    }
-
-    try {
-        this.transform_ = [
-            transform['A00'], transform['A10'], transform['A01'],
-            transform['A11'], transform['A02'], transform['A12']
-        ];
-    } catch(err) {
-        console.error("failed to set tranform");
-    }
-}
-
-/**
- * If a transform exists we apply it to the list of flat coordinates
- * @return {Array.<number>} an array of transformed coords equal in dimensinonality to the input
- */
-ome.ol3.geom.Ellipse.prototype.applyTransform = function(flatCoords) {
-    // preliminary checks:
-    // nothing's converted if we have no transform,
-    // no coords (as an array) or
-    // coords that are not a multiple of 2 (we need x and y)
-    if (this.transform_ === null ||
-        !ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length === 0 ||
-        flatCoords.length % 2 !== 0) return flatCoords;
-
-    var transCoords = new Array(flatCoords.length);
-    for (var i=0;i<transCoords.length;i+=2) {
-        transCoords[i] = //x
-            this.transform_[0] * flatCoords[i] +
-            this.transform_[2] * (-flatCoords[i+1]) +
-            this.transform_[4];
-        transCoords[i+1] = //y
-            -(this.transform_[1] * flatCoords[i] +
-            this.transform_[3] * (-flatCoords[i+1]) +
-            this.transform_[5]);
-    }
-    return transCoords;
-}
-
-/**
- * Performs an inverse transform (if exists) to the list of flat coordinates
- * @return {Array.<number>} an array of transformed coords equal in dimensinonality to the input
- */
-ome.ol3.geom.Ellipse.prototype.applyInverseTransform = function(flatCoords) {
-    // preliminary checks:
-    // nothing's converted if we have no transform,
-    // no coords (as an array) or
-    // coords that are not a multiple of 2 (we need x and y)
-    if (this.transform_ === null ||
-        !ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length === 0 ||
-        flatCoords.length % 2 !== 0) return flatCoords;
-
-    var inverseTransform = this.getInvertedTransformMatrix();
-    if (inverseTransform === null) return flatCoords;
-
-    var transCoords = new Array(flatCoords.length);
-    for (var i=0;i<transCoords.length;i+=2) {
-        transCoords[i] = //x
-            inverseTransform[0] * flatCoords[i] +
-            inverseTransform[2] * (-flatCoords[i+1]) +
-            inverseTransform[4];
-        transCoords[i+1] = //y
-            -(inverseTransform[1] * flatCoords[i] +
-            inverseTransform[3] * (-flatCoords[i+1]) +
-            inverseTransform[5]);
-    }
-    return transCoords;
-}
-
-/**
- * Turns the tansformation matrix back into a string of the format matrix (...)
- * @return {string|null} the transformation string or null
- */
-ome.ol3.geom.Ellipse.prototype.getInvertedTransformMatrix = function() {
-    if (this.transform_ === null) return null;
-
-    var det = this.transform_[0] * this.transform_[3] -
-        this.transform_[1] * this.transform_[2];
-    if (det === 0) return null;
-
-    var inverse = new Array(this.transform_.length);
-    var a = this.transform_[0];
-    var b = this.transform_[1];
-    var c = this.transform_[2];
-    var d = this.transform_[3];
-    var e = this.transform_[4];
-    var f = this.transform_[5];
-
-    inverse[0] = d / det;
-    inverse[1] = -b / det;
-    inverse[2] = -c / det;
-    inverse[3] = a / det;
-    inverse[4] = (c * f - d * e) / det;
-    inverse[5] = -(a * f - b * e) / det;
-
-    return inverse;
-}
-
-/**
- * Gets the transform in "affine transform" object notation (marshal schema 2016-06)
- * @return {Object|null} the transformation object or null
- */
-ome.ol3.geom.Ellipse.prototype.getTransform = function(asObject) {
-    if (!ome.ol3.utils.Misc.isArray(this.transform_) ||
-        this.transform_.length <= 2 ||
-        this.transform.length % 2 !== 0) return null;
-
-    return {
-        '@type': "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform",
-        'A00' : this.transform_[0], 'A10' : this.transform_[1],
-        'A01' : this.transform_[2], 'A11' : this.transform_[3],
-        'A02' : this.transform_[4], 'A12' : this.transform_[5]
-    };
+ome.ol3.geom.Ellipse.prototype.getTransform = function() {
+    return ome.ol3.utils.Transform.convertMatrixToAffineTransform(
+        this.transform_);
 }
 
 /**
@@ -367,6 +217,5 @@ ome.ol3.geom.Ellipse.prototype.scale = function(factor) {
  */
 ome.ol3.geom.Ellipse.prototype.clone = function() {
     return new ome.ol3.geom.Ellipse(
-        this.cx_, this.cy_, this.rx_, this.ry_,
-        this.getTransform(), this.theta_, this.step_);
+        this.cx_, this.cy_, this.rx_, this.ry_, this.getTransform());
 };

--- a/ol3-viewer/src/ome/ol3/geom/Ellipse.js
+++ b/ol3-viewer/src/ome/ol3/geom/Ellipse.js
@@ -265,31 +265,20 @@ ome.ol3.geom.Ellipse.prototype.getInvertedTransformMatrix = function() {
 }
 
 /**
- * Turns the tansformation matrix back into a string of the format matrix (...)
- * @return {string|null} the transformation string or null
+ * Gets the transform in "affine transform" object notation (marshal schema 2016-06)
+ * @return {Object|null} the transformation object or null
  */
 ome.ol3.geom.Ellipse.prototype.getTransform = function(asObject) {
     if (!ome.ol3.utils.Misc.isArray(this.transform_) ||
         this.transform_.length <= 2 ||
         this.transform.length % 2 !== 0) return null;
 
-    // by default we return as matrix string
-    if (typeof asObject !== 'boolean') asObject = false;
-
-    var transform = null;
-    if (asObject)
-        transform = {'A00' : this.transform_[0], 'A10' : this.transform_[1],
-                     'A01' : this.transform_[2], 'A11' : this.transform_[3],
-                     'A02' : this.transform_[4], 'A12' : this.transform_[5]};
-    else {
-        transform = "matrix(" +
-        this.transform_[0] + " " + this.transform_[1];
-        for (var i=2;i<this.transform_.length;i+=2)
-            transform += " " + this.transform_[i] + " " + this.transform_[i+1];
-        transform += ")";
-    }
-
-    return transform;
+    return {
+        '@type': "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform",
+        'A00' : this.transform_[0], 'A10' : this.transform_[1],
+        'A01' : this.transform_[2], 'A11' : this.transform_[3],
+        'A02' : this.transform_[4], 'A12' : this.transform_[5]
+    };
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
+++ b/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
@@ -84,8 +84,7 @@ goog.inherits(ome.ol3.geom.Rectangle, ol.geom.Polygon);
  * @return {Array.<number>} the upper left corner
  */
 ome.ol3.geom.Rectangle.prototype.getUpperLeftCorner = function() {
-    var flatCoords =
-        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
+    var flatCoords = this.getRectangleCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return null;
 
@@ -107,8 +106,7 @@ ome.ol3.geom.Rectangle.prototype.setUpperLeftCorner = function(value) {
  * @return {number} the width of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.getWidth = function() {
-    var flatCoords =
-        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
+    var flatCoords = this.getRectangleCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return 0;
 
@@ -129,8 +127,7 @@ ome.ol3.geom.Rectangle.prototype.setWidth = function(value) {
  * @return {number} the height of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.getHeight = function() {
-    var flatCoords =
-        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
+    var flatCoords = this.getRectangleCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return 0;
 
@@ -157,8 +154,7 @@ ome.ol3.geom.Rectangle.prototype.setHeight = function(value) {
  * @param {number} h the height of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.changeRectangle = function(x,y,w,h) {
-    var flatCoords =
-        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
+    var flatCoords = this.getRectangleCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return;
 
@@ -206,6 +202,16 @@ ome.ol3.geom.Rectangle.prototype.getTransform = function() {
             'A01' : this.transform_[2], 'A11' : this.transform_[3],
             'A02' : this.transform_[4], 'A12' : this.transform_[5]
     };
+}
+
+/**
+ * Returns the coordinates as a flat array (excl. any potential transform)
+ * @return {Array.<number>} the coordinates as a flat array
+ */
+ome.ol3.geom.Rectangle.prototype.getRectangleCoordinates = function() {
+    return (
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates()
+    );
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
+++ b/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
@@ -84,7 +84,8 @@ goog.inherits(ome.ol3.geom.Rectangle, ol.geom.Polygon);
  * @return {Array.<number>} the upper left corner
  */
 ome.ol3.geom.Rectangle.prototype.getUpperLeftCorner = function() {
-    var flatCoords = this.getFlatCoordinates();
+    var flatCoords =
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return null;
 
@@ -106,7 +107,8 @@ ome.ol3.geom.Rectangle.prototype.setUpperLeftCorner = function(value) {
  * @return {number} the width of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.getWidth = function() {
-    var flatCoords = this.getFlatCoordinates();
+    var flatCoords =
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return 0;
 
@@ -127,7 +129,8 @@ ome.ol3.geom.Rectangle.prototype.setWidth = function(value) {
  * @return {number} the height of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.getHeight = function() {
-    var flatCoords = this.getFlatCoordinates();
+    var flatCoords =
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return 0;
 
@@ -154,7 +157,8 @@ ome.ol3.geom.Rectangle.prototype.setHeight = function(value) {
  * @param {number} h the height of the rectangle
  */
 ome.ol3.geom.Rectangle.prototype.changeRectangle = function(x,y,w,h) {
-    var flatCoords = this.getFlatCoordinates();
+    var flatCoords =
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
     if (!ome.ol3.utils.Misc.isArray(flatCoords) || flatCoords.length != 10)
         return;
 
@@ -188,22 +192,6 @@ ome.ol3.geom.Rectangle.prototype.translate = function(deltaX, deltaY) {
                 this.transform_, this.initial_coords_);
         this.changed();
     } else ol.geom.SimpleGeometry.prototype.translate.call(this, deltaX, deltaY);
-};
-
-/**
- * Override scale to include possible transformation
- *
- * @private
- */
-ome.ol3.geom.Rectangle.prototype.scale = function(factor) {
-    // delegate
-    if (this.transform_) {
-        this.transform_[0] *= factor;
-        this.transform_[1] *= factor;
-        this.transform_[2] *= factor;
-        this.transform_[3] *= factor;
-    };
-    ol.geom.SimpleGeometry.prototype.scale.call(this, factor);
 };
 
 /**

--- a/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
+++ b/ol3-viewer/src/ome/ol3/geom/LabelRectangle.js
@@ -80,7 +80,7 @@ ome.ol3.geom.Rectangle = function(x, y, w, h, transform) {
 goog.inherits(ome.ol3.geom.Rectangle, ol.geom.Polygon);
 
 /**
- * Gets the upper left corner coordinates as an arry [x,y]
+ * Gets the upper left corner coordinates as an array [x,y]
  * @return {Array.<number>} the upper left corner
  */
 ome.ol3.geom.Rectangle.prototype.getUpperLeftCorner = function() {

--- a/ol3-viewer/src/ome/ol3/geom/Line.js
+++ b/ol3-viewer/src/ome/ol3/geom/Line.js
@@ -177,12 +177,29 @@ ome.ol3.geom.Line.prototype.getTransform = function() {
 }
 
 /**
+ * Returns the coordinates after (potentially) inverting a transformation
+ * @return {Array} the coordinate array
+ */
+ome.ol3.geom.Line.prototype.getInvertedCoordinates = function() {
+    if (this.transform_ === null) return this.getCoordinates();
+
+    var coords = this.getCoordinates();
+    var invCoords = new Array(coords.length);
+    for (var i=0;i<coords.length;i++)
+        invCoords[i] =
+            ome.ol3.utils.Transform.applyInverseTransform(
+                this.transform_, coords[i]);
+                
+    return invCoords;
+}
+
+/**
  * Make a complete copy of the geometry.
  * @return {ome.ol3.geom.Line} Clone.
  * @api stable
  */
 ome.ol3.geom.Line.prototype.clone = function() {
   return new ome.ol3.geom.Line(
-      this.getCoordinates().slice(),
+      this.getInvertedCoordinates().slice(),
         this.has_start_arrow_, this.has_end_arrow_, this.getTransform());
 };

--- a/ol3-viewer/src/ome/ol3/geom/Line.js
+++ b/ol3-viewer/src/ome/ol3/geom/Line.js
@@ -153,12 +153,19 @@ ome.ol3.geom.Line.prototype.getArrowGeometry = function(head, width, height) {
                   tip[1] - direction*height*unitLine[1] - width*perpLine[1]];
     var point2 = [tip[0] - direction*height*unitLine[0] + width*perpLine[0],
                   tip[1] - direction*height*unitLine[1] + width*perpLine[1]];
-    //var direction = head ? 1 : -1;
-    //tip = [tip[0] + direction*height*unitLine[0],
-    //       tip[1] + direction*height*unitLine[1]];
 
     return new ol.geom.Polygon([[tip, point1, point2]]);
 };
+
+/**
+ * Returns the coordinates as a flat array (excl. any potential transform)
+ * @return {Array.<number>} the coordinates as a flat array
+ */
+ome.ol3.geom.Line.prototype.getLineCoordinates = function() {
+    return (
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates()
+    );
+}
 
 /**
  * Gets the transformation associated with the Line

--- a/ol3-viewer/src/ome/ol3/geom/Point.js
+++ b/ol3-viewer/src/ome/ol3/geom/Point.js
@@ -1,0 +1,114 @@
+//
+// Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+goog.provide('ome.ol3.geom.Point');
+
+goog.require('ol.geom.Circle');
+
+/**
+ * @classdesc
+ * Point extends of the built-in ol.geom.Circle
+ *
+ * @constructor
+ * @extends {ol.geom.Circle}
+ *
+ * @param {Array.<number>} coords the point coordinates
+ * @param {Object=} transform an AffineTransform object according to omero marshal
+ */
+ome.ol3.geom.Point = function(coords, transform) {
+    // preliminary checks: are all mandatory paramters numeric
+    if (!ome.ol3.utils.Misc.isArray(coords) || coords.length !== 2)
+        console.error("Point needs an array of coordinates (length: 2)!");
+
+    /**
+     * the size of the point (radius of circle that is)
+     * @type {Array.<number>}
+     * @private
+     */
+    this.radius_ = 5;
+
+    /**
+     * the initial coordinates as a flat array
+     * @type {Array.<number>}
+     * @private
+     */
+    this.initial_coords_ = null;
+
+    /**
+     * the transformation matrix of length 6
+     * @type {Array.<number>|null}
+     * @private
+     */
+    this.transform_ =
+        ome.ol3.utils.Transform.convertAffineTransformIntoMatrix(transform);
+
+    // call super, handing in our coordinates and radius
+    goog.base(this, coords, this.radius_);
+    this.initial_coords_ = this.getFlatCoordinates();
+
+    // apply potential transform
+    this.flatCoordinates =
+        ome.ol3.utils.Transform.applyTransform(
+            this.transform_, this.initial_coords_);
+}
+goog.inherits(ome.ol3.geom.Point, ol.geom.Circle);
+
+
+/**
+ * Returns the coordinates as a flat array (excl. any potential transform)
+ * @return {Array.<number>} the coordinates as a flat array
+ */
+ome.ol3.geom.Point.prototype.getPointCoordinates = function() {
+    var ret =
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates();
+    return ret.slice(0, 2);
+}
+
+/**
+ * Gets the transformation associated with the point
+ * @return {Object|null} the AffineTransform object (omero marshal) or null
+ */
+ome.ol3.geom.Point.prototype.getTransform = function() {
+    return ome.ol3.utils.Transform.convertMatrixToAffineTransform(
+        this.transform_);
+}
+
+/**
+ * First translate then store the newly translated coords
+ *
+ * @private
+ */
+ome.ol3.geom.Point.prototype.translate = function(deltaX, deltaY) {
+    // delegate
+    if (this.transform_) {
+        this.transform_[4] += deltaX;
+        this.transform_[5] -= deltaY;
+        this.flatCoordinates =
+            ome.ol3.utils.Transform.applyTransform(
+                this.transform_, this.initial_coords_);
+        this.changed();
+    } else ol.geom.SimpleGeometry.prototype.translate.call(this, deltaX, deltaY);
+};
+
+/**
+ * Make a complete copy of the geometry.
+ * @return {ome.ol3.geom.Point} Clone.
+ */
+ome.ol3.geom.Point.prototype.clone = function() {
+    return new ome.ol3.geom.Point(
+        this.getPointCoordinates(), this.getTransform());
+};

--- a/ol3-viewer/src/ome/ol3/geom/Polygon.js
+++ b/ol3-viewer/src/ome/ol3/geom/Polygon.js
@@ -67,7 +67,7 @@ goog.inherits(ome.ol3.geom.Polygon, ol.geom.Polygon);
  * Returns the coordinates as a flat array (excl. any potential transform)
  * @return {Array.<number>} the coordinates as a flat array
  */
-ome.ol3.geom.Line.prototype.getPolygonCoordinates = function() {
+ome.ol3.geom.Polygon.prototype.getPolygonCoordinates = function() {
     return (
         this.transform_ ? this.initial_coords_ : this.getFlatCoordinates()
     );

--- a/ol3-viewer/src/ome/ol3/geom/Polygon.js
+++ b/ol3-viewer/src/ome/ol3/geom/Polygon.js
@@ -100,9 +100,27 @@ ome.ol3.geom.Polygon.prototype.translate = function(deltaX, deltaY) {
 };
 
 /**
+ * Returns the coordinates after (potentially) inverting a transformation
+ * @return {Array} the coordinate array
+ */
+ome.ol3.geom.Polygon.prototype.getInvertedCoordinates = function() {
+    if (this.transform_ === null) return this.getCoordinates();
+
+    var coords = this.getCoordinates();
+    var invCoords = new Array(coords[0].length);
+    for (var i=0;i<coords[0].length;i++)
+        invCoords[i] =
+            ome.ol3.utils.Transform.applyInverseTransform(
+                this.transform_, coords[0][i]);
+
+    return [invCoords];
+}
+
+/**
  * Make a complete copy of the geometry.
  * @return {ome.ol3.geom.Polygon} Clone.
  */
 ome.ol3.geom.Polygon.prototype.clone = function() {
-    return new ome.ol3.geom.Polygon(this.getCoordinates(), this.getTransform());
+    return new ome.ol3.geom.Polygon(
+            this.getInvertedCoordinates(), this.getTransform());
 };

--- a/ol3-viewer/src/ome/ol3/geom/Polygon.js
+++ b/ol3-viewer/src/ome/ol3/geom/Polygon.js
@@ -1,0 +1,98 @@
+//
+// Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+goog.provide('ome.ol3.geom.Polygon');
+
+goog.require('ol.geom.Polygon');
+
+/**
+ * @classdesc
+ * Polygon is an extension of the built-in ol.geom.Polygon to be able
+ * to use affine transformations
+ *
+ *
+ * @constructor
+ * @extends {ol.geom.Polygon}
+ *
+ * @param {Array.<Array>} coords the coordinates for the polygon
+ * @param {Object=} transform an AffineTransform object according to omero marshal
+ */
+ome.ol3.geom.Polygon = function(coords, transform) {
+    // preliminary checks: are all mandatory paramters numeric
+    if (!ome.ol3.utils.Misc.isArray(coords) || coords.length === 0)
+        console.error("Polygon needs a non-empty array of coordinates!");
+
+    /**
+     * the initial coordinates as a flat array
+     * @type {Array.<number>}
+     * @private
+     */
+    this.initial_coords_ = null;
+
+    /**
+     * the transformation matrix of length 6
+     * @type {Array.<number>|null}
+     * @private
+     */
+    this.transform_ =
+        ome.ol3.utils.Transform.convertAffineTransformIntoMatrix(transform);
+
+    // call super and hand in our coordinate array
+    goog.base(this, coords);
+    this.initial_coords_ = this.getFlatCoordinates();
+
+    // apply potential transform
+    this.flatCoordinates =
+        ome.ol3.utils.Transform.applyTransform(
+            this.transform_, this.initial_coords_);
+}
+goog.inherits(ome.ol3.geom.Polygon, ol.geom.Polygon);
+
+
+/**
+ * Gets the transformation associated with the polygon
+ * @return {Object|null} the AffineTransform object (omero marshal) or null
+ */
+ome.ol3.geom.Polygon.prototype.getTransform = function() {
+    return ome.ol3.utils.Transform.convertMatrixToAffineTransform(
+        this.transform_);
+}
+
+/**
+ * First translate then store the newly translated coords
+ *
+ * @private
+ */
+ome.ol3.geom.Polygon.prototype.translate = function(deltaX, deltaY) {
+    // delegate
+    if (this.transform_) {
+        this.transform_[4] += deltaX;
+        this.transform_[5] -= deltaY;
+        this.flatCoordinates =
+            ome.ol3.utils.Transform.applyTransform(
+                this.transform_, this.initial_coords_);
+        this.changed();
+    } else ol.geom.SimpleGeometry.prototype.translate.call(this, deltaX, deltaY);
+};
+
+/**
+ * Make a complete copy of the geometry.
+ * @return {ome.ol3.geom.Polygon} Clone.
+ */
+ome.ol3.geom.Polygon.prototype.clone = function() {
+    return new ome.ol3.geom.Polygon(this.getCoordinates(), this.getTransform());
+};

--- a/ol3-viewer/src/ome/ol3/geom/Polygon.js
+++ b/ol3-viewer/src/ome/ol3/geom/Polygon.js
@@ -64,6 +64,16 @@ goog.inherits(ome.ol3.geom.Polygon, ol.geom.Polygon);
 
 
 /**
+ * Returns the coordinates as a flat array (excl. any potential transform)
+ * @return {Array.<number>} the coordinates as a flat array
+ */
+ome.ol3.geom.Line.prototype.getPolygonCoordinates = function() {
+    return (
+        this.transform_ ? this.initial_coords_ : this.getFlatCoordinates()
+    );
+}
+
+/**
  * Gets the transformation associated with the polygon
  * @return {Object|null} the AffineTransform object (omero marshal) or null
  */

--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -464,7 +464,7 @@ ome.ol3.interaction.Draw.prototype.drawArrow_ = function(event) {
 ome.ol3.interaction.Draw.prototype.drawPoint_ = function(event) {
     this.drawShapeCommonCode_('Point', "point",
         function(coordinates, opt_geometry) {
-            return new ol.geom.Circle(coordinates, 5);
+            return new ome.ol3.geom.Point(coordinates);
     });
 };
 

--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -394,7 +394,16 @@ ome.ol3.interaction.Draw.prototype.endDrawingInteraction = function(reset) {
  * @param {Object} event the event object for the drawing interaction
  */
 ome.ol3.interaction.Draw.prototype.drawPolygon_ = function(event) {
-    this.drawShapeCommonCode_('Polygon', 'polygon');
+    this.drawShapeCommonCode_('Polygon', 'polygon',
+        function(coordinates, opt_geometry) {
+            var geometry = new ome.ol3.geom.Polygon(coordinates);
+
+            if (opt_geometry) {
+                opt_geometry.setCoordinates(geometry.getCoordinates());
+            }
+
+            return geometry;
+        });
 };
 
 /**

--- a/ol3-viewer/src/ome/ol3/interaction/Modify.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Modify.js
@@ -246,7 +246,8 @@ ome.ol3.interaction.Modify.handleDragEvent_ = function(mapBrowserEvent) {
             var potentialTransform = geometry.getTransform();
             var v = vertex;
             if (potentialTransform)
-                v = geometry.applyInverseTransform([v[0], v[1]]);
+                v = ome.ol3.utils.Transform.applyInverseTransform(
+                    potentialTransform, [v[0], v[1]]);
             geometry.rx_ = Math.abs(geometry.cx_-v[0]);
             geometry.ry_ = Math.abs(geometry.cy_-v[1]);
             var tmp =

--- a/ol3-viewer/src/ome/ol3/interaction/Modify.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Modify.js
@@ -143,9 +143,12 @@ ome.ol3.interaction.Modify.prototype.handlePointerAtPixel_ = function(pixel, map
         // get closest node
         var node = nodes[0];
 
-        // we only continue if we don't have an unmodifyable labels
-        if (!(node.geometry instanceof ome.ol3.geom.Label) &&
-            !(node.geometry instanceof ol.geom.Circle)) {
+        var disallowModification =
+            node.geometry instanceof ome.ol3.geom.Label ||
+            node.geometry instanceof ol.geom.Circle ||
+            (ome.ol3.utils.Misc.isArray(node.geometry.transform_) &&
+                    !(node.geometry instanceof ome.ol3.geom.Ellipse));
+        if (!disallowModification) {
             var closestSegment = node.segment;
             var vertex =
                 (ol.coordinate.closestOnSegment(
@@ -243,11 +246,11 @@ ome.ol3.interaction.Modify.handleDragEvent_ = function(mapBrowserEvent) {
             coordinates[depth[0]][segmentData.index + index] = vertex;
             segment[index] = vertex;
         } else if (geometry instanceof ome.ol3.geom.Ellipse) {
-            var potentialTransform = geometry.getTransform();
+            var potentialTransform =geometry.getTransform();
             var v = vertex;
             if (potentialTransform)
                 v = ome.ol3.utils.Transform.applyInverseTransform(
-                    potentialTransform, [v[0], v[1]]);
+                    geometry.transform_, [v[0], v[1]]);
             geometry.rx_ = Math.abs(geometry.cx_-v[0]);
             geometry.ry_ = Math.abs(geometry.cy_-v[1]);
             var tmp =

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -352,7 +352,7 @@ ome.ol3.utils.Conversion.ellipseToJsonObject = function(geometry, shape_id) {
     var radius = geometry.getRadius();
     ret['RadiusX'] = radius[0];
     ret['RadiusY'] = radius[1];
-    var trans = geometry.getTransform(true);
+    var trans = geometry.getTransform();
     if (typeof trans === 'object' && trans !== null) {
         trans['@type'] =
             "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
@@ -600,8 +600,8 @@ ome.ol3.utils.Conversion.integrateStyleIntoJsonObject = function(feature, jsonOb
                     jsonObject['FontStyle'] = fontTokens[0];
                     jsonObject['FontSize'] =  {
                         '@type': 'TBD#LengthI',
-                        'Unit': 'PIXEL',
-                        'Symbol': 'px',
+                        'Unit': 'POINT',
+                        'Symbol': 'pt',
                         'Value': parseInt(fontTokens[1])
                     };
                     jsonObject['FontFamily'] = fontTokens[2];

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -312,20 +312,26 @@ ome.ol3.utils.Conversion.convertColorToSignedInteger = function(color, alpha) {
  *
  * @static
  * @function
- * @param {ol.geom.Circle} geometry the circle instance for the point feature
+ * @param {ome.ol3.geom.Point} geometry the point geometry
  * @param {number=} shape_id the optional shape id
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.pointToJsonObject = function(geometry, shape_id) {
-    if (!(geometry instanceof ol.geom.Circle))
-        throw "shape type point must be of instance ol.geom.Circle!";
+    if (!(geometry instanceof ome.ol3.geom.Point))
+        throw "shape type point must be of instance ome.ol3.geom.Point!";
 
     var ret = {};
     if (typeof shape_id === 'number') ret['@id'] = shape_id;
     ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Point";
-    var center = geometry.getCenter();
+    var center = geometry.getPointCoordinates();
     ret['X'] = center[0];
     ret['Y'] = -center[1];
+    var trans = geometry.getTransform();
+    if (typeof trans === 'object' && trans !== null) {
+        trans['@type'] =
+            "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
+        ret['Transform'] = trans;
+    }
 
     return ret;
 }

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -409,7 +409,7 @@ ome.ol3.utils.Conversion.lineToJsonObject = function(geometry, shape_id) {
 
     var ret = {};
     if (typeof shape_id === 'number') ret['@id'] = shape_id;
-    var flatCoords = geometry.getFlatCoordinates();
+    var flatCoords = geometry.getLineCoordinates();
     //delegate if we happen to have turned into a polyline
     if (geometry.isPolyline())
         return ome.ol3.utils.Conversion.polylineToJsonObject.call(
@@ -449,7 +449,7 @@ ome.ol3.utils.Conversion.polylineToJsonObject = function(geometry, shape_id) {
 
     var ret = {};
     if (typeof shape_id === 'number') ret['@id'] = shape_id;
-    var flatCoords = geometry.getFlatCoordinates();
+    var flatCoords = geometry.getLineCoordinates();
     //delegate if we happen to have turned into a line
     if (!geometry.isPolyline())
         return ome.ol3.utils.Conversion.lineToJsonObject.call(
@@ -509,13 +509,13 @@ ome.ol3.utils.Conversion.labelToJsonObject = function(geometry, shape_id) {
  * @return {Object} returns an object ready to be turned into json
  */
 ome.ol3.utils.Conversion.polygonToJsonObject = function(geometry, shape_id) {
-    if (!(geometry instanceof ol.geom.Polygon))
-        throw "shape type polygon must be of instance ol.geom.Polygon!";
+    if (!(geometry instanceof ome.ol3.geom.Polygon))
+        throw "shape type polygon must be of instance ome.ol3.geom.Polygon!";
 
     var ret = {};
     if (typeof shape_id === 'number') ret['@id'] = shape_id;
     ret['@type'] = "http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon";
-    var flatCoords = geometry.getFlatCoordinates();
+    var flatCoords = geometry.getPolygonCoordinates();
 
     ret['Points'] = "";
     for (var i=0; i<flatCoords.length;i+= 2) {

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -384,6 +384,13 @@ ome.ol3.utils.Conversion.rectangleToJsonObject = function(geometry, shape_id) {
     ret['Width'] = geometry.getWidth();
     ret['Height'] = geometry.getHeight();
 
+    var trans = geometry.getTransform();
+    if (typeof trans === 'object' && trans !== null) {
+        trans['@type'] =
+            "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
+        ret['Transform'] = trans;
+    }
+
     return ret;
 }
 
@@ -416,6 +423,13 @@ ome.ol3.utils.Conversion.lineToJsonObject = function(geometry, shape_id) {
 
     if (geometry.has_start_arrow_) ret['MarkerStart'] = "Arrow";
     if (geometry.has_end_arrow_) ret['MarkerEnd'] = "Arrow";
+
+    var trans = geometry.getTransform();
+    if (typeof trans === 'object' && trans !== null) {
+        trans['@type'] =
+            "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
+        ret['Transform'] = trans;
+    }
 
     return ret;
 }
@@ -450,6 +464,13 @@ ome.ol3.utils.Conversion.polylineToJsonObject = function(geometry, shape_id) {
 
     if (geometry.has_start_arrow_) ret['MarkerStart'] = "Arrow";
     if (geometry.has_end_arrow_) ret['MarkerEnd'] = "Arrow";
+
+    var trans = geometry.getTransform();
+    if (typeof trans === 'object' && trans !== null) {
+        trans['@type'] =
+            "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
+        ret['Transform'] = trans;
+    }
 
     return ret;
 }

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -523,6 +523,13 @@ ome.ol3.utils.Conversion.polygonToJsonObject = function(geometry, shape_id) {
         ret['Points'] += flatCoords[i] + "," + (-flatCoords[i+1]);
     }
 
+    var trans = geometry.getTransform();
+    if (typeof trans === 'object' && trans !== null) {
+        trans['@type'] =
+            "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform";
+        ret['Transform'] = trans;
+    }
+
     return ret;
 }
 

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -22,8 +22,6 @@
 goog.provide('ome.ol3.utils.Regions');
 
 goog.require('ol.Feature');
-goog.require('ol.geom.Circle');
-goog.require('ol.geom.Polygon');
 goog.require('ol.extent');
 
 /**
@@ -37,8 +35,11 @@ goog.require('ol.extent');
 ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
     "point" : function(shape) {
         var feat =
-            new ol.Feature({"geometry" : new ol.geom.Circle(
-                [shape['X'], -shape['Y']], 5)});
+            new ol.Feature({
+                "geometry" : new ome.ol3.geom.Point(
+                    [shape['X'], -shape['Y']],
+                    typeof shape['Transform'] === 'object' ?
+                        shape['Transform'] : null)});
         feat['type'] = "point";
         feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
         return feat;

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -55,7 +55,9 @@ ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
     },
     "rectangle" : function(shape) {
         var feat = new ol.Feature({"geometry" : new ome.ol3.geom.Rectangle(
-            shape['X'], -shape['Y'], shape['Width'], shape['Height'])});
+            shape['X'], -shape['Y'], shape['Width'], shape['Height'],
+            typeof shape['Transform'] === 'object' ?
+                shape['Transform'] : null)});
         feat['type'] = "rectangle";
         feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
         return feat;
@@ -68,7 +70,9 @@ ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
                 shape['MarkerEnd'] === 'Arrow';
         var feat = new ol.Feature({"geometry" : new ome.ol3.geom.Line(
                 [[shape['X1'], -shape['Y1']], [shape['X2'], -shape['Y2']]],
-                drawStartArrow, drawEndArrow)});
+                drawStartArrow, drawEndArrow,
+                typeof shape['Transform'] === 'object' ?
+                    shape['Transform'] : null)});
         feat['type'] = "line";
         feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
         return feat;
@@ -85,7 +89,9 @@ ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
             typeof shape['MarkerEnd'] === 'string' &&
                 shape['MarkerEnd'] === 'Arrow';
         var feat = new ol.Feature({"geometry" : new ome.ol3.geom.Line(
-                coords, drawStartArrow, drawEndArrow)});
+                coords, drawStartArrow, drawEndArrow,
+                typeof shape['Transform'] === 'object' ?
+                    shape['Transform'] : null)});
         feat['type'] = "polyline";
         feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
         return feat;
@@ -125,7 +131,10 @@ ome.ol3.utils.Regions.FEATURE_FACTORY_LOOKUP_TABLE = {
             ome.ol3.utils.Conversion.convertPointStringIntoCoords(shape['Points']);
         if (coords === null) return null;
 
-        var feat = new ol.Feature({"geometry" : new ol.geom.Polygon([coords])});
+        var feat = new ol.Feature({"geometry" :
+            new ome.ol3.geom.Polygon([coords],
+                typeof shape['Transform'] === 'object' ?
+                    shape['Transform'] : null)});
         feat['type'] = "polygon";
         feat.setStyle(ome.ol3.utils.Style.createFeatureStyle(shape));
         return feat;

--- a/ol3-viewer/src/ome/ol3/utils/Transform.js
+++ b/ol3-viewer/src/ome/ol3/utils/Transform.js
@@ -137,3 +137,41 @@ ome.ol3.utils.Transform.applyInverseTransform = function(transform, coords) {
 
     return transCoords;
 }
+
+/**
+ * Takes the 3x2 transformation matrix and extracts the rotation and scaling
+ *
+ * @static
+ * @param {Array.<number>} transform a flat transformation matrix (length: 3 * 2)
+ * @return {Object|null} an object properties for scale_x, scale_y,
+ *                       rot_deg and rot_rad or null (if invalid matrix)
+ */
+ome.ol3.utils.Transform.getRotationAndScaling = function(transform) {
+    // preliminary checks:
+    if (!ome.ol3.utils.Misc.isArray(transform) ||
+        transform.length !== 6) return null;
+
+    // extract scale factors for x/y
+    var scale_x =
+        Math.sqrt(
+            transform[0] * transform[0] + transform[1] * transform[1]);
+    var scale_y =
+        Math.sqrt(
+            transform[2] * transform[2] + transform[3] * transform[3]);
+    // recover angle in radians
+    var rot_rad = Math.atan2(transform[2],transform[3]);
+    // see if scales are negative
+    if ((rot_rad >= 0 && rot_rad <= Math.PI && transform[0] < 0) ||
+        (rot_rad > Math.PI && rot_rad < Math.PI*2) && transform[0] > 0)
+            scale_x *= -1;
+    if ((rot_rad >= 0 && rot_rad <= Math.PI && transform[3] < 0) ||
+        (rot_rad > Math.PI && rot_rad < Math.PI*2) && transform[3] > 0)
+            scale_y *= -1;
+
+    return {
+        'scale_x': scale_x,
+        'scale_y': scale_y,
+        'rot_rad': rot_rad,
+        'rot_deg': rot_rad * (180 / Math.PI)
+    };
+}

--- a/ol3-viewer/src/ome/ol3/utils/Transform.js
+++ b/ol3-viewer/src/ome/ol3/utils/Transform.js
@@ -1,0 +1,139 @@
+//
+// Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+/**
+ * @namespace ome.ol3.utils.Transform
+ */
+goog.provide('ome.ol3.utils.Transform');
+
+/**
+ * Converts the AffineTransform Object into a flat transformation matrix
+ *
+ * @static
+ * @param {Object} transform a transformation object with properties A00-A12
+ * @return {Array.<number>} a transformation matrix as an array of length 6
+ *                          or null if an error occured
+ */
+ome.ol3.utils.Transform.convertAffineTransformIntoMatrix = function(transform) {
+    if (typeof transform !== 'object' ||
+        transform === null || typeof transform['@type'] !== 'string' ||
+        transform['@type'].indexOf("#AffineTransform") === -1) return null;
+
+    try {
+        return [
+            transform['A00'], transform['A10'], transform['A01'],
+            transform['A11'], transform['A02'], transform['A12']
+        ];
+    } catch(err) {
+        console.error("failed to convert tranform into matrix");
+    }
+    return null;
+}
+
+/**
+ * Gets the transformation as an AffineTransform object (omero marshal 2016-06)
+ * given a transformation matrix of length 6
+ *
+ * @static
+ * @param {Array.<number>} transform the supposed transformation matrix
+ * @return {Object|null} an AffineTransform object according to omero marshal
+ */
+ome.ol3.utils.Transform.convertMatrixToAffineTransform = function(transform) {
+    // check geometry for a flat transformation matrix of length 6
+    if (!ome.ol3.utils.Misc.isArray(transform) || transform.length !== 6)
+        return null;
+
+    return {
+        '@type': "http://www.openmicroscopy.org/Schemas/OME/2016-06#AffineTransform",
+        'A00' : transform[0], 'A10' : transform[1],
+        'A01' : transform[2], 'A11' : transform[3],
+        'A02' : transform[4], 'A12' : transform[5]
+    };
+}
+
+/**
+ * Applies a transformation to the given coordinates
+ *
+ * @static
+ * @param {Array.<number>} transform a flat transformation matrix (length: 3 * 2)
+ * @param {Array.<number>} coords a flat array of coordinates (n * (x|y) tuples)
+ * @return {Array.<number>} an array of transformed coords
+ */
+ome.ol3.utils.Transform.applyTransform = function(transform, coords) {
+    // preliminary checks
+    if (!ome.ol3.utils.Misc.isArray(transform) || transform.length !== 6 ||
+        !ome.ol3.utils.Misc.isArray(coords) || coords.length === 0 ||
+        coords.length % 2 !== 0) return coords;
+
+    var len = coords.length;
+    var transCoords = new Array(len);
+    for (var i=0;i<len;i+=2) {
+        transCoords[i] = //x
+            transform[0] * coords[i] +
+                transform[2] * (-coords[i+1]) + transform[4];
+        transCoords[i+1] = //y
+            -(transform[1] * coords[i] +
+                transform[3] * (-coords[i+1]) + transform[5]);
+    }
+    return transCoords;
+}
+
+/**
+ * Performs an inverse transform (if exists) on some transformed coordinates
+ * given a their original transformation matrix
+ *
+ * @static
+ * @param {Array.<number>} transform a flat transformation matrix (length: 3 * 2)
+ * @param {Array.<number>} coords a flat array of coordinates (n * (x|y) tuples)
+ * @return {Array.<number>} an array of transformed coords equal in dimensinonality to the input
+ */
+ome.ol3.utils.Transform.applyInverseTransform = function(transform, coords) {
+    // preliminary checks:
+    if (!ome.ol3.utils.Misc.isArray(transform) || transform.length !== 6 ||
+        !ome.ol3.utils.Misc.isArray(coords) || coords.length === 0 ||
+        coords.length % 2 !== 0) return coords;
+
+    // find matrix inverse hecking for determinant being 0 (trace)
+    var det = transform[0] * transform[3] - transform[1] * transform[2];
+    if (det === 0) return coords;
+    var inverse = new Array(transform.length);
+    var a = transform[0];
+    var b = transform[1];
+    var c = transform[2];
+    var d = transform[3];
+    var e = transform[4];
+    var f = transform[5];
+    inverse[0] = d / det;
+    inverse[1] = -b / det;
+    inverse[2] = -c / det;
+    inverse[3] = a / det;
+    inverse[4] = (c * f - d * e) / det;
+    inverse[5] = -(a * f - b * e) / det;
+
+    // multiply coordinates with inverted matrix
+    var len = coords.length;
+    var transCoords = new Array(len);
+    for (var i=0;i<len;i+=2) {
+        transCoords[i] = //x
+            inverse[0] * coords[i] + inverse[2] * (-coords[i+1]) + inverse[4];
+        transCoords[i+1] = //y
+            -(inverse[1] * coords[i] + inverse[3] * (-coords[i+1]) + inverse[5]);
+    }
+
+    return transCoords;
+}

--- a/test/unit/geom/geometries.js
+++ b/test/unit/geom/geometries.js
@@ -85,4 +85,29 @@ describe("Geometries", function() {
         expect(polyline.getFlatCoordinates()).to.eql([500,400,1000,800,1100,700]);
     });
 
+    it('createPolygon', function() {
+        var polygon =
+            new ome.ol3.geom.Polygon([[[250,0], [400,200], [100,200], [250,0]]]);
+
+        assert.instanceOf(polygon, ome.ol3.geom.Polygon);
+        expect(polygon.getFlatCoordinates()).to.eql(
+            [250,0,400,200,100,200,250,0]);
+
+        // test translation
+        polygon.translate(-150,100);
+        expect(polygon.getFlatCoordinates()).to.eql(
+            [100,100,250,300,-50,300,100,100]);
+    });
+
+    it('createPoint', function() {
+        var point = new ome.ol3.geom.Point([500, 500]);
+
+        assert.instanceOf(point, ome.ol3.geom.Point);
+        expect(point.getPointCoordinates()).to.eql([500,500]);
+
+        // test translation
+        point.translate(-500,-500);
+        expect(point.getPointCoordinates()).to.eql([0,0]);
+    });
+
 });

--- a/test/unit/utils/conversion.js
+++ b/test/unit/utils/conversion.js
@@ -112,7 +112,7 @@ describe("Conversion", function() {
     });
 
     var pointFeature = new ol.Feature({
-        geometry: new ol.geom.Circle([10,-10], 2)
+        geometry: new ome.ol3.geom.Point([10,-10])
     });
 
     it('pointToJsonObject', function() {

--- a/test/unit/utils/conversion.js
+++ b/test/unit/utils/conversion.js
@@ -258,7 +258,7 @@ describe("Conversion", function() {
         assert.equal(jsonObject['FontFamily'] , 'arial');
         assert.equal(jsonObject['FontStyle'] , 'bold');
         assert.equal(jsonObject['FontSize']['@type'] , 'TBD#LengthI');
-        assert.equal(jsonObject['FontSize']['Unit'] , 'PIXEL');
+        assert.equal(jsonObject['FontSize']['Unit'] , 'POINT');
         assert.equal(jsonObject['FontSize']['Value'] , 666);
     });
 

--- a/test/unit/utils/conversion.js
+++ b/test/unit/utils/conversion.js
@@ -207,7 +207,7 @@ describe("Conversion", function() {
     });
 
     var polygonFeature = new ol.Feature({
-        geometry: new ol.geom.Polygon(
+        geometry: new ome.ol3.geom.Polygon(
             [[[0,0],[10,-10], [0,-100], [0,0]]])
     });
 

--- a/test/unit/utils/regions.js
+++ b/test/unit/utils/regions.js
@@ -90,7 +90,7 @@ describe("Regions", function() {
 
         feature = ome.ol3.utils.Regions.featureFactory(point_info);
         assert.instanceOf(feature, ol.Feature);
-        assert.instanceOf(feature.getGeometry(),  ol.geom.Circle);
+        assert.instanceOf(feature.getGeometry(),  ome.ol3.geom.Point);
         expect(feature.getGeometry().getCenter()).to.eql([10,-25]);
         expect(feature.getGeometry().getRadius()).to.eql(5);
 

--- a/test/unit/utils/regions.js
+++ b/test/unit/utils/regions.js
@@ -128,7 +128,7 @@ describe("Regions", function() {
         for (var f in features) {
             assert.instanceOf(features[f], ol.Feature);
             var geom = features[f].getGeometry();
-            assert.instanceOf(geom, ol.geom.Polygon);
+            assert.instanceOf(geom, ome.ol3.geom.Polygon);
             assert(ol.extent.containsExtent([0,-1000,1000,0], geom.getExtent()));
         }
     });


### PR DESCRIPTION
A general refactoring of transformations.

Uses omero-marshal schema 2016-06 for retrieval/storage with AffineTransform object (json).

Test: 
- Use http://web-dev-merge.openmicroscopy.org and open image with iviewer. 
- Note: shapes cannot (yet) be rotated in iviewer. 

1. Either choose an image that has alrady a shape with a transform (e.g. http://web-dev-merge.openmicroscopy.org/iviewer/9443/?dataset=1457 - user 1) or create a new one in insight.

2. Modify it and then store it. Open it again to see that is displays properly. Double check with the default web viewer and/or insight after persistence.

