### PR TITLE
Rois Persistence Revisited

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1639,7 +1639,7 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * Persists modified/added/deleted shapes
  * see: {@link ome.ol3.source.Regions.storeRegions}
  *
- * @param {Array.<number>} rois_to_be_deleted an array of roi ids for deletion
+ * @param {Object} rois_to_be_deleted an associative array of roi ids for deletion
  * @param {boolean} useSeparateRoiForEachNewShape if false all new shapes are combined within one roi
  * @param {boolean} omit_client_update an optional flag that's handed back to the client
  *                  to indicate that a client side update to the response is not needed
@@ -1661,7 +1661,8 @@ ome.ol3.Viewer.prototype.storeRegions =
             new ol.Collection(this.regions_.getFeatures());
         var roisAsJsonObject =
             ome.ol3.utils.Conversion.toJsonObject(
-                collectionOfFeatures, useSeparateRoiForEachNewShape);
+                collectionOfFeatures, useSeparateRoiForEachNewShape,
+                rois_to_be_deleted);
 
         // check if we have nothing to persist, i.e. to send to the back-end
         if (roisAsJsonObject['count'] === 0) {

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1499,11 +1499,11 @@ ome.ol3.Viewer.prototype.generateShapes = function(shape_info, options) {
     if (this.eventbus_) {
         var newRegionsObject =
             ome.ol3.utils.Conversion.toJsonObject(
-                new ol.Collection(generatedShapes), true, true);
+                new ol.Collection(generatedShapes), true);
         if (typeof newRegionsObject !== 'object' ||
-            !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
-            newRegionsObject['rois'].length === 0) return;
-        var params = {"shapes": newRegionsObject['rois']};
+            !ome.ol3.utils.Misc.isArray(newRegionsObject['new']) ||
+            newRegionsObject['new'].length === 0) return;
+        var params = {"shapes": newRegionsObject['new']};
         if (typeof options['hist_id'] === 'number')
             params['hist_id'] = options['hist_id'];
         if (typeof options['add_history'] === 'boolean')
@@ -1671,8 +1671,8 @@ ome.ol3.Viewer.prototype.storeRegions =
                     new ol.Collection(this.regions_.getFeatures());
 
         var roisAsJsonObject =
-        ome.ol3.utils.Conversion.toJsonObject(
-            collectionOfFeatures, useSeparateRoiForEachNewShape);
+            ome.ol3.utils.Conversion.toJsonObject(
+                collectionOfFeatures, useSeparateRoiForEachNewShape);
         // check if we have nothing to persist, i.e. to send to the back-end
         if (roisAsJsonObject['count'] === 0) {
             // we may still want to clean up new but deleted shapes

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1639,14 +1639,14 @@ ome.ol3.Viewer.prototype.getSmallestViewExtent = function() {
  * Persists modified/added/deleted shapes
  * see: {@link ome.ol3.source.Regions.storeRegions}
  *
- * @param {Array.<string>} deleted an array of ids for deletion (of the form: roi_id:shape_id)
+ * @param {Array.<number>} rois_to_be_deleted an array of roi ids for deletion
  * @param {boolean} useSeparateRoiForEachNewShape if false all new shapes are combined within one roi
  * @param {boolean} omit_client_update an optional flag that's handed back to the client
  *                  to indicate that a client side update to the response is not needed
  * @return {boolean} true if a storage request was made, false otherwise
  */
 ome.ol3.Viewer.prototype.storeRegions =
-    function(deleted, useSeparateRoiForEachNewShape, omit_client_update) {
+    function(rois_to_be_deleted, useSeparateRoiForEachNewShape, omit_client_update) {
 
         if (!(this.regions_ instanceof ome.ol3.source.Regions))
             return false; // no regions, nothing to persist...
@@ -1657,22 +1657,12 @@ ome.ol3.Viewer.prototype.storeRegions =
             typeof(useSeparateRoiForEachNewShape) === 'boolean' ?
                 useSeparateRoiForEachNewShape : true;
 
-        var isDeleteRequest =
-            ome.ol3.utils.Misc.isArray(deleted) && deleted.length > 0;
-        var collectionOfFeatures = null;
-        if (isDeleteRequest) {
-            collectionOfFeatures = new ol.Collection();
-            for (var i=0;i<deleted.length;i++) {
-                var id = deleted[i];
-                if (typeof this.regions_.idIndex_[id] === 'object')
-                    collectionOfFeatures.push(this.regions_.idIndex_[id]);
-            };
-        } else collectionOfFeatures =
-                    new ol.Collection(this.regions_.getFeatures());
-
+        var collectionOfFeatures =
+            new ol.Collection(this.regions_.getFeatures());
         var roisAsJsonObject =
             ome.ol3.utils.Conversion.toJsonObject(
                 collectionOfFeatures, useSeparateRoiForEachNewShape);
+
         // check if we have nothing to persist, i.e. to send to the back-end
         if (roisAsJsonObject['count'] === 0) {
             // we may still want to clean up new but deleted shapes
@@ -1689,15 +1679,12 @@ ome.ol3.Viewer.prototype.storeRegions =
                     }
                     if (this.eventbus_) {
                         ome.ol3.utils.Misc.sendEventNotification(
-                            this, "REGIONS_STORED_SHAPES", {
-                                'shapes': ids, 'is_delete': isDeleteRequest});
+                            this, "REGIONS_STORED_SHAPES", {'shapes': ids});
                     }
             }
             return false;
         }
 
-        // remember deleted ids for history removal
-        roisAsJsonObject['is_delete'] = isDeleteRequest;
         return this.regions_.storeRegions(roisAsJsonObject, omit_client_update);
 }
 

--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -161,12 +161,12 @@ ome.ol3.interaction.Draw.prototype.drawShapeCommonCode_ =
                     if (this.roi_id_ < 0) event.feature['roi_id'] = this.roi_id_;
                     var newRegionsObject =
                         ome.ol3.utils.Conversion.toJsonObject(
-                            new ol.Collection([event.feature]), false, true);
+                            new ol.Collection([event.feature]), false);
                     if (typeof newRegionsObject !== 'object' ||
-                        !ome.ol3.utils.Misc.isArray(newRegionsObject['rois']) ||
-                        newRegionsObject['rois'].length === 0) return;
+                        !ome.ol3.utils.Misc.isArray(newRegionsObject['new']) ||
+                        newRegionsObject['new'].length === 0) return;
                     var opts = {
-                        "shapes": newRegionsObject['rois'],
+                        "shapes": newRegionsObject['new'],
                         "drawn" : true, "add": add
                     };
                     if (typeof hist_id === 'number') opts['hist_id'] = hist_id;

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -554,26 +554,9 @@ ome.ol3.source.Regions.prototype.storeRegions =
     if (typeof omit_client_update !== 'boolean') omit_client_update = false;
 
     try {
-        // loop over given given shapes, wrapping them
-        var rois = {};
-        for (var r in roisAsJsonObject['rois']) {
-            for (var s in roisAsJsonObject['rois'][r]['shapes']) {
-                // else add roi/shape
-                if (typeof(rois[r]) !== 'object') {
-                    var newRois = {
-                        "@type" : "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI",
-                        "shapes" : []
-                    };
-                    var roisId = parseInt(r);
-                    if (roisId >= 0) newRois['@id'] = roisId;
-                    rois[r] = newRois;
-                }
-                rois[r]['shapes'].push(roisAsJsonObject['rois'][r]['shapes'][s]);
-            }
-        };
         var postContent = {
             "imageId": this.viewer_.id_,
-            "rois": rois
+            "rois": roisAsJsonObject
         };
 
         // set properties for ajax request

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -574,7 +574,7 @@ ome.ol3.source.Regions.prototype.storeRegions =
 
         // the success handler for the POST
         properties["success"] = function(data) {
-            var error = null;
+            var errors = null;
             try {
                 data = JSON.parse(data);
 
@@ -601,12 +601,12 @@ ome.ol3.source.Regions.prototype.storeRegions =
                     if (typeof capturedRegionsReference.idIndex_[id] === 'object') {
                         capturedRegionsReference.removeFeature(
                             capturedRegionsReference.idIndex_[id]);
-                            data['ids'][id] = id;
-                        }
+                        data['ids'][id] = id;
+                    }
                 };
-                if (typeof data['error'] === 'string') error = data['error'];
+                if (typeof data['error'] === 'string') errors = data['errors'];
             } catch(err) {
-                error = err;
+                errors = [err];
             }
 
             var params = {
@@ -615,7 +615,7 @@ ome.ol3.source.Regions.prototype.storeRegions =
                     typeof data['ids'] === 'object' ? data['ids'] : null,
                 "omit_client_update" : omit_client_update
             };
-            if (error) params['error'] = error;
+            if (errors) params['errors'] = errors;
 
             ome.ol3.utils.Misc.sendEventNotification(
                 capturedRegionsReference.viewer_, "REGIONS_STORED_SHAPES", params);

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -667,9 +667,6 @@ ome.ol3.utils.Conversion.integrateMiscInfoIntoJsonObject  = function(feature, js
         }
     });
 
-    if (feature['state'] === ome.ol3.REGIONS_STATE.REMOVED)
-        jsonObject['markedForDeletion'] = true;
-
     if (typeof feature['Area'] === 'number')
         jsonObject['Area'] = feature['Area'];
     if (typeof feature['Length'] === 'number')

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -98,7 +98,7 @@ def persist_rois(request, conn=None, **kwargs):
         return JsonResponse({"error": "No image id provided!"})
     rois = rois_dict.get('rois', None)
     if rois is None:
-        return JsonResponse({"error": "Could not find rois array!"})
+        return JsonResponse({"error": "Could not find rois object!"})
 
     # get the associated image and an instance of the update service
     image = conn.getObject("Image", image_id, opts=conn.SERVICE_OPTS)
@@ -107,98 +107,39 @@ def persist_rois(request, conn=None, **kwargs):
 
     # prepare services
     update_service = conn.getUpdateService()
-    rois_service = conn.getRoiService()
-    if update_service is None or rois_service is None:
-        return JsonResponse({"error": "Could not get update/rois service!"})
+    if update_service is None:
+        return JsonResponse({"error": "Could not get update service!"})
 
     # when persisting we use the specific group context
     conn.SERVICE_OPTS['omero.group'] = image.getDetails().getGroup().getId()
 
-    # loop over the given rois, marshal and persist/delete
-    ret_ids = {}
+    # for id sync
+    ret_ids = []
+
     try:
-        for r in rois:
-            roi = rois.get(r)
-            # marshal and asscociate with image
-            decoder = omero_marshal.get_decoder(roi.get("@type"))
-            decoded_roi = decoder.decode(roi)
+        # delete first
+        deleted = rois.get('deleted', None)
+
+        # modify next
+        modified = rois.get('modified', [])
+
+        # insert last
+        new = rois.get('new', [])
+        decoded_rois = []
+        for n in new:
+            new_roi = {
+                "@type":
+                "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI",
+                "shapes": [n]
+            }
+            decoder = omero_marshal.get_decoder(new_roi.get("@type"))
+            decoded_roi = decoder.decode(new_roi)
             decoded_roi.setImage(image._obj)
-
-            # differentiate between new rois and existing ones
-            if int(r) < 0:
-                # we save the new ones including all its new shapes
-                decoded_roi = update_service.saveAndReturnObject(
-                    decoded_roi, conn.SERVICE_OPTS)
-                roi_id = decoded_roi.getId().getValue()
-                # we associate them with the ids handed in
-                i = 0
-                for s in decoded_roi.copyShapes():
-                    old_id = roi['shapes'][i].get('oldId', None)
-                    shape_id = s.getId().getValue()
-                    ret_ids[old_id] = str(roi_id) + ":" + str(shape_id)
-                    i += 1
-            else:
-                # we fetch the existing ones
-                result = rois_service.findByRoi(
-                    long(r), None, conn.SERVICE_OPTS)
-                # we need to have one only for each id
-                if result is None or len(result.rois) != 1:
-                    continue
-                existing_rois = result.rois[0]
-
-                # loop over decoded shapes (new, deleted and modified)
-                j = 0
-                shapes_done = {}
-                shapes_deleted = 0
-                shapes_to_be_added = []
-                roi_id = decoded_roi.getId().getValue()
-                for s in decoded_roi.copyShapes():
-                    old_id = roi['shapes'][j].get('oldId', None)
-                    delete = roi['shapes'][j].get('markedForDeletion', None)
-                    j += 1
-                    shape_id = s.getId().getValue()
-                    if shape_id < 0:
-                        # due to deletions/modifications that we store first
-                        # the newly added ones are added afterwards
-                        decoded_roi.removeShape(s)
-                        shapes_to_be_added.append(
-                            {"oldId": old_id, "shape": s})
-                        continue
-                    if delete is not None:
-                        decoded_roi.removeShape(s)
-                        shapes_deleted += 1
-                    shapes_done[shape_id] = old_id
-                # needed for saving multiple shapes in same roi
-                # otherwise the update routine keeps only the modified
-                for e in existing_rois.copyShapes():
-                    found = shapes_done.get(e.getId().getValue(), None)
-                    if found is None:
-                        decoded_roi.addShape(e)
-                # persist deletions and modifications
-                decoded_roi = update_service.saveAndReturnObject(
-                    decoded_roi, conn.SERVICE_OPTS)
-                # now append the new shapes to the existing ones
-                # and persist them
-                for n in shapes_to_be_added:
-                    decoded_roi.addShape(n['shape'])
-                decoded_roi = update_service.saveAndReturnObject(
-                    decoded_roi, conn.SERVICE_OPTS)
-                nr_of_existing_shapes = decoded_roi.sizeOfShapes()
-                nr_of_added_shapes = len(shapes_to_be_added)
-                # if we deleted all shapes in the roi => remove it as well
-                if nr_of_existing_shapes == 0:
-                    conn.deleteObjects("Roi", [roi_id], wait=False)
-                elif nr_of_added_shapes > 0:
-                    # gather new ids for newly persisted shapes
-                    start = nr_of_existing_shapes - nr_of_added_shapes
-                    for n in shapes_to_be_added:
-                        n_id = str(roi_id) + ":" +  \
-                            str(decoded_roi.getShape(start).getId().getValue())
-                        ret_ids[str(n['oldId'])] = n_id
-                        start += 1
-                # add to the list that contains the successfully persisted ids
-                for x in shapes_done.values():
-                    ret_ids[x] = x
+            decoded_rois.append(decoded_roi)
+        if len(decoded_rois) > 0:
+            decoded_rois
+            ret_ids = update_service.saveAndReturnIds(decoded_rois)
+        return JsonResponse({'ids': ret_ids})
     except Exception as marshalOrPersistenceException:
         # we return all successfully stored rois up to the error
         # as well as the error message

--- a/src/model/regions_history.js
+++ b/src/model/regions_history.js
@@ -308,49 +308,4 @@ export default class RegionsHistory {
        this.history = [];
        this.historyPointer = -1;
     }
-
-    /**
-    * Removes all entries that concern the given ids
-    * @param {Array.<string>} ids an array of ids (of the form roi_id:shape_id)
-    * @memberof History
-    */
-    removeEntries(ids) {
-        if (!Misc.isArray(ids) || ids.length === 0 ||
-            this.history.length === 0) return;
-
-        // a helper for removing a history entry
-        let adjustHistory = (index) => {
-            this.history.splice(index, 1);
-            if (this.historyPointer >= index) this.historyPointer--;
-        };
-
-        for (let i=this.history.length-1;i>=0;i--) {
-            let entry = this.history[i];
-
-            // first remove info/records referring to deleted shapes
-            // then check if we have other history records left or can delete
-            // the history entry altogether
-            for (let j=ids.length-1;j>=0;j--) {
-                let id = ids[j];
-                switch (entry.action) {
-                    case this.action.OL_ACTION:
-                        let idx = entry.records[0].shape_ids.indexOf(id);
-                        if (idx !== -1)
-                            entry.records[0].shape_ids.splice(idx, 1);
-                        if (j === 0 && entry.records[0].shape_ids.length === 0)
-                            adjustHistory(i);
-                        break;
-                    case this.action.PROPERTIES:
-                    case this.action.SHAPES:
-                        for (let k=entry.records.length-1;k>=0;k--) {
-                            if (entry.records[k].shape_id === id)
-                                entry.records.splice(k, 1);
-                        }
-                        if (j === 0 && entry.records.length === 0)
-                            adjustHistory(i);
-                        break;
-                }
-            }
-        }
-    }
 }

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -250,12 +250,12 @@ export default class RegionsInfo  {
                     this.number_of_shapes--;
                     if (!shape.visible) this.visibility_toggles++;
             } else if (property === 'visible') this.visibility_toggles--;
-        } else if (property === 'deleted' && !value) {
-            roi.deleted--;
-            if (typeof shape.is_new === 'boolean' && shape.is_new) {
-                    this.number_of_shapes++;
-                    if (!shape.visible) this.visibility_toggles--;
-                }
+        } else if (property === 'deleted' &&
+                    typeof shape.is_new === 'boolean' && shape.is_new &&
+                    !value) {
+                        roi.deleted--;
+                        this.number_of_shapes++;
+                        if (!shape.visible) this.visibility_toggles--;
         }
     }
 
@@ -555,6 +555,28 @@ export default class RegionsInfo  {
     getNumberOfDeletedShapes() {
         return this.unsophisticatedShapeFilter(
             ["deleted"], [true], ['canDelete']).length;
+    }
+
+    /**
+     * Returns an associative array of empty rois
+     *
+     * @return {Object} an associative array of empty rois
+     * @memberof RegionsInfo
+     */
+    getEmptyRois() {
+        let ret = {};
+        this.data.forEach(
+            (roi, key) => {
+                let total = roi.shapes.size - roi.deleted;
+                if (key > -1 && roi.shapes instanceof Map && total > 0) {
+                    let count = 0;
+                    roi.shapes.forEach((shape) => {
+                        if (shape.deleted) count++;
+                    });
+                    if (count === total) ret[key] = null;
+                }
+        });
+        return ret;
     }
 
     /**

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -833,12 +833,10 @@ export default class Ol3Viewer extends EventSubscriber {
             params.config_id !== this.image_config.id) return;
 
         let numberOfdeletedShapes =
-            this.image_config.regions_info.getNumberOfDeletedShapes(true);
+            this.image_config.regions_info.getNumberOfDeletedShapes();
         let storeRois = () => {
             let requestMade =
-                this.viewer.storeRegions(
-                    Misc.isArray(params.deleted) ? params.deleted : [],
-                    false, params.omit_client_update);
+                this.viewer.storeRegions([], false, params.omit_client_update);
 
             if (requestMade) Ui.showModalMessage("Saving Regions. Please wait...");
             else if (params.omit_client_update)
@@ -978,12 +976,8 @@ export default class Ol3Viewer extends EventSubscriber {
         this.image_config.image_info.roi_count =
             this.image_config.regions_info.data.size;
 
-        // if we stored as part of a delete request we need to clean up
-        // the history for the deleted shapes,
-        // otherwise we wipe the history altogether
-        if (params.is_delete)
-            this.image_config.regions_info.history.removeEntries(ids);
-        else this.image_config.regions_info.history.resetHistory();
+        // clear history
+        this.image_config.regions_info.history.resetHistory();
 
         // error handling
         if (Misc.isArray(params.errors)) {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -985,13 +985,12 @@ export default class Ol3Viewer extends EventSubscriber {
             this.image_config.regions_info.history.removeEntries(ids);
         else this.image_config.regions_info.history.resetHistory();
 
-        // error handling: will probably be adjusted
-        if (typeof params.error === 'string') {
+        // error handling
+        if (Misc.isArray(params.errors)) {
             let msg = "Saving of Rois/Shapes failed.";
-            if (params.error.indexOf("SecurityViolation") !== -1)
-                msg = "Insufficient Permissions to save some Rois/Shapes.";
+            for (let e in params.errors)
+                console.error(params.errors[e]);
             Ui.showModalMessage(msg, 'OK');
-            console.error(params.error);
             return;
         }
     }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -834,9 +834,13 @@ export default class Ol3Viewer extends EventSubscriber {
 
         let numberOfdeletedShapes =
             this.image_config.regions_info.getNumberOfDeletedShapes();
+        let empty_rois =
+            numberOfdeletedShapes > 0 ?
+                this.image_config.regions_info.getEmptyRois() : {};
         let storeRois = () => {
             let requestMade =
-                this.viewer.storeRegions([], false, params.omit_client_update);
+                this.viewer.storeRegions(
+                    empty_rois, false, params.omit_client_update);
 
             if (requestMade) Ui.showModalMessage("Saving Regions. Please wait...");
             else if (params.omit_client_update)

--- a/test/unit/utils/conversion.js
+++ b/test/unit/utils/conversion.js
@@ -314,38 +314,30 @@ describe("Conversion", function() {
         pointFeature['type'] = 'point';
         pointFeature.setId("-1:2");
         features.push(pointFeature);
+        ellipseFeature['state'] = ome.ol3.REGIONS_STATE.REMOVED;
+        ellipseFeature.setId("2:2");
+        features.push(ellipseFeature);
+        lineFeature['state'] = ome.ol3.REGIONS_STATE.REMOVED;
+        lineFeature.setId("-2:-2");
+        features.push(lineFeature);
+        polylineFeature['state'] = ome.ol3.REGIONS_STATE.REMOVED;
+        polylineFeature.setId("10:10");
+        features.push(polylineFeature);
 
-        var jsonObject = ome.ol3.utils.Conversion.toJsonObject(features);
+        var empty_rois = {'10': null};
+        var jsonObject =
+            ome.ol3.utils.Conversion.toJsonObject(features, true, empty_rois);
 
-        assert.equal(jsonObject['count'],3);
-        assert.equal(jsonObject['rois']['1']['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-        assert.equal(jsonObject['rois']['1']['shapes'][0]['@id'],1);
-        assert.equal(jsonObject['rois']['1']['shapes'][0]['@type'],
+        assert.equal(jsonObject['count'], 5);
+        assert.equal(jsonObject['modified'][0]['@id'], 1);
+        assert.equal(jsonObject['modified'][0]['@type'],
             "http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-        assert.equal(jsonObject['rois']['-1']['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-        assert.equal(jsonObject['rois']['-1']['shapes'][0]['@type'],
+        assert.equal(jsonObject['new'][0]['@type'],
             "http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-        assert.equal(jsonObject['rois']['-1']['shapes'][1]['@type'],
+        assert.equal(jsonObject['new'][1]['@type'],
             "http://www.openmicroscopy.org/Schemas/OME/2016-06#Point");
-
-        // test variation: each shape gets its own roi
-        var jsonObject = ome.ol3.utils.Conversion.toJsonObject(features, true);
-
-        assert.equal(jsonObject['count'], 3);
-        assert.equal(jsonObject['rois']['1']['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-        assert.equal(jsonObject['rois']['1']['shapes'][0]['@id'],1);
-        assert.equal(jsonObject['rois']['1']['shapes'][0]['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#Label");
-        assert.equal(jsonObject['rois']['-1']['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-        assert.equal(jsonObject['rois']['-1']['shapes'][0]['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle");
-        assert.equal(jsonObject['rois']['-2']['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI");
-        assert.equal(jsonObject['rois']['-2']['shapes'][0]['@type'],
-            "http://www.openmicroscopy.org/Schemas/OME/2016-06#Point");
+        assert.equal(jsonObject['deleted']['2'][0], '2:2');
+        assert.equal(jsonObject['new_and_deleted'][0], ['-2:-2']);
+        assert.equal(jsonObject['empty_rois']['10'][0], '10:10');
     });
 });


### PR DESCRIPTION
see: https://trello.com/c/Kn7HBtKx/13-bug-100-rois-deletion-fails
and somewhat related: https://trello.com/c/GiDmiT8N/4-permission-testing-new-role

The new approach breaks persistence into the following sections:
- new and deleted (eliminated on the js side and not being sent - mentioned for completeness sake)
- new
- modified
- empty rois, i.e. deleted shapes resulting in an empty roi which has to also be deleted
- deleted shapes

The size of json sent for the ajax request should be smaller now and the amount of marshalling work reduced. For deletion only the ids are sent. No objects are marshalled for return but instead only ids to sync in the front-end and receive the new ids for new objects.

The preferred method of deletion is `deleteObjects` on the roi level for empty rois.

The only exception is for the deletion of individual shapes in a rois with multiple shapes which would have to be created outside of iviewer, e.g. script or insight. With those the `removeShape() `method is used such as to not create index holes in the collection. I have opted for this solution for now since no server solution is in sight (see 2. trello discussion). Another approach is to not mind about creating index holes (using `deleteObject` as well) but that necessitates changes in omero-marshal which as is gets tripped by the None entries that are created in the shapes collection when it tries to marshal them. A "solution" I don't even want to put out there is the move back to marshalling in the iviewer view which was abandoned in favor of the web api.

