### PR TITLE
Bug: ensure capture at start of translation

### DIFF
--- a/ol3-viewer/src/ome/ol3/interaction/Translate.js
+++ b/ol3-viewer/src/ome/ol3/interaction/Translate.js
@@ -81,7 +81,9 @@ ome.ol3.interaction.Translate = function(regions_reference) {
                     f['permissions'] !== null &&
                     typeof f['permissions']['canEdit'] === 'boolean' &&
                     !f['permissions']['canEdit'])) continue;
-                this.translatedFeatures_.push(f);
+                var clonedF = f.clone();
+                clonedF.setId(f.getId());
+                this.translatedFeatures_.push(clonedF);
             }
         }, this);
 


### PR DESCRIPTION
Testing https://github.com/ome/omero-iviewer/pull/188 I tried out scenarios of pasting and the deleting shapes (as opposed to drawing). While doing so I translated then undid the change and ended up with a tiniest offset as described in https://github.com/ome/omero-iviewer/pull/185.

The problem is not related to either one of the other PRs but the translation & its history (capturing of original geometry). It could now be seen with a second shape pasted on top and zoomed in.

TEST: Either draw or use an existing shape. Copy and paste it then translate one of the 2. After undoing your action via the history button the two shapes should end up straight on top of each other as was before the translate. You have to zoom in close on the lines,