### PR TITLE
multiple_viewers_layout

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -757,8 +757,8 @@ export default class Context {
      * based on the position and size of each image viewer
      *
      * @memberof Context
-     * @param {x} id the ImageConfig id
-     * @param {y} forceRequest if true an ajax request is forced to update the data
+     * @param {x} x coordinate
+     * @param {y} y coordinate
      * @return {list} of ImageConfig objects
      */
     getImageConfigsAtPosition(x, y) {

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -753,6 +753,31 @@ export default class Context {
     }
 
     /**
+     * Retrieves any image configs that occupy a given x, y position,
+     * based on the position and size of each image viewer
+     *
+     * @memberof Context
+     * @param {x} id the ImageConfig id
+     * @param {y} forceRequest if true an ajax request is forced to update the data
+     * @return {list} of ImageConfig objects
+     */
+    getImageConfigsAtPosition(x, y) {
+        let configs = [];
+        for (let [id, conf] of this.image_configs) {
+            if (conf.position === null) continue;
+            let left = parseInt(conf.position.left);
+            let top = parseInt(conf.position.top);
+            let width = parseInt(conf.size.width);
+            let height = parseInt(conf.size.height);
+            if (left < x && (left + width) > x &&
+                top < y && (top + height) > y) {
+                configs.push(conf);
+            }
+        }
+        return configs;
+    }
+
+    /**
      * Convenience or short hand way of publishing via the internal eventbus.
      * It will just delegate whatever you hand it as arguments
      *

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -180,6 +180,9 @@ export default class Ol3Viewer extends EventSubscriber {
         let minX = 0, maxX = 0, minY = 0, maxY = 0;;
         let container = this.getContainer();
 
+        let config_ids = Array.from(this.image_config.context.image_configs.keys());
+        let config_index = config_ids.indexOf(this.image_config.id);
+
         // set previous position for mdi 'replacement'
         if (this.image_config.position === null) {
             minX = frame.position().left+10;
@@ -190,10 +193,23 @@ export default class Ol3Viewer extends EventSubscriber {
             maxY =
                 frame.position().top+frame.height()-
                     parseInt(this.image_config.size.height);
-            this.image_config.position = {
-                top: Misc.getRandomInteger(minY,maxY) + 'px',
-                left: Misc.getRandomInteger(minX,maxX) + 'px'
-            };
+
+            // For the first 4 viewers, position them in a 2 x 2 grid...
+            if (config_index === 0) {
+                this.image_config.position = {top: minY + 'px', left: minX + 'px'}
+            } else if (config_index === 1) {
+                this.image_config.position = {top: minY + 'px', left: frame.width()/2 + 'px'}
+            } else if (config_index === 2) {
+                this.image_config.position = {top: frame.height()/2 + 'px', left: minX + 'px'}
+            } else if (config_index === 3) {
+                this.image_config.position = {top: frame.height()/2 + 'px', left: frame.width()/2 + 'px'}
+            } else {
+                // Otherwise choose random location
+                this.image_config.position = {
+                    top: Misc.getRandomInteger(minY,maxY) + 'px',
+                    left: Misc.getRandomInteger(minX,maxX) + 'px'
+                };
+            }
         }
 
         // make viewer windows draggable/resizable within boundaries


### PR DESCRIPTION
This attempts to improve on the random layout of viewers when opened by double-clicking.

To test:

 - The first 4 viewers should be laid out in a 2 x 2 grid. 
 - Additional viewers have random location as before.
 - If any of the first 4 viewers are closed or moved out of their original position, then subsequent viewers will be opened in that spot.

Possible improvement: Could make the viewers bigger if screen space is larger?

![screen shot 2018-04-06 at 17 17 39](https://user-images.githubusercontent.com/900055/38432226-adf5be02-39be-11e8-8021-e56887168739.png)
