### PR TITLE
bump jquery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "aurelia-templating-router": "1.1.0",
     "bluebird": "3.5.0",
     "bootstrap": "3.3.7",
-    "jquery": "2.2.4",
+    "jquery": "3.3.1",
     "jquery-ui" : "1.12.1",
     "spectrum-colorpicker": "1.8.0",
     "d3" : "4.2.7",


### PR DESCRIPTION
Old JQuery (2.x.x) gives the following warning:
![image](https://user-images.githubusercontent.com/1559229/35594104-bbddc652-065d-11e8-9de1-af97b20edf3b.png)

This PR bumps it to 3.3.1
