### PR TITLE
csv export - don't try requesting for big images

### DIFF
--- a/src/app/header.js
+++ b/src/app/header.js
@@ -262,7 +262,7 @@ export class Header {
             regInf.selected_shapes.filter((s) => s.indexOf("-") == -1);
         // if we have no saved shapes or no active channels ...
         // forget about it
-        if (ids_for_stats.length === 0 ||
+        if (this.image_config.image_info.tiled || ids_for_stats.length === 0 ||
             regInf.image_info.getActiveChannels().length === 0) {
             this.writeCsv(regInf.selected_shapes, utf);
         } else {


### PR DESCRIPTION
while working on https://github.com/ome/omero-iviewer/pull/182 I noticed that the front end tries to send a request for rois intensities in the case of tiled images. this is not supported by the server and it sends back a json response saying so. consequently, however, no roi listing is exported.

this PR redirects for tiled images so that one gets a csv with front end measures only as is the case with new but unsaved shapes.

TEST: find a big image with rois (or draw new ones and save them), select a bunch, then hit export. you should get a csv that contains them.