### PR TITLE
Acquisition & Import Date Display

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -263,6 +263,10 @@ def image_data(request, image_id, conn=None, **kwargs):
 
         rv['delta_t'] = time_list
         rv['delta_t_unit_symbol'] = delta_t_unit_symbol
+        df = "%Y-%m-%d %H:%M:%S"
+        rv['import_date'] = image.creationEventDate().strftime(df)
+        if image.getAcquisitionDate() is not None:
+            rv['acquisition_date'] = image.getAcquisitionDate().strftime(df)
 
         return JsonResponse(rv)
     except Exception as image_data_retrieval_exception:

--- a/src/info/info.js
+++ b/src/info/info.js
@@ -123,10 +123,6 @@ export class Info {
     onImageConfigChange() {
         if (this.image_info === null) return;
 
-        let acquisition_date = "-";
-        if (typeof this.image_info.image_timestamp === 'number') {
-            acquisition_date = new Date(this.image_info.image_timestamp * 1000).toISOString().slice(-25, -14);
-        }
         let pixels_size = "";
         let pixels_size_label = "Pixels Size (XYZ)";
         if (typeof this.image_info.image_pixels_size === 'object' &&
@@ -178,26 +174,33 @@ export class Info {
         this.columns = [
             {"label": "Owner:",
              "value": this.image_info.author,
-            },
-            {"label": "Acquisition Date:",
-             "value": acquisition_date,
-            },
-            {"label": "Dimension (XY):",
-             "value": size_xy,
-            },
-            {"label": "Pixels Type:",
-             "value": this.image_info.image_pixels_type,
-            },
-            {"label": pixels_size_label,
-             "value": pixels_size,
-            },
-            {"label": "Z-sections:",
-             "value": this.image_info.dimensions.max_z,
-            },
-            {"label": "Timepoints:",
-             "value": this.image_info.dimensions.max_t,
             }
         ];
+        if (this.image_info.acquisition_date) {
+            this.columns.push(
+                {"label": "Acquisition Date:",
+                 "value": this.image_info.acquisition_date});
+        };
+        this.columns = this.columns.concat([
+            {"label": "Import Date:",
+             "value": this.image_info.import_date
+            },
+            {"label": "Dimension (XY):",
+             "value": size_xy
+            },
+            {"label": "Pixels Type:",
+             "value": this.image_info.image_pixels_type
+            },
+            {"label": pixels_size_label,
+             "value": pixels_size
+            },
+            {"label": "Z-sections:",
+             "value": this.image_info.dimensions.max_z
+            },
+            {"label": "Timepoints:",
+             "value": this.image_info.dimensions.max_t
+            }
+        ]);
         if (typeof this.image_info.parent_id === 'number') {
             let isWell =
                 this.context.initial_type === INITIAL_TYPES.WELL ||

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -120,7 +120,14 @@ export default class ImageInfo {
      * @memberof ImageInfo
      * @type {string}
      */
-    image_timestamp = null;
+    acquisition_date = null;
+
+    /**
+     * the import date in the json response
+     * @memberof ImageInfo
+     * @type {string}
+     */
+    import_date = null;
 
     /**
      * the pixels type in the json response
@@ -348,7 +355,9 @@ export default class ImageInfo {
         }
         if (typeof response.meta.pixelsType === 'string')
             this.image_pixels_type = response.meta.pixelsType;
-        this.image_timestamp = response.meta.imageTimestamp;
+        this.import_date = response.import_date;
+        if (typeof response.acquisition_date === 'string')
+            this.acquisition_date = response.acquisition_date;
         this.setFormattedDeltaT(response);
         this.roi_count = response.roi_count;
         if (typeof response.meta.datasetName === 'string')


### PR DESCRIPTION
see: https://trello.com/c/Dse1xHso/5-acquisition-date-in-info

The info tab displayed what was the import date at times (plus it omitted the time).
With the changes in this PR the handling is analog to the web client down to the image methods used to get the respective dates:

The import date is displayed in full always. The acquisition date (incl. time) if exists.

TEST: http://web-dev-merge.openmicroscopy.org