### PR TITLE
don't reset initial version parameter

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -250,7 +250,7 @@ ome.ol3.Viewer = function(id, options) {
         actual_version = parseInt(actual_version.replace(/[.]/g, ""));
         if (isNaN(actual_version)) return false;
 
-        return version >= actual_version;
+        return actual_version >= version;
     }
 
     /**

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -455,7 +455,10 @@ ome.ol3.Viewer.prototype.bootstrapOpenLayers = function(postSuccessHook, initHoo
        channels.push(newC);
     }
 
-    // create an OmeroImage source (tiled)
+    var isTiled =
+        typeof this.image_info_['tiles'] === 'boolean' &&
+            this.image_info_['tiles'];
+    // create an OmeroImage source
     var source = new ome.ol3.source.Image({
        server : this.getServer(),
        uri : this.getPrefixedURI(ome.ol3.WEBGATEWAY),
@@ -468,9 +471,8 @@ ome.ol3.Viewer.prototype.bootstrapOpenLayers = function(postSuccessHook, initHoo
        resolutions: zoom > 1 ? zoomLevelScaling : [1],
        img_proj:  parsedInitialProjection,
        img_model:  initialModel,
-       tiled: typeof this.image_info_['tiles'] === 'boolean' &&
-            this.image_info_['tiles'],
-       tile_size: this.supportsOmeroServerVersion("5.4.4") ?
+       tiled: isTiled,
+       tile_size: isTiled && this.supportsOmeroServerVersion("5.4.4") ?
             ome.ol3.DEFAULT_TILE_DIMS :
                 this.image_info_['tile_size'] ?
                     this.image_info_['tile_size'] : null

--- a/ol3-viewer/src/ome/ol3/source/Image.js
+++ b/ol3-viewer/src/ome/ol3/source/Image.js
@@ -238,18 +238,18 @@ ome.ol3.source.Image = function(options) {
             if (this.tiled_ || this.use_tiled_retrieval_) {
                 var zoom = this.tiled_ ?
                     this.tileGrid.resolutions_.length - tileCoord[0] - 1 : 0;
-                if (this.tile_size_) {
+                if (this.tiled_) {
                     url += 'tile=' + zoom  + ',' +
-                        tileCoord[1] + ',' + (-tileCoord[2]-1) + ',';
+                        tileCoord[1] + ',' + (-tileCoord[2]-1);
                 } else {
-                    // for non pyramid images that are retrieved tiled 
+                    // for non pyramid images that are retrieved tiled
                     // force tile size with 'region' to be compatible
                     // with older versions of omero server
                     url += 'region=' +
                         (tileCoord[1] * this.tileGrid.tileSize_[0]) + ',' +
-                        ((-tileCoord[2]-1) * this.tileGrid.tileSize_[1]) + ',';
+                        ((-tileCoord[2]-1) * this.tileGrid.tileSize_[1]);
                 }
-                url += this.tileGrid.tileSize_[0] + ',' +
+                url += ',' + this.tileGrid.tileSize_[0] + ',' +
                     this.tileGrid.tileSize_[1] + '&';
             }
 

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -52,9 +52,8 @@ QUERY_DISTANCE = 25
 
 @login_required()
 def index(request, iid=None, conn=None, **kwargs):
-    # set params
-    params = {'VERSION': __version__}
-    params = {'OMERO_VERSION': omero_version}
+    # create params (incl. versions)
+    params = {'VERSION': __version__, 'OMERO_VERSION': omero_version}
 
     # check for image_id (default viewer setup)
     if iid is not None:

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -797,8 +797,12 @@ export default class Context {
      * @memberof Context
      */
     resetInitParams() {
+        let omeroServerVersion =
+            this.getInitialRequestParam(REQUEST_PARAMS.OMERO_VERSION);
         // empty all handed in params
         this.initParams = {};
+        // keep omero server information
+        this.initParams[REQUEST_PARAMS.OMERO_VERSION] = omeroServerVersion;
         // we do need our uri prefixes again
         this.prefixed_uris.forEach((value, key) => this.initParams[key] = value);
     }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -121,6 +121,7 @@ export const REQUEST_PARAMS = {
     IMAGES: 'IMAGES',
     MAPS: 'MAPS',
     MODEL: 'M',
+    OMERO_VERSION: 'OMERO_VERSION',
     PLANE: 'Z',
     PROJECTION: 'P',
     SERVER: 'SERVER',


### PR DESCRIPTION
see: https://trello.com/c/AdRIcaBJ/37-viewing-large-non-tiled-image-fails

when the image is initially opened in iviewer the omero server version information is handed in by the python layer. since initial url values get wiped after the initial load so was the version information which caused the issue described in the trello card.

also, the iviewer version display was fixed, and in between small and pyramid size images (see trello card) are now backwards compatible to omero server versions below 5.4.4.

TEST: use the images in this dataset:  http://web-dev-merge.openmicroscopy.org/webclient/?show=dataset-1682 (user-3).
