### PR TITLE
fix for regions-header when opacity row overlaps

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -772,6 +772,7 @@ thumbnail-slider img {
     font-weight: bold;
     font-size: 13px;
     border-bottom: solid #ddd 1px;
+    z-index: 1;
 }
 
 .regions-table {


### PR DESCRIPTION
see: https://trello.com/c/rCcTsba5/34-not-owned-shapes-show-in-table-header