### PR TITLE
bug: don't count new but instantly deleted

### DIFF
--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -559,7 +559,8 @@ export default class RegionsInfo  {
      */
     getNumberOfDeletedShapes() {
         return this.unsophisticatedShapeFilter(
-            ["deleted"], [true], ['canDelete']).length;
+            ["deleted", "is_new"], [true, "false"],
+            ['canDelete', 'canDelete']).length;
     }
 
     /**

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -489,7 +489,9 @@ export default class RegionsInfo  {
      * @return {boolean} true if shapes have been modified, otherwise false
      */
     hasBeenModified() {
-        return this.history instanceof RegionsHistory && this.history.canUndo();
+        return this.history instanceof RegionsHistory &&
+            this.history.historyPointer >= 0 &&
+            !this.history.hasOnlyNewlyDeleted;
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -452,7 +452,7 @@ export default class RegionsList extends EventSubscriber {
      * @memberof RegionsList
      */
     hasPermissions(shape) {
-        return !shape.permissions ||
+        return !(shape && shape.permissions) ||
            (shape.permissions &&
             shape.permissions.canAnnotate &&
             shape.permissions.canEdit &&

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -27,7 +27,8 @@
                     <button type="button" class="btn btn-default btn-sm"
                         disabled.bind="!(regions_info.history &&
                             regions_info.history.history.length > 0 &&
-                            regions_info.history.historyPointer >= 0)"
+                            regions_info.history.historyPointer >= 0 &&
+                            !regions_info.history.hasOnlyNewlyDeleted)"
                         click.delegate="saveShapes()">Save
                     </button>
                     <button type="button"


### PR DESCRIPTION
was part of the remarks on this card: https://trello.com/c/z3AruQMZ/38-feedback-from-mporter

https://github.com/ome/omero-iviewer/pull/72 was later abandoned in favor of general persistence on save with a warning about the number of deleted shapes on save.

this delete count includes newly drawn shapes that got deleted which is confusing and unnecessary since these shapes never existed on the server to begin with.

TEST: draw or paste a new shape(s), delete it/them, then save. There should not be a warning as is in the case when you delete an already existing shape and do the same