### PR TITLE
Info - redundant unbind

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -461,7 +461,7 @@ def get_intensity(request, conn=None, **kwargs):
                 return JsonResponse(
                     {"error": "One or more channels are out of bounds"})
             channels.append(tok)
-    except:
+    except Exception:
         return JsonResponse(
             {"error": "The channels have to be a comma separated string"})
     if len(channels) == 0:

--- a/src/info/info.js
+++ b/src/info/info.js
@@ -112,6 +112,7 @@ export class Info {
             if (o) o.dispose();
         });
         this.observers = [];
+        this.columns = [];
     }
 
     /**
@@ -215,16 +216,4 @@ export class Info {
             }
         } else this.parent_info = null;
     }
-
-    /**
-     * Overridden aurelia lifecycle method:
-     * called whenever the view is unbound within aurelia
-     * in other words a 'destruction' hook that happens after 'detached'
-     *
-     * @memberof Info
-     */
-    unbind() {
-        this.columns = [];
-    }
-
 }


### PR DESCRIPTION
I noticed that the info page code had the unbind() method defined twice (perhaps an accident while merging?). Due to  unbind()'s role this did not have a noticeable impact on the app but should be corrected nonetheless.

Test: Check that the info tab displays properly (web-dev-merge.openmicroscopy.org)