### PR TITLE
Webpack Dev Server Setup - Reincarnated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "6"
 
+addons:
+  chrome: stable
+
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Either development setup expects the following:
 
 **Notes**:
 
-The webpack dev-server config expects a local OMERO server at http://localhost.
+The webpack dev-server config expects a local OMERO server at http://localhost (default port 80).
 Should the server instance use a different port you will need to modify all
 proxy target entries in `webpack.dev.config.js <webpack.dev.config.js>`_:
 
@@ -89,6 +89,29 @@ you will need to change its port property in `webpack.dev.config.js <webpack.dev
     devServer: {
         port: your_port
     }
+
+
+The initial data type (e.g. image, dataset, well) and its respective ID can be set/changed
+in `index-dev.html <src/index-dev.html>`_:
+
+.. code-block:: html
+
+    <html>
+        <head>
+            <link rel="stylesheet" type="text/css" href="build/css/all.min.css" />
+
+            <script type="text/javascript">
+                // modify according to your needs
+                // in particular: choose an existing id !
+                window.INITIAL_REQUEST_PARAMS = {
+                        'VERSION': "DEV_SERVER",
+                        'WEB_API_BASE': 'api/v0/',
+                        //'IMAGES': "1",
+                        'DATASET': "1",
+                        //'WELL': "1"
+                };
+            </script>
+    ...
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,27 @@ please read the section *ol3-viewer* below!
 Development
 ===========
 
-Run:
+Building the uncompressed version of iviewer as described above the application
+can be deployed locally or to a test server, to then be debugged.
+It is also possible to run/debug it with webpack dev-server:
 
 ::
- 
+
     $ npm run dev
 
-To be able to run the ``webpack-dev`` server locally at: ``localhost:3000``
+will build the bundle and start the webpack dev-server (localhost:8080)
+
+Either development setup expects the following:
+- an OMERO server installation
+- an iviewer 'deploy' to that OMERO server:
+
+::
+    $ export PYTHONPATH=$PYTHONPATH:/path/to/iviewer-project-root/plugin
+    $ bin/omero config append omero.web.apps '"omero_iviewer"'
+
+**Note**:
+
+The webpack dev-server config expects a local OMERO server (http://localhost)!
 
 Documentation
 =============
@@ -59,7 +73,7 @@ To build the html in build/docs, run:
 ::
 
     $ npm run docs
- 
+
 
 ol3-viewer
 ==========
@@ -84,4 +98,3 @@ More detailed resources on how to create a web app and development setup can be 
 
 1. `CreateApp <https://www.openmicroscopy.org/site/support/omero5/developers/Web/CreateApp.html>`_
 2. `Deployment <https://www.openmicroscopy.org/site/support/omero5/developers/Web/Deployment.html>`_
-

--- a/README.rst
+++ b/README.rst
@@ -58,12 +58,37 @@ Either development setup expects the following:
 - an iviewer 'deploy' to that OMERO server:
 
 ::
+
     $ export PYTHONPATH=$PYTHONPATH:/path/to/iviewer-project-root/plugin
     $ bin/omero config append omero.web.apps '"omero_iviewer"'
 
-**Note**:
+**Notes**:
 
-The webpack dev-server config expects a local OMERO server (http://localhost)!
+The webpack dev-server config expects a local OMERO server at http://localhost.
+Should the server instance use a different port you will need to modify all
+proxy target entries in `webpack.dev.config.js <webpack.dev.config.js>`_:
+
+.. code-block::
+
+    devServer: {
+        proxy: {
+            '/iviewer/**': {
+                target: 'http://localhost:your_port'
+            },
+            '/api/**': {
+                target: 'http://localhost:your_port'
+            }, ...
+        }
+    }
+
+If you want to bind the webpack dev server to a port other than 8080
+you will need to change its port property in `webpack.dev.config.js <webpack.dev.config.js>`_:
+
+.. code-block::
+
+    devServer: {
+        port: your_port
+    }
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ It is also possible to run/debug it with webpack dev-server:
 will build the bundle and start the webpack dev-server (localhost:8080)
 
 Either development setup expects the following:
+
 - an OMERO server installation
 - an iviewer 'deploy' to that OMERO server:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.0",
   "description": "OMERO.iviewer",
   "scripts": {
-    "dev": "./ol3_viewer_prepare.sh DEV && ant prepare-css && webpack-dev-server --config webpack.dev.config.js --hot --inline --progress --devtool eval",
+    "dev": "./ol3_viewer_prepare.sh DEV && webpack-dev-server --config webpack.dev.config.js --hot --inline --progress --devtool eval-source-map",
     "debug": "./ol3_viewer_prepare.sh DEV && ./prepare_build.sh DEV && webpack --config webpack.prod.config.js --progress --devtool source-map && ./deploy_build.sh",
     "prod": "./ol3_viewer_prepare.sh && ./prepare_build.sh && webpack -p --config webpack.prod.config.js --progress && ./deploy_build.sh",
     "docs": "./generate_docs.sh"
@@ -48,7 +48,7 @@
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",
     "webpack": "3.6.0",
-    "webpack-dev-server": "2.8.0",
+    "webpack-dev-server": "2.9.5",
     "html-webpack-plugin": "2.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
     "expose-loader": "0.7.3",
     "file-loader": "0.11.2",
     "html-loader": "0.4.5",
+    "html-webpack-plugin": "2.29.0",
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",
     "webpack": "3.6.0",
     "webpack-dev-server": "2.9.5",
-    "html-webpack-plugin": "2.29.0"
+    "webpack-conditional-loader": "1.0.11"
   }
 }

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -405,16 +405,6 @@ export default class Context {
     }
 
     /**
-     * Adjustments that are necessary if we are running under the
-     * webpack dev server
-     * @memberof Context
-     */
-    tweakForDevServer() {
-        this.is_dev_server = true;
-        this.prefixed_uris.set(IVIEWER, "");
-    }
-
-    /**
      * Creates an app wide key down listener
      * that will listen for key presses registered via addKeyListener
      *
@@ -501,7 +491,7 @@ export default class Context {
         let parent_id = null;
         let selConf = this.getSelectedImageConfig();
         if (selConf === null) return;
-        
+
         let parentType =
             this.initial_type === INITIAL_TYPES.IMAGES ?
                 selConf.image_info.parent_type : this.initial_type;

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -19,23 +19,48 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <link rel="stylesheet" type="text/css" href="build/css/all.min.css" />
+      <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css" />
+      <link rel="stylesheet" type="text/css" href="css/theme.css" />
+      <link rel="stylesheet" type="text/css" href="css/spinner.css" />
+      <link rel="stylesheet" type="text/css" href="css/slider.css" />
+      <link rel="stylesheet" type="text/css" href="css/spectrum.css" />
+      <link rel="stylesheet" type="text/css" href="css/ol3-viewer.css" />
+      <link rel="stylesheet" type="text/css" href="css/app.css" />
 
       <script type="text/javascript">
         // modify according to your needs
-        window.INITIAL_REQUEST_PARAMS =
-            {
+        // in particular: choose an existing id !
+        window.INITIAL_REQUEST_PARAMS = {
                 'DEV_SERVER': true,
-                //'SERVER': "https://cowfish.openmicroscopy.org/webtrial",
-                //'IMAGE_ID': 20901,
-                'SERVER': "https://demo.openmicroscopy.org",
-                'IMAGE_ID': 208443,
-            };
+                'VERSION': "DEV_SERVER",
+                'WEB_API_BASE': 'api/v0/',
+                //'IMAGES': "1",
+                'DATASET': "1",
+                //'WELL': "1"
+        };
+        // check if we need to log in
+        // regular redirect logic of server
+        // fails with different origin (proxy)
+        var xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function() {
+            if (this.readyState == 4 && this.status == 200) {
+                if (xhttp.responseText !== 'OK') {
+                    window.location.replace(
+                        'http://localhost:8080/webclient/login?url=http://localhost:8080/');
+                }
+                return;
+            } else if (this.readyState == 4) {
+                alert('Check if your OMERO server is running');
+            }
+        };
+        xhttp.open("GET", "webclient/keepalive_ping", true);
+        xhttp.send();
       </script>
 
       <title>iViewer</title>
   </head>
 
-  <body class="container-fluid"></body>
+  <body class="container-fluid">
+  </body>
 
 </html>

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -31,7 +31,6 @@
         // modify according to your needs
         // in particular: choose an existing id !
         window.INITIAL_REQUEST_PARAMS = {
-                'DEV_SERVER': true,
                 'VERSION': "DEV_SERVER",
                 'WEB_API_BASE': 'api/v0/',
                 //'IMAGES': "1",

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,16 @@ import Misc from './utils/misc';
 import {URI_PREFIX, PLUGIN_NAME, WINDOWS_1252} from './utils/constants';
 import * as Bluebird from 'bluebird';
 
+// #if process.env.NODE_ENV
+require('../node_modules/bootstrap/dist/css/bootstrap.min.css');
+require('../node_modules/jquery-ui/themes/base/theme.css');
+require('../node_modules/jquery-ui/themes/base/spinner.css');
+require('../node_modules/jquery-ui/themes/base/slider.css');
+require('../node_modules/spectrum-colorpicker/spectrum.css');
+require('../css/ol3-viewer.css');
+require('../css/app.css');
+// #endif
+
 // global scope settings
 Bluebird.config({ warnings: { wForgottenReturn: false } });
 window['encoding-indexes'] = {"windows-1252": WINDOWS_1252};
@@ -33,20 +43,15 @@ window['encoding-indexes'] = {"windows-1252": WINDOWS_1252};
  * has to happen before the bootstrap!
  */
 let req = window.INITIAL_REQUEST_PARAMS || {};
-let is_dev_server = typeof req["DEV_SERVER"] === 'boolean' && req["DEV_SERVER"];
+let is_dev_server = false;
+// #if process.env.NODE_ENV === 'dev-server'
+is_dev_server = true;
+// #endif
 if (!is_dev_server) {
     let prefix =
         typeof req[URI_PREFIX] === 'string' ?
             Misc.prepareURI(req[URI_PREFIX]) : "";
     __webpack_public_path__ = prefix + '/static/' + PLUGIN_NAME + '/';
-} else {
-    require('../node_modules/bootstrap/dist/css/bootstrap.min.css');
-    require('../node_modules/jquery-ui/themes/base/theme.css');
-    require('../node_modules/jquery-ui/themes/base/spinner.css');
-    require('../node_modules/jquery-ui/themes/base/slider.css');
-    require('../node_modules/spectrum-colorpicker/spectrum.css');
-    require('../css/ol3-viewer.css');
-    require('../css/app.css');
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,14 @@ if (!is_dev_server) {
         typeof req[URI_PREFIX] === 'string' ?
             Misc.prepareURI(req[URI_PREFIX]) : "";
     __webpack_public_path__ = prefix + '/static/' + PLUGIN_NAME + '/';
+} else {
+    require('../node_modules/bootstrap/dist/css/bootstrap.min.css');
+    require('../node_modules/jquery-ui/themes/base/theme.css');
+    require('../node_modules/jquery-ui/themes/base/spinner.css');
+    require('../node_modules/jquery-ui/themes/base/slider.css');
+    require('../node_modules/spectrum-colorpicker/spectrum.css');
+    require('../css/ol3-viewer.css');
+    require('../css/app.css');
 }
 
 /**
@@ -49,7 +57,7 @@ if (!is_dev_server) {
 bootstrap(function(aurelia) {
     aurelia.use.basicConfiguration();
     let ctx = new Context(aurelia.container.get(EventAggregator), req);
-    if (is_dev_server) ctx.tweakForDevServer();
+    if (is_dev_server) ctx.is_dev_server = true;
     aurelia.container.registerInstance(Context,ctx);
 
     aurelia.start().then(

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -50,6 +50,10 @@ export default class Misc {
      * @return {boolean} true if we regard the server string remote
      */
     static useJsonp(server="") {
+        // THIS IS INTENTIONAL !!!
+        // jsonp was only used for the dev server
+        return false;
+
         if (typeof server !== 'string') return false;
 
         let host = window.location.host.toLowerCase();

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -18,7 +18,10 @@ module.exports = {
     filename: 'bundle.js'
   },
   plugins: [
-    new AureliaPlugin({aureliaApp: undefined}),
+    new AureliaPlugin({
+      aureliaApp: undefined,
+      aureliaConfig: "basic",
+      features: {svg: false}}),
     new ProvidePlugin({
         Promise: 'bluebird',
         $: 'jquery',
@@ -49,7 +52,27 @@ module.exports = {
       { test: require.resolve('jquery'), loader: 'expose-loader?$!expose-loader?jQuery' },
       { test: /\.(png|gif|jpg|jpeg)$/, loader: 'file-loader?name=css/images/[name].[ext]' },
       { test: /\.(woff|woff2)$/, loader: 'file-loader?name=css/fonts/[name].[ext]' },
+      { test: /\.css?$/, loader: 'file-loader?name=css/[name].[ext]' },
       { test: /\.html$/, loader: 'html-loader' }
     ]
+  },
+  devServer: {
+    proxy: {
+        '/iviewer/**': {
+            target: 'http://localhost'
+        },
+        '/api/**': {
+            target: 'http://localhost'
+        },
+        '/webgateway/**': {
+            target: 'http://localhost'
+        },
+        '/webclient/**': {
+            target: 'http://localhost'
+        },
+        '/static/**': {
+            target: 'http://localhost'
+        }
+    }
   }
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -4,10 +4,6 @@ const {AureliaPlugin} = require('aurelia-webpack-plugin');
 const ProvidePlugin = require('webpack/lib/ProvidePlugin');
 
 module.exports = {
-  devServer: {
-    host: 'localhost',
-    port: 3000
-  },
   entry: {
     main: [
       './src/main'
@@ -57,6 +53,7 @@ module.exports = {
     ]
   },
   devServer: {
+    port: 8080,
     proxy: {
         '/iviewer/**': {
             target: 'http://localhost'

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -39,8 +39,9 @@ module.exports = {
   module: {
     noParse: [/libs\/ol3-viewer.js$/],
     rules: [
-        { test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/,
-          query: { compact: false,
+        { test: /\.js$/, exclude: /node_modules/, use: [{
+            loader: 'babel-loader',
+            query: { compact: false,
                    presets: [[ 'env', {
                        "loose": true,
                        "uglify": process.env.NODE_ENV === 'production',
@@ -48,6 +49,7 @@ module.exports = {
                        "useBuiltIns": true } ]],
                    plugins: ['transform-decorators-legacy',
                              'transform-class-properties'] } },
+            {loader: 'webpack-conditional-loader'}]},
         { test: /[\/\\]node_modules[\/\\]bluebird[\/\\].+\.js$/, loader: 'expose-loader?Promise' },
         { test: require.resolve('jquery'), loader: 'expose-loader?$!expose-loader?jQuery' },
         { test: /\.(png|gif|jpg|jpeg)$/, loader: 'file-loader?name=css/images/[name].[ext]' },


### PR DESCRIPTION
With increased public interest in setting up iviewer for development and the first choice being webpack dev server 'mode' I revisited ```npm run dev```.

Turns out there is handy webpack devserver proxy functionality so that the running of scripts/altering of webserver configurations is not necessary.

With this PR one can just run the above command and then navigate to http://localhost:8080.
Java Script and Css is served by the dev server, so hot deploy will work -give or take an occasional browser refresh that might be necessary.

The devtool settings is set to _eval-source-map_. This makes for slightly longer initial/incremental builds but gives a full source map. I'll leave it up to the developer to change that as they wish: https://webpack.js.org/configuration/devtool/

TEST: Has to be done locally. So, anybody who has checked out the project and built and deployed it at least once on their local machine is in good shape to use this branch and test (see instructions above)