### PR TITLE
fix sidebar resizing

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -528,6 +528,7 @@ a.ui-button:active,
 .thumbnail-panel {
     padding-top: 30px;
     width: 100px;
+    flex: 0 0 100px;
     max-width: 100px;
     text-align: center;
     overflow-x: hidden;
@@ -590,6 +591,7 @@ thumbnail-slider img {
 
 .right-hand-panel {
     width: 350px;
+    flex: 0 0 350px;
     max-width: 1000px;
     overflow-y: hidden;
 }

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -61,6 +61,7 @@ export default class Ui {
 
                 if (x > minWidth && x < maxWidth && e.pageX < rightBound) {
                     el.width(x);
+                    el.css('flex', '0 0 ' + x + 'px');
                 }
                 eventbus.publish(IMAGE_VIEWER_RESIZE,
                     {config_id: -1, is_dragging: true});
@@ -140,6 +141,7 @@ export default class Ui {
                 (leftSplit && newWidth === 0 ||
                     !leftSplit && newWidth !== 0 ? "right" : "left") + ".png");
             el.width(newWidth);
+            el.css('flex', '0 0 ' + newWidth + 'px');
             if (newWidth === 0)
                 $(e.currentTarget).parent().css("cursor", "default");
             else


### PR DESCRIPTION
This should fix a couple of issues with resizing and expand/collapse of side bars.

To test:
 - resize right-hand panel to make it bigger. Then resize browser window to force page to re-render. Should see no change in right-panel width on page resize.
 - expand & collapse left and right panels repeatedly. Should return to correct size each time and not affect each other (e.g expand/collapse/resize of right panel shouldn't affect thumbnail slider on left).