### PR TITLE
About dialog url

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1155,13 +1155,9 @@ thumbnail-slider img {
 }
 .modal-content {
     width: 300px;
-    max-height: 250px;
 }
 .modal-message .ok {
     width: 50px;
-}
-.modal-footer {
-    padding: 4px;
 }
 .modal-open .modal {
     overflow-y: hidden;
@@ -1218,7 +1214,6 @@ thumbnail-slider img {
 
 .modal-about .modal-content {
     width: 550px;
-    max-height: 220px;
 }
 .modal-about .modal-dialog {
     top: 45%;

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -137,11 +137,17 @@
                             ${context.version}
                     </p>
                     <p>
-                        &copy; 2017 University of Dundee &amp; Open Microscopy Environment<br>
-                        OMERO and OMERO.iviewer are distributed under the terms of the GNU GPL.<br>
-                        See: <a target="new" href="http://www.openmicroscopy.org">openmicroscopy.org</a>
+                        For more information, visit the
+                        <a target="new" href="https://www.openmicroscopy.org/omero/iviewer/">
+                            OMERO.iviewer page</a>.
                     </p>
-                </h4>
+                    <p>
+                        &copy; 2017-2018 University of Dundee &amp; Open Microscopy Environment<br>
+                        OMERO is distributed under the terms of the GNU GPL and<br>
+                        OMERO.iviewer under AGPL.<br>
+                        See: <a target="new" href="https://www.openmicroscopy.org">openmicroscopy.org</a>
+                    </p>
+                </div>
                 <div class="modal-footer">
                 <button type="button"
                         class="ok center-block btn btn-default"


### PR DESCRIPTION
Since we now have https://www.openmicroscopy.org/omero/iviewer/ available, this adds the link to the iviewer about dialog.

Also removed some css rules to allow dialog to expand to fit additional text and have larger footer (which also affects other dialogs).

Before:
![screen shot 2018-03-19 at 11 28 10](https://user-images.githubusercontent.com/900055/37593371-a84277d8-2b69-11e8-9bd3-377e5b208f2a.png)

After:
![screen shot 2018-03-19 at 11 28 26](https://user-images.githubusercontent.com/900055/37593388-b653b6d4-2b69-11e8-96ae-17d03339d851.png)

About dialog:
![screen shot 2018-03-19 at 11 28 40](https://user-images.githubusercontent.com/900055/37593403-bd3469f8-2b69-11e8-8f9b-a83b6ca04f83.png)

