### PR TITLE
csv export - unattached shapes

### DIFF
--- a/src/app/header.html
+++ b/src/app/header.html
@@ -81,8 +81,14 @@
                     <li class="${image_config.regions_info.ready &&
                                  image_config.regions_info.selected_shapes.length > 0 ?
                                     '' : 'disabled-color'}">
-                        <a click.delegate="saveRoiMeasurements()"
-                           href="#">Export</a>
+                        <a click.delegate="saveRoiMeasurements(false)"
+                           href="#">Export (Excel)</a>
+                    </li>
+                    <li class="${image_config.regions_info.ready &&
+                                 image_config.regions_info.selected_shapes.length > 0 ?
+                                    '' : 'disabled-color'}">
+                        <a click.delegate="saveRoiMeasurements(true)"
+                           href="#">Export (CSV)</a>
                     </li>
                 </ul>
             </div>

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -674,7 +674,10 @@ export default class RegionsInfo  {
             if (id.indexOf("-") !== -1) continue;
             let shape = this.getShape(ids[i]);
             if (shape === null) continue;
-            if (shape) addToRequest(shape);
+            if (shape) {
+                if (shape.TheT === -1 || shape.TheZ === -1) continue;
+                addToRequest(shape);
+            }
         }
 
         // we need no request

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -392,4 +392,19 @@ export default class Misc {
     static roundAtDecimal(value, digits) {
         return Number(Math.round(value +'e' + digits) + 'e-' + digits);
     }
+
+    /**
+     * 'Normalizes' a csv cell value to work with most readers.
+     * Values are quoted to allow for , as content
+     * Quotes are 'escaped' with a quote themselves
+     *
+     * @param {string|number} value a number or string
+     * @return {string} the quoted cell value
+     * @static
+     */
+    static quoteCsvCellValue(value) {
+        if (typeof value === 'number') value = "" + value;
+        if (typeof value !== 'string') return value;
+        return '"' + value.replace(/"/g, '""') + '"';
+    }
 }


### PR DESCRIPTION
see: https://trello.com/c/yaN31Wzy/22-do-not-default-to-a-plane

The following changes have been made in this PR:
- Only shapes that are attached to specific t/z planes will be sent to be queried.
- These unattached shapes will be exported with their stats columns empty
- Commas in channel label or file name will be quoted (in the csv spirit)

Note: We could go all quotes, even for column values that are numeric or don't contain spaces, separators or quotes. I have one older software that insists on that but, strictly speaking, quoting values is optional except for when there are "special" characters such as the ones mentioned.

@jburel I'm going to add an option to the menu for UTF export, such that both excel and "less proprietary" csv are available. If that's too much, I can rollback that commit...

TEST: 
- Export selected shapes where at least one has an unattached z/t (or both). Check that stats cells are empty.
- Try out the non excel option for export and open with a non-microsoft office (e.g. libre/open office), google docs, or an open online csv viewer, e.g. http://www.convertcsv.com/csv-viewer-editor.htm, http://www.becsv.com/csv-viewer.php