### PR TITLE
permission issue build

### DIFF
--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -50,6 +50,7 @@ class RunProd(Command):
     def run(self):
         if not os.path.isdir('omero_iviewer/static'):
             self.spawn(['npm', 'run', 'prod'])
+            self.spawn(['rm', '-rf', '../node_modules'])
 
 
 cmdclass['run_prod'] = RunProd


### PR DESCRIPTION
Remove node_modules folder after run prod in setup.py
This should have no impact when running locally ``npm run prod``
I have created a card to review later on the build system
https://trello.com/b/clkD8YDR/iviewer-priority-list

Possibility: this could become the last step for ``prod``, ``debug`` etc. This means that each local build will take a bit longer
Check that travis is green