### PR TITLE
delete tmp data after initRegions

### DIFF
--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -251,7 +251,10 @@ export default class Ol3Viewer extends EventSubscriber {
                         (newValue, oldValue) => {
                             if (this.viewer === null) return;
                             this.viewer.removeRegions();
-                            if (newValue) this.initRegions();
+                            if (newValue) {
+                                this.initRegions();
+                                delete this.image_config.regions_info.tmp_data;
+                            }
                     });
             // mdi needs to switch image config when using controls
             this.getContainer().find('.ol-control').on(
@@ -715,7 +718,6 @@ export default class Ol3Viewer extends EventSubscriber {
             !Misc.isArray(this.image_config.regions_info.tmp_data)) return;
 
         this.viewer.addRegions(this.image_config.regions_info.tmp_data);
-        delete this.image_config.regions_info.tmp_data;
         this.changeRegionsModes(
             { modes: this.image_config.regions_info.regions_modes});
         this.viewer.showShapeComments(


### PR DESCRIPTION
The data (json) from the regions request is better deleted after the initialization of regions in the "ready" observer has fired. 

Testing with IE I happened to notice that the regions layer was not added in multi viewer mode when a new image was opened (very likely due to a different execution order for async handling and/or memory deletion policy).

TEST (especially in IE10+ since this does problem does not manifest itself in chrome and FF)
Open an image, switch to multi viewer mode, view ROIS (clicking tab), then open more images (with rois). They should display properly.