### PR TITLE
Z-projection disabled big images

### DIFF
--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -443,3 +443,8 @@ goog.exportSymbol(
     'ome.ol3.REGIONS_MODE',
     ome.ol3.REGIONS_MODE,
     OME);
+
+goog.exportSymbol(
+    'ome.ol3.UNTILED_RETRIEVAL_LIMIT',
+    ome.ol3.UNTILED_RETRIEVAL_LIMIT,
+    OME);

--- a/src/controls/dimension-slider.html
+++ b/src/controls/dimension-slider.html
@@ -36,10 +36,8 @@
                     image_config.image_info.dimensions[dim]+1}
         </span>
         <span class="dim-projection
-                     ${player_info.handle !== null && player_info.dim === dim &&
-                       player_info.forwards ? 'disabled-color' : ''}"
-              title="${player_info.handle !== null && player_info.dim === dim &&
-                        player_info.forwards ? 'Projection disabled' :
+                     ${getZProjectionDisabled(player_info.handle, player_info.forwards) ? 'disabled-color' : ''}"
+              title="${getZProjectionDisabled(player_info.handle, player_info.forwards) ? 'Projection disabled' :
                             image_config.image_info.projection === INTMAX ?
                                 'Turn off projection' : 'Turn on projection'}"
               css="${image_config.image_info.projection === INTMAX ?

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -449,7 +449,10 @@ export default class DimensionSlider {
      * @memberof DimensionSlider
      */
     toggleProjection() {
-        if (this.player_info.handle !== null) return;
+        if (this.getZProjectionDisabled(this.player_info.handle,
+                                        this.player_info.forwards)) {
+            return;
+        }
 
         let imgInf = this.image_config.image_info;
         imgInf.projection_opts.start = 0;

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -19,6 +19,7 @@
 import Context from '../app/context';
 import {inject,customElement, bindable, BindingEngine} from 'aurelia-framework';
 import Misc from '../utils/misc';
+import {ol3} from '../../libs/ol3-viewer.js';
 import {slider} from 'jquery-ui/ui/widgets/slider';
 import {PROJECTION} from '../utils/constants';
 import {
@@ -467,5 +468,21 @@ export default class DimensionSlider {
         imgInf.projection =
             imgInf.projection === PROJECTION.NORMAL ?
                 PROJECTION.INTMAX: PROJECTION.NORMAL;
+    }
+
+    /**
+     * Calculates whether Z-projection should be disabled.
+     *
+     * Disabled is true while playing Z-stack movie or if
+     * the Viewer will be loading tiles
+     * Used by template which passes in arguments that are bound,
+     * so we update only when needed
+     * See http://davismj.me/blog/aurelia-computed-from-patterns/
+     *
+     * @memberof DimensionSlider
+     */
+    getZProjectionDisabled(handle, forwards) {
+        let dims = this.image_config.image_info.dimensions;
+        return (handle !== null && forwards || (dims.max_x * dims.max_y) > ol3.UNTILED_RETRIEVAL_LIMIT);
     }
 }


### PR DESCRIPTION
This disables the Z-projection button if the Image is loaded with tiles.
Currently iviewer loads images with tiles if ```sizeX * sizeY > 4000000```.

To test:
 - Find image where ```sizeX * sizeY > 4000000``` with Z-stack and check if Z-projection button disabled.
 - Clicking button should have no effect.
 - For images below this limit, Z-projection button should behave as before (disabled while Z movie is playing).