### PR TITLE
tiled image tests

### DIFF
--- a/ol3-viewer/src/ome/ol3/source/Image.js
+++ b/ol3-viewer/src/ome/ol3/source/Image.js
@@ -236,6 +236,10 @@ ome.ol3.source.Image = function(options) {
         origin: ol.extent.getTopLeft(extent),
         resolutions: this.resolutions_
     });
+    tileGrid.getZForResolution = function(resolution, opt_direction) {
+        var z = ol.array.linearFindNearest(this.resolutions_, resolution, 1);
+        return ol.math.clamp(z, this.minZoom, this.maxZoom);
+    };
 
     // a custom tile url function concatinating all image specificiations
     // needed to retrieve the image from the server

--- a/ol3-viewer/src/ome/ol3/utils/Misc.js
+++ b/ol3-viewer/src/ome/ol3/utils/Misc.js
@@ -87,9 +87,9 @@ ome.ol3.utils.Misc.prepareResolutions = function(resolutions) {
         var resAtI = resolutions[i];
         var resBefI = resolutions[i-1];
         var delta = Math.abs(resBefI - resAtI);
-        // we divide up into 8 levels in between, i.e. 12.5% of the original delta
-        var partialDelta = delta * 0.125;
-        for (var j=1;j<=8;j++) newRes.push(resAtI + j * partialDelta);
+        // we divide up into 4 levels in between, i.e. 12.5% of the original delta
+        var partialDelta = delta * 0.25;
+        for (var j=1;j<=4;j++) newRes.push(resAtI + j * partialDelta);
     }
     // append zoom in factors (if present, unlikely with tiled)
     if (oneToOneIndex < resolutions.length-1)

--- a/test/unit/utils/misc.js
+++ b/test/unit/utils/misc.js
@@ -28,9 +28,9 @@ describe("Misc", function() {
         expect(resolutions.length).to.eql(80);
         expect(resolutions[40]).to.eql(1);
         resolutions = ome.ol3.utils.Misc.prepareResolutions([2.2,0.6, 0.1]);
-        expect(resolutions.length).to.eql(21);
+        expect(resolutions.length).to.eql(17);
         expect(resolutions[5]).to.eql(2.2);
-        expect(resolutions[13]).to.eql(1);
-        expect(resolutions.slice(14,16)).to.eql([0.6,0.1]);
+        expect(resolutions[9]).to.eql(1);
+        expect(resolutions.slice(10,12)).to.eql([0.6,0.1]);
     });
 });


### PR DESCRIPTION
this PR is for testing, to illustrate the effect that some measures have.

for a start the 8 in between resolution levels have been halved.
also, as opposed to choosing the next closest resolution level, the lower one is chosen always unless we hit a natural resolution level. This means that there is no such case when tiles get smaller (as in the case we snap to the higher resolution). Unfortunately this also means that quality is lost when the naturally lower resolution tiles need to be made bigger.