### PR TITLE
omit unneeded rerendering

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1820,8 +1820,7 @@ ome.ol3.Viewer.prototype.changeChannelRange = function(ranges) {
     var omeroImage = this.getImage();
     if (omeroImage === null) return;
 
-    omeroImage.changeChannelRange(ranges);
-    this.affectImageRender();
+    if (omeroImage.changeChannelRange(ranges)) this.affectImageRender();
 }
 
 /**


### PR DESCRIPTION
see: https://trello.com/c/SdIkKcKE/27-bug-grayscale-and-color-switch

TEST: Check that there are no rerenders (that is: no new image/tile fetching) if rendering setting changes were made on a channel that happens to be inactive (exception: settting it to active!) and, more specifically, if color/lookup changes were made when grayscale option is enabled.

The "easiest" way to be sure is to open the dev tools in your favorite browser (F12 for FF and Chrome), switch to the networking tab, optionally clearing it/filtering for images and then go on testing. No new requests should be visible. 

To be honest, especially with tiled images the rerender is instantly visible even without the dev tools method.

![screenshot_2018-02-22_10-28-54](https://user-images.githubusercontent.com/1559229/36513423-45560da4-17bb-11e8-8c50-c4ba41c1a751.png)


