### PR TITLE
Fix to lower case bug from for in loop

### DIFF
--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1252,13 +1252,11 @@ ome.ol3.Viewer.prototype.getPrefixedURI = function(resource) {
 ome.ol3.Viewer.prototype.readPrefixedUris = function(params) {
     if (typeof params !== 'object' || params === null) return;
 
-    for (var uri in ome.ol3.PREFIXED_URIS) {
-        var resource = ome.ol3.PREFIXED_URIS[uri];
-        console.trace('resource', resource);
+    ome.ol3.PREFIXED_URIS.forEach(resource => {
         if (typeof params[resource] === 'string')
             this.prefixed_uris_[resource] = params[resource];
         else this.prefixed_uris_[resource] = '/' + resource.toLowerCase();
-    }
+    });
 }
 
 /**

--- a/ol3-viewer/src/ome/ol3/Viewer.js
+++ b/ol3-viewer/src/ome/ol3/Viewer.js
@@ -1254,6 +1254,7 @@ ome.ol3.Viewer.prototype.readPrefixedUris = function(params) {
 
     for (var uri in ome.ol3.PREFIXED_URIS) {
         var resource = ome.ol3.PREFIXED_URIS[uri];
+        console.trace('resource', resource);
         if (typeof params[resource] === 'string')
             this.prefixed_uris_[resource] = params[resource];
         else this.prefixed_uris_[resource] = '/' + resource.toLowerCase();

--- a/ol3-viewer/src/ome/ol3/source/Regions.js
+++ b/ol3-viewer/src/ome/ol3/source/Regions.js
@@ -282,6 +282,7 @@ ome.ol3.source.Regions.prototype.setModes = function(modes) {
     var oldModes = this.present_modes_.slice();
     this.present_modes_ = [];
 
+    console.log('modes', modes)
     for (var m in modes) {
         // we have to be a numnber and within the enum range
         if (typeof(modes[m]) !== 'number' || modes[m] < 0 || modes[m] > 4)

--- a/ol3-viewer/src/ome/ol3/utils/Conversion.js
+++ b/ol3-viewer/src/ome/ol3/utils/Conversion.js
@@ -208,7 +208,7 @@ ome.ol3.utils.Conversion.checkColorObjectCorrectness = function(color) {
     // check correctness of color object,
     // we take alpha to be optional, setting it to 1
     var needsToBeThere = ["red", "green", "blue"];
-    for (var n in needsToBeThere) {
+    for (var n=0; n<needsToBeThere.length; n++) {
         if (typeof(color[needsToBeThere[n]]) === 'undefined') return null;
         var c = color[needsToBeThere[n]];
         if (c < 0 || c > 255) return null;
@@ -837,12 +837,13 @@ ome.ol3.utils.Conversion.toJsonObject =
 
     // flatten out shapes in rois
     var flattenedArray = [];
-    for (var r in rois) {
+    for (let r=0; r<rois.length; r++) {
         if (!ome.ol3.utils.Misc.isArray(
                 rois[r]['shapes'])) continue;
         var shap = rois[r]['shapes'];
-        for (var s in shap)
-            flattenedArray.push(shap[s]);
+        shap.forEach(s => {
+            flattenedArray.push(s);
+        });
     }
     categorizedRois['new'] =  flattenedArray;
 
@@ -910,21 +911,21 @@ ome.ol3.utils.Conversion.convertPointStringIntoCoords = function(points) {
     if (typeof points !== 'string') return null;
 
     var tokens = points.split(" ");
+    console.log('convertPointStringIntoCoords tokens', tokens);
     if (tokens.length === 0) return null;
 
-    var ret = [];
-    for (var t in tokens) {
-        var tok = tokens[t].trim();
-        // empty tokens are ignored
-        if (tok === '') continue;
-        var c = tok.split(",");
-        if (c.length < 2) return null;
+    tokens = tokens.map(t => t.trim());
+    tokens = tokens.filter(t => t.length > 0);
+    tokens = tokens.map(t => t.split(","));
+    tokens = tokens.filter(t => t.length > 1);
+
+    var ret = tokens.map(c => {
         var x = parseFloat(c[0]);
         var y = parseFloat(c[1]);
         // NaNs are not acceptable
         if (isNaN(x) || isNaN(y)) return null;
-        ret.push([x, -y]);
-    }
+        return [x, -y];
+    });
 
     return ret;
 }

--- a/ol3-viewer/src/ome/ol3/utils/Misc.js
+++ b/ol3-viewer/src/ome/ol3/utils/Misc.js
@@ -132,6 +132,7 @@ function(features) {
 
     // determine priority of whih feature ought to be returned
     var filteredIntersectingFeatures = [];
+    console.log('featuresAtCoords features', features)
     for (var i in features)
         if (filteredIntersectingFeatures.length > 0) {
             // this should ensure that if a feature is contained by another
@@ -260,7 +261,7 @@ ome.ol3.utils.Misc.parseChannelParameters = function(channel_info, maps_info) {
     if (chans.length === 0) return null;
 
     // iterate over channel tokens
-    for (var k in chans) {
+    for (var k=0; k<chans.length; k++) {
         // extract channel number
         var c = chans[k];
         var pos = c.indexOf('|');

--- a/ol3-viewer/src/ome/ol3/utils/Regions.js
+++ b/ol3-viewer/src/ome/ol3/utils/Regions.js
@@ -386,7 +386,7 @@ ome.ol3.utils.Regions.createFeaturesFromRegionsResponse =
             !ome.ol3.utils.Misc.isArray(regions.regions_info_)) return null;
 
         var ret = [];
-        for (var roi in regions.regions_info_) {
+        for (var roi=0; roi<regions.regions_info_.length; roi++) {
             // we gotta have an id and shapes, otherwise no features...
             if (typeof(regions.regions_info_[roi]['@id']) !== 'number' ||
                 !ome.ol3.utils.Misc.isArray(regions.regions_info_[roi]['shapes']))
@@ -397,7 +397,7 @@ ome.ol3.utils.Regions.createFeaturesFromRegionsResponse =
             regions.regions_info_[roi]['state'] = ome.ol3.REGIONS_STATE.DEFAULT;
 
             // descend deeper into shapes for rois
-            for (var s in regions.regions_info_[roi]['shapes']) {
+            for (var s=0; s<regions.regions_info_[roi]['shapes'].length; s++) {
                 var shape = regions.regions_info_[roi]['shapes'][s];
                 // id, TheT and TheZ have to be present
                 if (typeof(shape['@id']) !== 'number') continue;
@@ -477,7 +477,7 @@ ome.ol3.utils.Regions.createFeaturesFromRegionsResponse =
         // time and plane
         if (typeof include_new_features === 'boolean' && include_new_features &&
                 typeof regions.new_unsaved_shapes_ === 'object')
-            for (var f in regions.new_unsaved_shapes_) {
+            for (var f=0; f<regions.new_unsaved_shapes_.length; f++) {
                 var newUnsFeat = regions.new_unsaved_shapes_[f];
                 var newUnsFeatT =
                     typeof newUnsFeat['TheT'] === 'number' ?

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -308,9 +308,8 @@ export default class RegionsInfo  {
 
         try {
             let count = 0;
-            for (let r in data) {
+            data.forEach(roi => {
                 let shapes = new Map();
-                let roi = data[r];
                 // add shapes
                 if (Misc.isArray(roi.shapes) && roi.shapes.length > 0) {
                     let roiId = roi['@id'];
@@ -324,8 +323,7 @@ export default class RegionsInfo  {
                         }
                         return (z1 < z2) ? -1: 1;
                     });
-                    for (let s in roi.shapes) {
-                        let shape = roi.shapes[s];
+                    roi.shapes.forEach(shape => {
                         let newShape =
                             Converters.amendShapeDefinition(
                                 Object.assign({}, shape));
@@ -338,14 +336,14 @@ export default class RegionsInfo  {
                         newShape.modified = false;
                         shapes.set(shapeId, newShape);
                         count++;
-                    }
+                    });
                     this.data.set(roiId, {
                         shapes: shapes,
                         show: false,
                         deleted: 0
                     });
                 }
-            }
+            });
             this.number_of_shapes = count;
             this.image_info.roi_count = this.data.size;
             this.tmp_data = data;
@@ -682,8 +680,7 @@ export default class RegionsInfo  {
             let statsOnShape = s.stats;
             // shape stats exist, we might not have all channels yet
             if (typeof statsOnShape === 'object' && statsOnShape !== null) {
-                for (let c in activeChannels) {
-                    let chan = activeChannels[c];
+                activeChannels.forEach(chan => {
                     if (typeof statsOnShape[chan] !== 'object') {
                         idsToBeRequested.push(s['@id']);
                         shapes.set(s['@id'], s);
@@ -692,7 +689,7 @@ export default class RegionsInfo  {
                             channelsToBeRequested.indexOf(chan) === -1)
                                 channelsToBeRequested.push(chan);
                     }
-                }
+                });
                 return;
             }
             // shape stats don't exist
@@ -704,7 +701,7 @@ export default class RegionsInfo  {
         }
 
         // loop and reduce what is requested
-        for (let i in ids) {
+        for (let i=0; i<ids.length; i++) {
             let id = ids[i];
             if (id.indexOf("-") !== -1) continue;
             let shape = this.getShape(ids[i]);
@@ -733,6 +730,7 @@ export default class RegionsInfo  {
             "success": (resp) => {
                 if (typeof resp === 'object' && resp !== null) {
                     // attach stats to their shapes
+                    console.log('resp', resp);
                     for (let r in resp) {
                         let shape = shapes.get(parseInt(r));
                         if (shape) {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -198,15 +198,16 @@ export default class Settings extends EventSubscriber {
                     img_id !== this.image_config.image_info.image_id) return;
 
                 let duplicatesCheck = new Map();
-                for (let r in response.rdefs) {
-                    let rdef = response.rdefs[r];
+                response.rdefs.forEach(rdef => {
                     let possibleDuplicate = duplicatesCheck.get(rdef.owner.id);
                     if (possibleDuplicate) {
-                        if (possibleDuplicate.id < rdef.id)
+                        if (possibleDuplicate.id < rdef.id) {
                             duplicatesCheck.set(rdef.owner.id, rdef);
-                        else continue;
-                    } else duplicatesCheck.set(rdef.owner.id, rdef);
-                }
+                        }
+                    } else {
+                        duplicatesCheck.set(rdef.owner.id, rdef);
+                    }
+                });
                 this.rdefs = [];
                 for (let [id, rdef] of duplicatesCheck) {
                     // merge in lut info and add to rdefs


### PR DESCRIPTION
Something in the CI build of iviewer is adding an extra key ```__au_patched__``` to lists, so that using ```(for var x in list)``` is iterating over extra keys that are not in the list.
This is causing a bug, but will probably cause others once this is fixed.
E.g. in console of iviewer on web-dev-merge
```
test = ["a", "b"]
for (var t in test) { console.log(t, test[t]) }
    0 a
    1 b
    __au_patched__ 1
```

This leads to the following error
```
Uncaught TypeError: r.toLowerCase is not a function
    at wn (main.js?_iviewer-0.5.0:formatted:7720)
    at new pn (main.js?_iviewer-0.5.0:formatted:7466)
    at i.initViewer (main.js?_iviewer-0.5.0:formatted:57827)
```

The ```__au_patched__``` is probably coming from Aurelia ```(au)``` but can't find any info by googling for this.