### PR TITLE
bugfix - wrong variable type

### DIFF
--- a/src/info/info.js
+++ b/src/info/info.js
@@ -123,12 +123,13 @@ export class Info {
         if (this.image_info === null) return;
 
         let acquisition_date = "-";
-        if (typeof this.image_info.image_pixels_size.x == 'number') {
+        if (typeof this.image_info.image_timestamp === 'number') {
             acquisition_date = new Date(this.image_info.image_timestamp * 1000).toISOString().slice(-25, -14);
         }
         let pixels_size = "";
         let pixels_size_label = "Pixels Size (XYZ)";
-        if (typeof this.image_info.image_pixels_size === 'object') {
+        if (typeof this.image_info.image_pixels_size === 'object' &&
+            this.image_info.image_pixels_size !== null) {
             let symbol = '\xB5m'; // microns by default
             let unit = 'MICROMETER';
             let count = 0;


### PR DESCRIPTION
in the info tab a type check needed corrections. the wrong member variable is checked, one whose parent (who is checked 2 lines later) could be null at that point.

TEST: open an image that has no pixel size (e.g.http://web-dev-merge.openmicroscopy.org/iviewer/?images=71652&dataset=1457 / user-1) and check that there are no errors.