### PR TITLE
update selected shapes array once new shape has been saved (id sync)

### DIFF
--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -341,7 +341,7 @@ ome.ol3.interaction.Draw.prototype.setDefaultDrawingStyle = function(shape) {
             var text =
                 new ol.style.Text(
                     {
-                      exceedLength: true,
+                      overflow: true,
                       text: "TEXT",
                       font: "normal " + geom.getHeight() + "px sans-serif",
                       fill: new ol.style.Fill(

--- a/ol3-viewer/src/ome/ol3/utils/Style.js
+++ b/ol3-viewer/src/ome/ol3/utils/Style.js
@@ -123,7 +123,7 @@ ome.ol3.utils.Style.createFeatureStyle = function(shape_info, is_label, fill_in_
             text['count']++;
     }
     if (text['count'] > 0) {
-        text['exceedLength'] = true;
+        text['overflow'] = true;
         style['text'] = new ol.style.Text(text);
 
         // we do not wish for defaults (ol creates default fill color)
@@ -238,7 +238,7 @@ ome.ol3.utils.Style.updateStyleFunction =
             }
 
             if (textStyle instanceof ol.style.Text) {
-                textStyle.setExceedLength(true);
+                textStyle.setOverflow(true);
                 // seems we want to adjust text to resolution level
                 if (scale_text) {
                     var newScale = 1/actual_resolution;
@@ -412,7 +412,7 @@ ome.ol3.utils.Style.cloneStyle = function(style) {
         // for our purposes and for now we are not going to set some things which
         // have sensible defaults anyhow
         newText = new ol.style.Text({
-            "exceedLength" : true,
+            "overflow" : true,
             "font" : font,
             "text" : text,
             "stroke" : stroke,
@@ -591,7 +591,7 @@ ome.ol3.utils.Style.modifyStyles =
                         newTextStyle.setTextBaseline(newStyle.getText().getTextBaseline());
                 }
                 if (newTextStyle instanceof ol.style.Text) {
-                    newTextStyle.exceedLength_ = true;
+                    newTextStyle.setOverflow(true);
                     if (typeof newTextStyle.text_ !== 'string') newTextStyle.text_ = "";
                     if (newTextStyle.fill_ === null)
                         newTextStyle.fill_ =

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -945,6 +945,12 @@ export default class Ol3Viewer extends EventSubscriber {
                     newShape['@id'] = newRoiAndShapeId.shape_id;
                     newRoi.shapes.set(newRoiAndShapeId.shape_id, newShape);
                     shape.deleted = true; // take out old entry
+                    // update newly created and saved shapes (if selected)
+                    let selShapes =
+                        this.image_config.regions_info.selected_shapes;
+                    let selShapesIdx = selShapes.indexOf(shape.shape_id);
+                    if (selShapesIdx !== -1)
+                        selShapes[selShapesIdx] = newShape.shape_id;
                 }
                 // we remove shapes flagged deleted=true
                 if (shape.deleted) {


### PR DESCRIPTION
Newly created shapes will receive a proper id from the backend after persistence. While these shape ids get synced/updated accordingly they get overlooked in the selected_shapes array (noticed in https://trello.com/c/Hi0GAFjH/80-bug-iviewer-roimeasurements-roi-selection-and-export). This PR fixes that.

TEST:
1. Draw 1...n new shapes.
2. End drawing.
3. Select 1..ln of these new shapes
4. Hit "Delete"
Expected Result: They should all appear deleted (gone and marked red in list)