### PR TITLE
Multi View - Saving Rendering Settings for All Open Images

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1299,3 +1299,10 @@ thumbnail-slider img {
     min-width: 45px;
     max-width: 45px;
 }
+.skipped-list-files {
+    overflow-x: auto;
+    overflow-y: auto;
+    max-height: 150px;
+    font-size: 15px;
+    margin-top: 15px;
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "spectrum-colorpicker": "1.8.0",
     "d3" : "4.2.7",
     "file-saver" : "1.3.3",
-    "text-encoding" : "0.6.4"
+    "text-encoding" : "0.6.4",
+    "jszip": "3.1.5"
   },
   "devDependencies": {
     "aurelia-tools": "1.0.0",

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -869,7 +869,7 @@ export default class Context {
 
     /**
      * Returns all configs that relate to the given image id
-     * and have modified image settings
+     * and have modified image settings or regions
      *
      * @param {number} image_id the image id
      * @param {boolean} has_modified_regions

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -37,7 +37,10 @@
                     <li class="${image_config.image_info.ready ?
                                  '' : 'disabled-color'}">
                         <a click.delegate="captureViewport()"
-                           href="#">Save Viewport as PNG</a>
+                           href="#">Save ${context.image_configs.size > 1 ?
+                                            'All Viewports as PNGs (zipped)' :
+                                            'Viewport as PNG'}
+                        </a>
                     </li>
                     <li class="${image_config.image_info.ready  &&
                                  image_config.image_info.projection !== PROJECTION.NORMAL?

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -34,6 +34,13 @@
                         <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu">
+                    <li show.bind="context.image_configs.size > 1"
+                        class="${ hasModifiedImageSettings ?
+                                 '' : 'disabled-color'}">
+                        <a click.delegate="saveAllImageSettings()"
+                           href="#">Save All Image Settings
+                        </a>
+                    </li>
                     <li class="${image_config.image_info.ready ?
                                  '' : 'disabled-color'}">
                         <a click.delegate="captureViewport()"

--- a/src/app/header.js
+++ b/src/app/header.js
@@ -471,13 +471,15 @@ export class Header {
      * @memberof Context
      */
     saveAllImageSettings() {
-        let conflictingImageChanged = this.context.saveAllImageSettings();
-        let len = conflictingImageChanged.length;
+        let conflictingImageChanges = this.context.saveAllImageSettings();
+        let len = conflictingImageChanges.length;
         if (len > 0) {
-            let msg = "Couldn't save image" + (len > 1 ? "s" : "") +
-                ":<br><br>";
-            for (let i in conflictingImageChanged)
-                msg += conflictingImageChanged[i] + '<br>';
+            let msg = "The following image" + (len > 1 ? "s were" : " was") +
+                " not saved (multiple/conflicting edits):" +
+                "<ul class='skipped-list-files'>";
+            for (let i in conflictingImageChanges)
+                msg += "<li>" + conflictingImageChanges[i] + "</li>";
+            msg += "</ul>";
 
             Ui.showModalMessage(msg, 'Close');
         }

--- a/src/app/header.js
+++ b/src/app/header.js
@@ -19,6 +19,7 @@
 import {inject,customElement, BindingEngine} from 'aurelia-framework';
 import Context from './context';
 import * as FileSaver from '../../node_modules/file-saver';
+import JSZip from '../../node_modules/jszip/dist/jszip';
 import * as TextEncoding from "../../node_modules/text-encoding";
 import Misc from '../utils/misc';
 import Ui from '../utils/ui';
@@ -368,8 +369,14 @@ export class Header {
      */
     captureViewport() {
         if (this.image_config === null) return;
-        this.context.eventbus.publish(
-            IMAGE_VIEWPORT_CAPTURE, {"config_id": this.image_config.id});
+        let params = {}
+        let configCount = this.context.image_configs.size;
+        if (configCount > 1) {
+            params.all_configs = true;
+            params.count = configCount;
+            params.zip = new JSZip();
+        } else params.config_id = this.image_config.id;
+        this.context.eventbus.publish(IMAGE_VIEWPORT_CAPTURE, params);
     }
 
     /**

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -16,8 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-/** whenever the bird's eye should be updated */
-export const BIRDSEYE_REFRESH = "BIRDSEYE_REFRESH";
+/** whenever the image settings have been refreshed */
+export const IMAGE_SETTINGS_REFRESH = "IMAGE_SETTINGS_REFRESH";
 /** whenever the image canvas data was retrieved */
 export const IMAGE_CANVAS_DATA = "IMAGE_CANVAS_DATA";
 /** whenever pixel intensity querying should be turned on/off */
@@ -70,6 +70,8 @@ export const REGIONS_COPY_SHAPES = "REGIONS_COPY_SHAPES";
 export const HISTOGRAM_RANGE_UPDATE = "HISTOGRAM_RANGE_UPDATE";
 /** whenever thumbnails are supposed to be updated */
 export const THUMBNAILS_UPDATE = "THUMBNAILS_UPDATE";
+/** whenever the presently active image settings should be saved */
+export const SAVE_ACTIVE_IMAGE_SETTINGS = "SAVE_ACTIVE_IMAGE_SETTINGS";
 
 /**
  * Facilitates recurring event subscription

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -23,7 +23,7 @@ import {
     APP_TITLE, CHANNEL_SETTINGS_MODE, INITIAL_TYPES, IVIEWER,
     PROJECTION, REQUEST_PARAMS, WEBGATEWAY
 } from '../utils/constants';
-import { BIRDSEYE_REFRESH } from '../events/events';
+import { IMAGE_SETTINGS_REFRESH } from '../events/events';
 
 /**
  * Holds basic image information required for viewing:
@@ -58,14 +58,6 @@ export default class ImageInfo {
      * @type {string}
      */
     dataset_name = null;
-
-    /**
-     * a flag that signals whether we have successfully
-     * received all backend info or not
-     * @memberof ImageInfo
-     * @type {boolean}
-     */
-    ready = false;
 
     /**
      * a flag whether we want to refresh the image settings only
@@ -372,7 +364,7 @@ export default class ImageInfo {
 
         if (refresh) {
             this.context.publish(
-                BIRDSEYE_REFRESH, { config_id : this.config_id});
+                IMAGE_SETTINGS_REFRESH, { config_id : this.config_id});
         }
     }
 

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -60,6 +60,14 @@ export default class ImageInfo {
     dataset_name = null;
 
     /**
+     * a flag that signals whether we have successfully
+     * received all backend info or not
+     * @memberof ImageInfo
+     * @type {boolean}
+     */
+    ready = false;
+
+    /**
      * a flag whether we want to refresh the image settings only
      * @memberof ImageInfo
      * @type {boolean}

--- a/src/settings/channel-settings.js
+++ b/src/settings/channel-settings.js
@@ -21,14 +21,16 @@ import Context from '../app/context';
 import Misc from '../utils/misc';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {CHANNEL_SETTINGS_MODE, WEBGATEWAY} from '../utils/constants';
-import { IMAGE_SETTINGS_CHANGE} from '../events/events';
+import {
+    IMAGE_SETTINGS_CHANGE, IMAGE_SETTINGS_REFRESH, EventSubscriber
+} from '../events/events';
 
 /**
  * Represents the settings section in the right hand panel
  */
 @customElement('channel-settings')
 @inject(Context, BindingEngine)
-export default class ChannelSettings {
+export default class ChannelSettings extends EventSubscriber {
     /**
      * a reference to the image config (bound in template)
      * @memberof ChannelSettings
@@ -38,6 +40,18 @@ export default class ChannelSettings {
     image_configChanged(newVal, oldVal) {
         this.waitForImageInfoReady();
     }
+
+    /**
+     * events we subscribe to
+     * @memberof Ol3Viewer
+     * @type {Array.<string,function>}
+     */
+    sub_list = [[IMAGE_SETTINGS_REFRESH,
+        (params={}) => {
+            if (typeof params.config_id !== 'number' ||
+                params.config_id !== this.image_config.id) return;
+            this.waitForImageInfoReady();
+        }]];
 
     /**
      * the present channel settings mode
@@ -95,6 +109,7 @@ export default class ChannelSettings {
      * @param {BindingEngine} bindingEngine injected instance of BindingEngine
      */
     constructor(context, bindingEngine) {
+        super(context.eventbus);
         this.context = context;
         this.bindingEngine = bindingEngine;
     }
@@ -107,6 +122,7 @@ export default class ChannelSettings {
      * @memberof ChannelSettings
      */
     bind() {
+        this.subscribe();
         this.waitForImageInfoReady();
     }
 
@@ -120,9 +136,12 @@ export default class ChannelSettings {
             this.image_config.image_info === null) return;
 
         let onceReady = () => {
-            // register observer
+            if (this.mode !== CHANNEL_SETTINGS_MODE.MIN_MAX) {
+                this.enable_mode_history = false;
+                this.mode = CHANNEL_SETTINGS_MODE.MIN_MAX;
+            }
+            // register observers
             this.registerObservers();
-            this.mode = CHANNEL_SETTINGS_MODE.MIN_MAX;
         };
 
         // tear down old observers
@@ -399,6 +418,7 @@ export default class ChannelSettings {
      * @memberof ChannelSettings
      */
     unbind() {
+        this.unsubscribe();
         this.unregisterObservers();
     }
 }

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -27,8 +27,8 @@ import {
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 
 import {
-    BIRDSEYE_REFRESH, IMAGE_INTENSITY_QUERYING, IMAGE_SETTINGS_CHANGE,
-    THUMBNAILS_UPDATE, EventSubscriber
+    IMAGE_SETTINGS_REFRESH, IMAGE_INTENSITY_QUERYING, IMAGE_SETTINGS_CHANGE,
+    SAVE_ACTIVE_IMAGE_SETTINGS, THUMBNAILS_UPDATE, EventSubscriber
 } from '../events/events';
 
 /**
@@ -103,7 +103,9 @@ export default class Settings extends EventSubscriber {
      * @type {Array.<string,function>}
      */
     sub_list = [[THUMBNAILS_UPDATE,
-                    (params={}) => this.revision++]];
+                    (params={}) => this.revision++],
+                [SAVE_ACTIVE_IMAGE_SETTINGS,
+                    (params={}) => this.saveImageSettings()]];
 
     /**
      * @constructor
@@ -293,48 +295,23 @@ export default class Settings extends EventSubscriber {
      * @memberof Settings
      */
     saveImageSettings() {
-        if (!this.image_config.image_info.ready ||
-            !this.image_config.image_info.can_annotate ||
-            this.image_config.history.length === 0 ||
-            this.image_config.historyPointer < 0) return;
-
         $('.save-settings').children('button').blur();
-        if (Misc.useJsonp(this.context.server)) {
-            alert("Saving the rendering settings will not work cross-domain!");
-            return;
-        }
-
-        let image_info = this.image_config.image_info;
-        let url =
-            this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
-            "/saveImgRDef/" +
-            image_info.image_id + '/?m=' + image_info.model[0] +
-            "&p=" + image_info.projection +
-            "&t=" + (image_info.dimensions.t+1) +
-            "&z=" + (image_info.dimensions.z+1) +
-            "&q=0.9&ia=0";
-        url = Misc.appendChannelsAndMapsToQueryString(image_info.channels, url);
-
-        $.ajax(
-            {url : url,
-             method: 'POST',
-            success : (response) => {
-                this.image_config.resetHistory();
-                // reissue get rendering requests, then
-                // force thumbnail update
-                let action =
-                    (() => {
-                        this.triggerUpdates([image_info.image_id]);
-                        if (this.context.useMDI)
-                            this.context.reloadImageConfigForGivenImage(
-                                image_info.image_id,
-                                IMAGE_CONFIG_RELOAD.IMAGE,
-                                this.image_config.id);
-                });
-                this.requestAllRenderingDefs(action);
-            },
-            error : (error) => {}
-        });
+        let success = (response) => {
+            this.image_config.resetHistory();
+            // reissue get rendering requests, then
+            // force thumbnail update
+            let action =
+                () => {
+                    let imgId = this.image_config.image_info.image_id;
+                    this.triggerUpdates([imgId]);
+                    if (this.context.useMDI)
+                        this.context.reloadImageConfigForGivenImage(
+                            imgId, IMAGE_CONFIG_RELOAD.IMAGE,
+                            this.image_config.id);
+            };
+            this.requestAllRenderingDefs(action);
+        };
+        this.image_config.saveImageSettings(success);
     }
 
     /**
@@ -444,7 +421,7 @@ export default class Settings extends EventSubscriber {
     }
 
     /**
-     * Triggers thumbnail/bird's eye update
+     * Triggered after image settings update
      *
      * @param {Array.<number>} ids image id(s) to update
      * @memberof Settings
@@ -454,7 +431,7 @@ export default class Settings extends EventSubscriber {
              THUMBNAILS_UPDATE,
              { "config_id" : this.image_config.id, "ids": ids});
          this.context.publish(
-             BIRDSEYE_REFRESH, { config_id : this.image_config.id});
+             IMAGE_SETTINGS_REFRESH, { config_id : this.image_config.id});
      }
 
     /**

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -32,8 +32,8 @@ import {
     REGIONS_DRAWING_MODE, RENDER_STATUS, VIEWER_ELEMENT_PREFIX, WEBCLIENT
 } from '../utils/constants';
 import {
-    BIRDSEYE_REFRESH, IMAGE_CANVAS_DATA, IMAGE_DIMENSION_CHANGE,
-    IMAGE_DIMENSION_PLAY, IMAGE_INTENSITY_QUERYING, IMAGE_SETTINGS_CHANGE,
+    IMAGE_CANVAS_DATA, IMAGE_DIMENSION_CHANGE, IMAGE_DIMENSION_PLAY,
+    IMAGE_INTENSITY_QUERYING, IMAGE_SETTINGS_CHANGE, IMAGE_SETTINGS_REFRESH,
     IMAGE_VIEWER_CONTROLS_VISIBILITY, IMAGE_VIEWER_INTERACTION,
     IMAGE_VIEWER_RESIZE, IMAGE_VIEWPORT_CAPTURE,
     REGIONS_CHANGE_MODES, REGIONS_COPY_SHAPES, REGIONS_DRAW_SHAPE,
@@ -143,7 +143,7 @@ export default class Ol3Viewer extends EventSubscriber {
             (params={}) => this.saveCanvasData(params)],
         [VIEWER_SET_SYNC_GROUP,
             (params={}) => this.setSyncGroup(params)],
-        [BIRDSEYE_REFRESH,
+        [IMAGE_SETTINGS_REFRESH,
             (params={}) => this.refreshBirdsEye(params)]];
 
     /**
@@ -256,6 +256,7 @@ export default class Ol3Viewer extends EventSubscriber {
                     updates.push(chanUpdate);
                 };
                 this.viewer.changeChannelRange(updates);
+                this.image_config.image_info.refresh = false;
                 return;
             }
 
@@ -1247,6 +1248,7 @@ export default class Ol3Viewer extends EventSubscriber {
      * @return
      */
     saveCanvasData(params={}) {
+        if (params.config_id !== this.image_config.id) return;
         if (!params.supported) { // blob not supported
                 console.error("Capturing Viewport as Blob not supported");
                 return;
@@ -1256,10 +1258,8 @@ export default class Ol3Viewer extends EventSubscriber {
             typeof params.all_configs === 'boolean' && params.all_configs;
         let saveAs = () => {
             if (allConfigs) {
-                if (params.count > 0) return;
-                // we are finished and like to write the zip now
                 if (!params.zip) console.error("no jszip instance!");
-                else {
+                else if (params.count === 0) {
                     params.zip.generateAsync({type:"blob"}).then(
                         (content) => FileSaver.saveAs(content, "images.zip"));
                 }


### PR DESCRIPTION
see: https://trello.com/c/ftiTGD9T/49-multi-view-save-actions

1. this PR aims at providing a means/shortcut via the header's File menu to save open images in multi view mode, without having to select them individually and do so.

2. it also offers a means to capture their canvases/viewports collectively (File menu option) - so far the png "screenshot" could only be done individually. the images will be saved in a zip.

Note for 1: If there were changes in an image that was opened and edited in more than one window this is treated as a "conflict" they won't get saved and a dialog shows the respective file(s).