### PR TITLE
Use full support URL for PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ OMERO.iviewer
 
 An OMERO.web app for visualizing images in OMERO.
 
-Also see `SUPPORT.md <./SUPPORT.md>`_
+Also see `SUPPORT.md <https://github.com/ome/omero-iviewer/blob/master/SUPPORT.md>`_
 
 Requirements
 ============


### PR DESCRIPTION
As per https://github.com/ome/omero-figure/pull/267 this updates the README to use the full URL for the support file so that the link works from PyPI