### PR TITLE
Add console.trace(resource) right before error

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1254,6 +1254,7 @@ ome.ol3.Viewer.prototype.readPrefixedUris = function(params) {
 
     for (var uri in ome.ol3.PREFIXED_URIS) {
         var resource = ome.ol3.PREFIXED_URIS[uri];
+        console.trace('resource', resource);
         if (typeof params[resource] === 'string')
             this.prefixed_uris_[resource] = params[resource];
         else this.prefixed_uris_[resource] = '/' + resource.toLowerCase();


### PR DESCRIPTION
Hopefully this console.log should give more info on the error we're seeing on web-dev-merge.

```
Uncaught TypeError: r.toLowerCase is not a function
    at wn (main.js?_iviewer-0.5.0:formatted:7720)
    at new pn (main.js?_iviewer-0.5.0:formatted:7466)
    at i.initViewer (main.js?_iviewer-0.5.0:formatted:57827)
```