### PR TITLE
IViewer - Default Viewer Configuration

### DIFF
--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -37,7 +37,7 @@ To replace the default omero.web viewer:
 
 ::
 
-    $ bin/omero config set omero.web.viewer.view omero_iviewer.views.index_default
+    $ bin/omero config set omero.web.viewer.view omero_iviewer.views.index
 
 To enable the "open with" feature:
 

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -37,13 +37,13 @@ To replace the default omero.web viewer:
 
 ::
 
-    $ bin/omero config set omero.web.viewer.view omero_iviewer_index_default
+    $ bin/omero config set omero.web.viewer.view omero_iviewer.views.index_default
 
 To enable the "open with" feature:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer.views.index",
+    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer_index",
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -43,7 +43,7 @@ To enable the "open with" feature:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer_index",
+    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer_index_default",
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -37,13 +37,13 @@ To replace the default omero.web viewer:
 
 ::
 
-    $ bin/omero config set omero.web.viewer.view omero_iviewer.views.index
+    $ bin/omero config set omero.web.viewer.view omero_iviewer_index_default
 
 To enable the "open with" feature:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer_index_default",
+    $ bin/omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer.views.index",
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -24,7 +24,10 @@ urlpatterns = patterns(
 
     'django.views.generic.simple',
 
-    # index 'home page' of the iviewer app
+    # entry point for default viewer
+    url(r'^/(?P<iid>[0-9]+)/$',
+        views.index_default, name='omero_iviewer_index_default'),
+    # general entry point for iviewer app
     url(r'^/?$', views.index, name='omero_iviewer_index'),
     url(r'^persist_rois/?$', views.persist_rois,
         name='omero_iviewer_persist_rois'),

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -23,10 +23,6 @@ import views
 urlpatterns = patterns(
 
     'django.views.generic.simple',
-
-    # entry point for default viewer
-    url(r'^/(?P<iid>[0-9]+)/$',
-        views.index_default, name='omero_iviewer_index_default'),
     # general entry point for iviewer app
     url(r'^/?$', views.index, name='omero_iviewer_index'),
     url(r'^persist_rois/?$', views.persist_rois,

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -51,9 +51,21 @@ QUERY_DISTANCE = 25
 
 
 @login_required()
-def index(request, conn=None, **kwargs):
+def index_default(request, iid=None, conn=None, **kwargs):
+    # delegate to index
+    return index(request, iid=iid, conn=conn)
+
+
+@login_required()
+def index(request, iid=None, conn=None, **kwargs):
     # set params
     params = {'VERSION': __version__}
+
+    # check for image_id (default viewer setup)
+    if iid is not None:
+        params['IMAGES'] = iid
+
+    # add rest of query string params
     for key in request.GET:
         if request.GET[key]:
             params[str(key).upper()] = str(request.GET[key])

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -51,12 +51,6 @@ QUERY_DISTANCE = 25
 
 
 @login_required()
-def index_default(request, iid=None, conn=None, **kwargs):
-    # delegate to index
-    return index(request, iid=iid, conn=conn)
-
-
-@login_required()
 def index(request, iid=None, conn=None, **kwargs):
     # set params
     params = {'VERSION': __version__}

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -473,7 +473,7 @@ def get_intensity(request, conn=None, **kwargs):
                 return JsonResponse(
                     {"error": "One or more channels are out of bounds"})
             channels.append(tok)
-    except:
+    except Exception:
         return JsonResponse(
             {"error": "The channels have to be a comma separated string"})
     if len(channels) == 0:

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -500,28 +500,49 @@ export default class Context {
         let newPath = window.location.pathname;
         let parent_id = null;
         let selConf = this.getSelectedImageConfig();
+
         let parentType =
             this.initial_type === INITIAL_TYPES.IMAGES ?
                 selConf.image_info.parent_type : this.initial_type;
         let parentTypeString =
             parentType === INITIAL_TYPES.WELL ? "well" : "dataset";
 
-        if (this.initial_type === INITIAL_TYPES.IMAGES) {
-            if (this.initial_ids.length > 1)
-                newPath += window.location.search;
-            else {
-                parent_id = selConf.image_info.parent_id;
-                newPath +=
-                    '?images=' + image_id + '&' + parentTypeString + "=" + parent_id;
+        // default viewer url
+        if (newPath.indexOf("webclient/img_detail") !== -1) {
+            let old_image_id =
+                selConf && selConf.image_info ?
+                    selConf.image_info.image_id: null;
+            if (old_image_id) {
+                newPath = newPath.replace(old_image_id, image_id);
+                parent_id =
+                    this.initial_type === INITIAL_TYPES.IMAGES ?
+                        (typeof selConf.image_info.parent_id === 'number' ?
+                            selConf.image_info.parent_id : null) :
+                        this.initial_ids[0];
+                if (parent_id)
+                    newPath += "?" + parentTypeString + "=" + parent_id;
             }
         } else {
-            parent_id = this.initial_ids[0];
-            newPath += "?" + parentTypeString + "=" + parent_id;
+            // 'standard' url
+            if (this.initial_type === INITIAL_TYPES.IMAGES) {
+                if (this.initial_ids.length > 1)
+                    newPath += window.location.search;
+                else {
+                    parent_id = selConf.image_info.parent_id;
+                    newPath +=
+                        '?images=' + image_id + '&' + parentTypeString + "=" + parent_id;
+                }
+            } else {
+                parent_id = this.initial_ids[0];
+                newPath += "?" + parentTypeString + "=" + parent_id;
+            }
+            if (this.is_dev_server) {
+                newPath += (newPath.indexOf('?') === -1) ? '?' : '&';
+                newPath += 'haveMadeCrossOriginLogin_';
+            }
         }
-        if (this.is_dev_server) {
-            newPath += (newPath.indexOf('?') === -1) ? '?' : '&';
-            newPath += 'haveMadeCrossOriginLogin_';
-        }
+
+        // add history entry
         window.history.pushState(
             {image_id: image_id,
              parent_id: parent_id,

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -500,7 +500,8 @@ export default class Context {
         let newPath = window.location.pathname;
         let parent_id = null;
         let selConf = this.getSelectedImageConfig();
-
+        if (selConf === null) return;
+        
         let parentType =
             this.initial_type === INITIAL_TYPES.IMAGES ?
                 selConf.image_info.parent_type : this.initial_type;

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -36,6 +36,7 @@
                  'border: 2px solid rgba(0,60,136,0.5)' : 'border: none'}"
              src.bind="thumb.url + '?version=' + thumb.revision"
              title="${thumb.title}"
+             alt="Not Found"
              click.delegate="onClick(thumb.id)"/>
     </div>
     <div show.bind="thumbnails_end_index < thumbnails_count"

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -303,7 +303,11 @@ export default class ThumbnailSlider extends EventSubscriber {
                 if (typeof response !== 'object' || response === null ||
                     !Misc.isArray(response.paths) ||
                     response.paths.length === 0) {
-                        this.hideMe();
+                        if (typeof this.image_config.image_info.parent_id === 'number' &&
+                            !isNaN(this.image_config.image_info.parent_id) &&
+                            this.image_config.image_info.parent_id > 0) {
+                                this.requestMoreThumbnails(true, true, true);
+                        } else this.hideMe();
                         return;
                 }
 

--- a/src/viewers/viewer-context-menu.js
+++ b/src/viewers/viewer-context-menu.js
@@ -364,10 +364,10 @@ export default class ViewerContextMenu {
                             "/?show=image-" + resp.id;
                         let linkIviewer = this.context.server +
                             this.context.getPrefixedURI(IVIEWER) +
-                            "/" + resp.id;
+                            "/?images=" + resp.id;
                         if (this.context.initial_type !== INITIAL_TYPES.WELL &&
                             typeof imgInf.parent_id === 'number')
-                                linkIviewer += "/?dataset=" + imgInf.parent_id;
+                                linkIviewer += "&dataset=" + imgInf.parent_id;
                     msg =
                         "<a href='" + linkWebclient + "' target='_blank'>" +
                         "Navigate to Image in Webclient</a><br>" +


### PR DESCRIPTION
Eearlier on iviewer's url was such that it was fully compatible to be used as the omero web default viewer.

With parameter renames and url changes to accomodate opening of image lists, datasets and wells this was broken.

This PR fixes the problem by adding a url entry point and delegating to the general index method.

TEST: Check that iviewer opens the right image when set as the web's default viewer.