### PR TITLE
calculate length for line geometries only

### DIFF
--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -514,9 +514,9 @@ ome.ol3.utils.Regions.calculateLengthAndArea =
             !(geom instanceof ol.geom.Circle) &&
             !(geom instanceof ome.ol3.geom.Line) &&
             !(geom instanceof ome.ol3.geom.Label);
-        var hasLength =
-            !(geom instanceof ol.geom.Circle) &&
-            !(geom instanceof ome.ol3.geom.Label);
+        // for now we only calculate length for line geometries
+        // TODO: adjust if perimeter for closed geometries is needed as well
+        var hasLength = geom instanceof ome.ol3.geom.Line;
 
         // if we are not micron we convert
         if (typeof pixel_symbol !== 'string' ||

--- a/test/unit/regions.js
+++ b/test/unit/regions.js
@@ -153,7 +153,7 @@ describe("Regions", function() {
                 polygon_info, 1, [0,-1000,1000,0], null, true);
         var expGeom =
             ome.ol3.utils.Regions.featureFactory(polygon_info).getGeometry();
-            
+
         assert.instanceOf(features, Array);
         for (var f in features) {
             assert.instanceOf(features[f], ol.Feature);
@@ -171,7 +171,7 @@ describe("Regions", function() {
 
         assert.instanceOf(measurement, Object);
         expect(measurement.Area).to.eql(180);
-        expect(measurement.Length).to.eql(54);
+        expect(measurement.Length).to.eql(-1);
 
         feature = ome.ol3.utils.Regions.featureFactory(line_info);
         measurement =
@@ -180,6 +180,13 @@ describe("Regions", function() {
         assert.instanceOf(measurement, Object);
         expect(measurement.Area).to.eql(-1);
         expect(measurement.Length).to.eql(81.394);
+
+        feature = ome.ol3.utils.Regions.featureFactory(polyline_info);
+        measurement =
+            ome.ol3.utils.Regions.calculateLengthAndArea(feature);
+        assert.instanceOf(measurement, Object);
+        expect(measurement.Area).to.eql(-1);
+        expect(measurement.Length).to.eql(164.239);
 
         feature = ome.ol3.utils.Regions.featureFactory(point_info);
         measurement =


### PR DESCRIPTION
see: https://trello.com/c/z3AruQMZ/38-feedback-from-mporter

to be consistent with insight and not violate the definition of length for non line type of geometries length is  only calculated for (poly)lines. doing it this way is actually more compact than changing display for both css export and rois table and has the positive side-effect that less calculation has to happen.

TEST: choose an image with rois and/or draw some. Check that the length column in the regions listing in the right hand panel (after selecting "Show Area/Length" option) shows only length in the case of line geometries. Also select rois and then export them to csv/excel via the header menu. Only rows for (poly)lines should show a value in the length column.