### PR TITLE
Reverse intensity rename iviewer

### DIFF
--- a/src/settings/channel-range.html
+++ b/src/settings/channel-range.html
@@ -38,7 +38,7 @@
                         disabled.bind="channel.reverseIntensity === null"
                         checked.bind="channel.reverseIntensity"
                         change.delegate="onReverseIntensityToggle()"/>
-                        &nbsp;Reverse Intensity
+                        &nbsp;Invert
                 </label>
             </div>
             <hr />


### PR DESCRIPTION
Simply renames the 'Reverse Intensity' checkbox to 'Invert'.

See also: https://trello.com/c/AN7eXyM3/19-rename-in-viewers-reverse-intensity
