### PR TITLE
Projection Sync Multi View

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -69,7 +69,7 @@
         <div class="frame col-xs-12">
             <div class="${context.useMDI && context.image_configs.size > 1 ?
                             'viewer-mdi' : 'viewer'}
-                        ${context.useMDI && context.selected_config === id && 
+                        ${context.useMDI && context.selected_config === id &&
                             context.image_configs.size > 1 ? 'mdi-selected' : ''}"
                  repeat.for="[id, conf] of context.image_configs"
                  css="${context.useMDI && context.image_configs.size > 1 ?
@@ -121,7 +121,7 @@
                                              (lock.CHAR === 'zt' &&
                                               conf.image_info.dimensions.max_z > 1 ||
                                               conf.image_info.dimensions.max_t > 1))"
-                                title="Lock ${lock.LABEL}}">
+                                title="Lock ${lock.LABEL}">
                              <input type="checkbox"
                                  checked.bind="conf.sync_locks[lock.CHAR]"
                                  change.delegate="

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -30,6 +30,8 @@ export const IMAGE_VIEWER_RESIZE = "IMAGE_VIEWER_RESIZE";
 export const IMAGE_VIEWER_INTERACTION = "IMAGE_VIEWER_INTERACTION";
 /** whenever the image rendering settings change: channel, model, projection*/
 export const IMAGE_SETTINGS_CHANGE = "IMAGE_SETTINGS_CHANGE";
+/** whenever the projection settings need to be synced*/
+export const VIEWER_PROJECTIONS_SYNC = "VIEWER_PROJECTIONS_SYNC";
 /** whenever an image dimension (c,t,z) changes */
 export const IMAGE_DIMENSION_CHANGE = "IMAGE_DIMENSION_CHANGE";
 /** whenever the dimension play should be started/stopped */

--- a/src/viewers/ol3-viewer-linked-events.js
+++ b/src/viewers/ol3-viewer-linked-events.js
@@ -148,6 +148,7 @@ export default class Ol3ViewerLinkedEvents {
      * Handles the following image changes of sync_group members:
      * - channel range (start, end, color, reverse)
      * - color/grayscale
+     * - projection
      *
      * @memberof Ol3ViewerLinkedEvents
      * @param {Object} params the event notification parameters
@@ -169,6 +170,49 @@ export default class Ol3ViewerLinkedEvents {
                     old_val : oldValue, new_val: newValue, type: 'string'});
                 // propagate to ol3 viewer
                 this.getViewer().changeImageModel(params.model);
+            }
+        } else if (typeof params.projection === 'string') {
+            let history = [];
+            let oldProjectionValue = conf.image_info.projection;
+            let newProjectionValue = params.projection;
+            if (oldProjectionValue !== newProjectionValue) {
+                // update data
+                conf.image_info.projection = newProjectionValue;
+                // add a change entry
+                history.push({
+                    prop: ['image_info', 'projection'],
+                    old_val : oldProjectionValue, new_val: newProjectionValue,
+                    type: 'string'});
+            }
+            let oldProjectionOpts = conf.image_info.projection_opts;
+            let newProjectionOpts = Object.assign({}, params.projection_opts);
+            let maxZ = conf.image_info.dimensions.max_z-1;
+            if (newProjectionOpts.start > maxZ)
+                newProjectionOpts.start = maxZ;
+            if (newProjectionOpts.end > maxZ)
+                newProjectionOpts.end = maxZ;
+            if (oldProjectionOpts.start !== newProjectionOpts.start ||
+                oldProjectionOpts.end !== newProjectionOpts.end) {
+                    // update data
+                    conf.image_info.projection_opts = newProjectionOpts;
+                    // add a change entry
+                    history.push({
+                        prop: ['image_info', 'projection_opts'],
+                        old_val : Object.assign({}, oldProjectionOpts),
+                        new_val: Object.assign({}, newProjectionOpts),
+                        type: 'object'});
+            }
+            if (history.length > 0) {
+                history.splice(0,0, {
+                    prop: ['image_info', 'projection_opts', 'synced'],
+                    old_val : false, new_val: false, type : "boolean"
+                });
+                conf.addHistory(history);
+                // propagate change to ol3 viewer
+                this.getViewer().changeImageProjection(
+                    params.projection, newProjectionOpts);
+                // hack to indicate that we have been synced
+                conf.image_info.projection_opts.synced = true;
             }
         } else if (Misc.isArray(params.ranges) && params.ranges.length > 0) {
             // make a copy because we need to alter it potentially
@@ -257,12 +301,30 @@ export default class Ol3ViewerLinkedEvents {
         if (!this.isLocked(SYNC_LOCK.ZT.CHAR, sync_locks)) return;
 
         let conf = this.getImageConfig();
+        let history = [];
+        let oldProjectionValue = conf.image_info.projection;
+        let newProjectionValue = params.projection;
+        if (oldProjectionValue !== newProjectionValue) {
+            // update data
+            conf.image_info.projection = newProjectionValue;
+            conf.image_info.projection_opts.synced = false;
+            // add a change entry
+            history.push({
+                prop: ['image_info', 'projection_opts', 'synced'],
+                old_val : false, new_val: false, type : "boolean"
+            });
+            history.push({
+                prop: ['image_info', 'projection'],
+                old_val : oldProjectionValue, new_val: newProjectionValue,
+                type: 'string'});
+        }
+
         let dims = conf.image_info.dimensions;
         let oldValue = dims[params.dim];
-        let dim_max = dims['max_' + params.dim];
+        let dim_max = dims['max_' + params.dim]-1;
         let newValue = params.value[0];
         // we must not exceed the bound
-        if (newValue >= dim_max) return;
+        if (newValue > dim_max) newValue = dim_max;
 
         this.preventEventPublish(true);
         try {
@@ -270,12 +332,13 @@ export default class Ol3ViewerLinkedEvents {
                 // update data
                 dims[params.dim] = newValue;
                 // add a change entry
-                conf.addHistory({
+                history.push({
                     prop: ['image_info', 'dimensions', params.dim],
                     old_val : oldValue, new_val: newValue, type: 'number'});
                 // propagate to ol3 viewer
                 this.getViewer().setDimensionIndex(params.dim, [newValue]);
             }
+            if (history.length > 0) conf.addHistory(history);
         } catch(just_in_case) {
             console.error(just_in_case);
         }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -472,7 +472,7 @@ export default class Ol3Viewer extends EventSubscriber {
         // we are syncing only with configs other than the originating
         if (typeof params.config_id !== 'number' ||
             params.config_id === this.image_config.id) return;
-        this.linked_events.syncAction(params, "changeImageSettings");
+        this.linked_events.syncAction(params, "setProjection");
     }
 
     /**


### PR DESCRIPTION
https://trello.com/c/zmaYZqM3/47-projection-multi-view

Note for testing: as with any other settings, the syncing of changes will be turned on only at locking the viewer windows to the same group. Only if the checkboxes for the actions (e.g. z/t, view, channels) are checked will a sync for these actions be performed.
![image](https://user-images.githubusercontent.com/1559229/38344198-9670bde8-38cb-11e8-8c2c-31b30c74c466.png)
