### PR TITLE
set tooltip/opacity for restricted permissions

### DIFF
--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -101,12 +101,23 @@
                     </div>
                     <div if.bind="!(shape.deleted && shape.is_new) &&
                                    !(roi.shapes.size > 1 && !roi.show)"
-                        title="ROI: ${roi_id} - Shape: ${shape_id}"
+                        title="${'ROI: ' + roi_id + ' - Shape: ' + shape_id +
+                                 (!shape.permissions ||
+                                    (shape.permissions &&
+                                     shape.permissions.canAnnotate &&
+                                     shape.permissions.canEdit &&
+                                     shape.permissions.canDelete) ? '' :
+                                        '\n(restricted permissions)')}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"
                         css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
                              ${shape.deleted ? 'color: red;' :
-                                (shape.modified ? 'color: blue;' : '')}"
+                                (shape.modified ? 'color: blue;' : '')}
+                             ${!shape.permissions ||
+                               (shape.permissions &&
+                                shape.permissions.canAnnotate &&
+                                shape.permissions.canEdit &&
+                                shape.permissions.canDelete) ? '' : 'opacity: 0.5'}"
                         click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
                         <div class="regions-table-col roi-toggle"></div>
                         <div class="regions-table-col shape-show">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -102,22 +102,14 @@
                     <div if.bind="!(shape.deleted && shape.is_new) &&
                                    !(roi.shapes.size > 1 && !roi.show)"
                         title="${'ROI: ' + roi_id + ' - Shape: ' + shape_id +
-                                 (!shape.permissions ||
-                                    (shape.permissions &&
-                                     shape.permissions.canAnnotate &&
-                                     shape.permissions.canEdit &&
-                                     shape.permissions.canDelete) ? '' :
+                                    (hasPermissions(shape) ? '' :
                                         '\nOwner: ' + shape.owner)}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"
                         css="${shape.selected ? 'background-color: #d0d0ff;' : ''}
                              ${shape.deleted ? 'color: red;' :
                                 (shape.modified ? 'color: blue;' : '')}
-                             ${!shape.permissions ||
-                               (shape.permissions &&
-                                shape.permissions.canAnnotate &&
-                                shape.permissions.canEdit &&
-                                shape.permissions.canDelete) ? '' : 'opacity: 0.5'}"
+                             ${hasPermissions(shape) ? '' : 'opacity: 0.5'}"
                         click.delegate="selectShape(shape.shape_id, shape.selected, $event)">
                         <div class="regions-table-col roi-toggle"></div>
                         <div class="regions-table-col shape-show">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -107,7 +107,7 @@
                                      shape.permissions.canAnnotate &&
                                      shape.permissions.canEdit &&
                                      shape.permissions.canDelete) ? '' :
-                                        '\n(restricted permissions)')}"
+                                        '\nOwner: ' + shape.owner)}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"
                         css="${shape.selected ? 'background-color: #d0d0ff;' : ''}

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -359,6 +359,23 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
+     * Evaluates whether permission(s) are missing for a given shape
+     * (Helper method for template only!)
+     *
+     * @private
+     * @param {Object} shape a shape
+     * @return {boolean} if true user has full permissions, otherwise not
+     * @memberof RegionsList
+     */
+    hasPermissions(shape) {
+        return !shape.permissions ||
+           (shape.permissions &&
+            shape.permissions.canAnnotate &&
+            shape.permissions.canEdit &&
+            shape.permissions.canDelete);
+    }
+
+    /**
      * Overridden aurelia lifecycle method:
      * called whenever the view is unbound within aurelia
      * in other words a 'destruction' hook that happens after 'detached'

--- a/src/utils/converters.js
+++ b/src/utils/converters.js
@@ -154,11 +154,26 @@ export class Converters {
 
       // use permissions
       if (typeof shape['omero:details'] === 'object' &&
-          shape['omero:details'] !== null &&
-          typeof shape['omero:details']['permissions'] === 'object' &&
-          shape['omero:details']['permissions'] !== null) {
-              shape.permissions =
-                    Object.assign({}, shape['omero:details']['permissions']);
+          shape['omero:details'] !== null) {
+              if (typeof shape['omero:details']['permissions'] === 'object' &&
+              shape['omero:details']['permissions'] !== null) {
+                  shape.permissions =
+                        Object.assign({}, shape['omero:details']['permissions']);
+              }
+              if (typeof shape['omero:details']['owner'] === 'object' &&
+                  shape['omero:details']['owner'] !== null) {
+                      let firstName =
+                          typeof shape['omero:details']['owner']['FirstName'] === 'string' ?
+                              shape['omero:details']['owner']['FirstName'] : '';
+                      let lastName =
+                          typeof shape['omero:details']['owner']['LastName'] === 'string' ?
+                              shape['omero:details']['owner']['LastName'] : '';
+                      let user =
+                          typeof shape['omero:details']['owner']['UserName'] === 'string' ?
+                              shape['omero:details']['owner']['UserName'] : '';
+                      shape.owner = (firstName === '' && lastName === '') ?
+                          user : firstName + " " + lastName;
+              }
               delete shape['omero:details'];
       }
 


### PR DESCRIPTION
see: https://trello.com/c/4Z3O6Z6F/18-show-roi-shape-ownership

Setting the opacity for the row is just an idea to indicate that the user does not have full permissions.
Not sure if the tooltip text should be changed or if 'restricted permissions' is good enough.