### PR TITLE
Bug: drawing mode and context (right) click

### DIFF
--- a/ol3-viewer/src/ome/ol3/interaction/Draw.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Draw.js
@@ -190,6 +190,11 @@ ome.ol3.interaction.Draw.prototype.drawShapeCommonCode_ =
         this.ol_draw_ = new ol.interaction.Draw({
             style: this.default_style_function_,
             type: ol_shape,
+            condition: function(e) {
+                // ignore right clicks (from context)
+                return ol.events.condition.noModifierKeys(e) &&
+                    ol.events.condition.primaryAction(e);
+            },
             geometryFunction:
                 typeof(geometryFunction) === 'function' ?
                     geometryFunction : null


### PR DESCRIPTION
was part of the remarks on this card: https://trello.com/c/z3AruQMZ/38-feedback-from-mporter

While in drawing mode a right click for context triggers a mouse down event as well to the effect that this is regarded the start of a shape drawing. 

What this PR does:
In the openlayers interaction a condition checks that we don't have a right-click for a context menu so that no new shape drawing will be initiated.

What this PR doesn't do:
It doesn't abort the drawing interaction as such, e.g. in the case of a started drawing of a shape a right-click will not abort the drawing, likewise clicking anywhere but the context menu will start a new shape.

TEST: While in drawing mode right-click to bring up context menu. This should not trigger the start of a new shape.