### PR TITLE
light admin - controls disabled

### DIFF
--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -539,8 +539,7 @@ export default class RegionsInfo  {
                 permission !== 'canEdit' &&
                 permission !== 'canDelete')) return false;
 
-        return this.image_info.can_annotate &&
-                !(typeof shape['permissions'] === 'object' &&
+        return !(typeof shape['permissions'] === 'object' &&
                 shape['permissions'] !== null &&
                 typeof shape['permissions'][permission] === 'boolean' &&
                 !shape['permissions'][permission]);

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -822,10 +822,8 @@ export default class RegionsEdit extends EventSubscriber {
             this.regions_info.checkShapeForPermission(
                 this.last_selected, "canDelete");
         let showEditDisabled =
-            !this.regions_info.image_info.can_annotate ||
                 (this.regions_info.selected_shapes.length >= 1 && !canEdit);
         let showDeleteDisabled =
-            !this.regions_info.image_info.can_annotate ||
                 (this.regions_info.selected_shapes.length >= 1 && !canDelete);
 
         // break up adjustment into individual sections

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -29,11 +29,8 @@
                     <button type="button" class="btn btn-default btn-sm"
                         disabled.bind="!(regions_info.history &&
                             regions_info.history.history.length > 0 &&
-                            regions_info.history.historyPointer >= 0) ||
-                            !regions_info.image_info.can_annotate"
-                        click.delegate="saveShapes()"
-                        title="${!regions_info.image_info.can_annotate ?
-                                    'No permission to save' : ''}">Save
+                            regions_info.history.historyPointer >= 0)"
+                        click.delegate="saveShapes()">Save
                     </button>
                     <button type="button"
                         disabled.bind="!(regions_info.history &&


### PR DESCRIPTION
see https://trello.com/c/GiDmiT8N/4-permission-testing-new-role

The permission check for shape deletion/edit/save included image.can_annotate as well.
