### PR TITLE
Rois Pasting

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1412,7 +1412,7 @@ ome.ol3.Viewer.prototype.setRegionsModes = function(modes) {
  * - position => the position to place the shape(s) or null (random placement)
  * - extent => a bounding box for generation, default: the entire viewport
  * - theDims => a list of dims to attach to
- * - scale_factor => a scale factor to apply because of image dimension differences
+ * - is_compatible => the image size of the originating image was smaller or equal
  * - add_history => determines whether we should add the generation to the history
  * - hist_id => the history id to pass through
  */
@@ -1457,7 +1457,9 @@ ome.ol3.Viewer.prototype.generateShapes = function(shape_info, options) {
     // delegate
     var generatedShapes =
         ome.ol3.utils.Regions.generateRegions(
-            shape_info, number, extent, position, options['scale_factor']);
+            shape_info, number, extent, position,
+            typeof options['is_compatible'] === 'boolean' && 
+                options['is_compatible']);
     // another brief sanity check in case not all shapes were created
     if (generatedShapes === null ||
             (!oneToManyRelationShip &&

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -919,8 +919,8 @@ ome.ol3.utils.Conversion.convertPointStringIntoCoords = function(points) {
         if (tok === '') continue;
         var c = tok.split(",");
         if (c.length < 2) return null;
-        var x = parseInt(c[0]);
-        var y = parseInt(c[1]);
+        var x = parseFloat(c[0]);
+        var y = parseFloat(c[1]);
         // NaNs are not acceptable
         if (isNaN(x) || isNaN(y)) return null;
         ret.push([x, -y]);

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -602,10 +602,14 @@ export default class RegionsInfo  {
             this.copied_shapes.length === 0) return;
 
         this.syncCopiedShapesWithLocalStorage();
+        let isCompatibleTargetImage =
+            this.copied_image_dims.width <= this.image_info.dimensions.max_x &&
+            this.copied_image_dims.height <= this.image_info.dimensions.max_y;
         let params = {
             config_id: this.image_info.config_id,
             number: 1, paste: true,
             shapes: this.copied_shapes,
+            is_compatible: isCompatibleTargetImage,
             hist_id: this.history.getHistoryId(),
             position: pixel
         };

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -201,9 +201,15 @@ export default class RegionsInfo  {
             this.copied_shapes = JSON.parse(
                 window.localStorage.getItem(IVIEWER + ".copy_shape_defs"));
             if (!Misc.isArray(this.copied_shapes)) this.copied_shapes = [];
+        } catch(ignored) {
+            this.copied_shapes = [];
+        }
+        try {
             this.copied_image_dims = JSON.parse(
                 window.localStorage.getItem(IVIEWER + ".copy_image_dims"));
-        } catch(ignored) {}
+        } catch(ignored) {
+            this.copied_image_dims = null;
+        }
     }
 
     /**
@@ -603,6 +609,7 @@ export default class RegionsInfo  {
 
         this.syncCopiedShapesWithLocalStorage();
         let isCompatibleTargetImage =
+            this.copied_image_dims &&
             this.copied_image_dims.width <= this.image_info.dimensions.max_x &&
             this.copied_image_dims.height <= this.image_info.dimensions.max_y;
         let params = {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -195,7 +195,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 left: Misc.getRandomInteger(minX,maxX) + 'px'
             };
         }
-        
+
         // make viewer windows draggable/resizable within boundaries
         container.draggable({
             handle: '.viewer-handle',
@@ -610,11 +610,10 @@ export default class Ol3Viewer extends EventSubscriber {
                       let opts = {
                           'number': params.number,
                           'position': params.position,
+                          'is_compatible': params.is_compatible,
                           'extent': this.viewer.getSmallestViewExtent(),
                           'theDims': theDims
                       };
-                      if (typeof params.scale_factor === 'number')
-                          opts['scale_factor'] = params.scale_factor;
                       if (typeof params.add_history === 'boolean')
                           opts['add_history'] = params.add_history;
                       if (typeof params.hist_id === 'number')
@@ -1135,7 +1134,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 IVIEWER + ".copy_image_dims",
                 JSON.stringify({
                     width: this.image_config.image_info.dimensions.max_x,
-                    height: this.image_config.image_info.dimensions.max_x
+                    height: this.image_config.image_info.dimensions.max_y
             }));
             // remember shape definitions for generating copies
             window.localStorage.setItem(

--- a/test/unit/regions.js
+++ b/test/unit/regions.js
@@ -119,7 +119,7 @@ describe("Regions", function() {
         expect(feature.getGeometry().getRadius()).to.eql([25, 55]);
     });
 
-    it('generateRegions', function() {
+    it('generateRegionsRandom', function() {
         var features =
             ome.ol3.utils.Regions.generateRegions(
                 polygon_info, 10, [0,-1000,1000,0]);
@@ -130,6 +130,37 @@ describe("Regions", function() {
             var geom = features[f].getGeometry();
             assert.instanceOf(geom, ome.ol3.geom.Polygon);
             assert(ol.extent.containsExtent([0,-1000,1000,0], geom.getExtent()));
+        }
+    });
+
+    it('generateRegionsPosition', function() {
+        var features =
+            ome.ol3.utils.Regions.generateRegions(
+                polygon_info, 1, [0,-1000,1000,0], [0,0]);
+
+        assert.instanceOf(features, Array);
+        for (var f in features) {
+            assert.instanceOf(features[f], ol.Feature);
+            var geom = features[f].getGeometry();
+            assert.instanceOf(geom, ome.ol3.geom.Polygon);
+            expect(ol.extent.getTopLeft(geom.getExtent())).to.deep.equal([0,0]);
+        }
+    });
+
+    it('generateRegionsSamePlace', function() {
+        var features =
+            ome.ol3.utils.Regions.generateRegions(
+                polygon_info, 1, [0,-1000,1000,0], null, true);
+        var expGeom =
+            ome.ol3.utils.Regions.featureFactory(polygon_info).getGeometry();
+            
+        assert.instanceOf(features, Array);
+        for (var f in features) {
+            assert.instanceOf(features[f], ol.Feature);
+            var geom = features[f].getGeometry();
+            assert.instanceOf(geom, ome.ol3.geom.Polygon);
+            expect(geom.getPolygonCoordinates()).to.deep.equal(
+                expGeom.getPolygonCoordinates());
         }
     });
 


### PR DESCRIPTION
see also: https://trello.com/c/Yr5NmQ0B/30-copy-paste-rois

If shapes are copied between 'compatible' images, i.e. the target image is equal or bigger than the source image their coordinates remain the same. If not they are put in a random location.
NOTE: This does not apply to the context menu (right-click) pasting option "Paste ROI here" which will still use the mouse location to allow the user to place the shape!