### PR TITLE
Thumbnail scrolling

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -534,7 +534,7 @@ a.ui-button:active,
 }
 .thumbnail-wrapper {
     display: inline-block;
-    background: #cccccc;
+    background: #f0f0f0;
     width: 80px;
     height: 80px;
     margin: 5px;

--- a/css/app.css
+++ b/css/app.css
@@ -527,16 +527,23 @@ a.ui-button:active,
     background-color: #ffffff;
 }
 .thumbnail-panel .thumbnail-scroll-panel {
-    padding-bottom: 30px;
     overflow-x: hidden;
     overflow-y: auto;
     height: 100%;
     width: 100%;
 }
+.thumbnail-wrapper {
+    display: inline-block;
+    background: #cccccc;
+    width: 80px;
+    height: 80px;
+    margin: 5px;
+}
 thumbnail-slider img {
-    margin-top: 10px;
+    margin: 0;
     cursor: pointer;
-    max-width: 75px;
+    max-width: 80px;
+    max-height: 80px;
 }
 .thumbnail-panel .thumbnail-collapse {
     height: 28px;

--- a/css/app.css
+++ b/css/app.css
@@ -545,6 +545,12 @@ thumbnail-slider img {
     max-width: 80px;
     max-height: 80px;
 }
+.thumbnail-wrapper .selected {
+    border: 5px solid rgba(0,60,136,0.5)
+}
+.transparent {
+    opacity: 0;
+}
 .thumbnail-panel .thumbnail-collapse {
     height: 28px;
     position: absolute;

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -29,9 +29,9 @@
         show.bind="!requesting_thumbnail_data"
         scroll.trigger="handleScrollEvent($event)">
 
-        <div css="height: ${ (thumbnails_count * 50) }px">
-            Count: ${ thumbnails_count } ${ thumbnails_count * 10 }
-            <img id="${'img-thumb-' + thumb.id}" repeat.for="thumb of thumbnails"
+        <div>
+            <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper">
+              <img show.bind="thumb.id" id="${'img-thumb-' + thumb.id}"
                 css="${image_config.image_info.image_id === thumb.id ?
                     'border: 5px solid rgba(0,60,136,0.5)' : 'border: none'}"
                 src.bind="thumb.url + '?version=' + thumb.revision"
@@ -39,7 +39,7 @@
                 alt="Not Found"
                 click.delegate="onClick(thumb.id)"
                 dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
-
+            </div>
         </div>
 
     </div>

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -27,13 +27,14 @@
 
     <div class="thumbnail-scroll-panel"
         show.bind="!requesting_thumbnail_data"
-        scroll.trigger="handleScrollEvent($event) & debounce:10">
+        resize.trigger="panelResized($event)"
+        scroll.trigger="handleScrollEvent($event) & debounce:100">
 
         <div>
             <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper">
-              <img show.bind="thumb.id" id="${'img-thumb-' + thumb.id}"
-                css="${image_config.image_info.image_id === thumb.id ?
-                    'border: 5px solid rgba(0,60,136,0.5)' : 'border: none'}"
+              <img id="${'img-thumb-' + thumb.id}"
+                class="${image_config.image_info.image_id === thumb.id ? 'selected' : ''}
+                    ${thumb.id ? '' : 'transparent'}"
                 src.bind="thumb.url + '?version=' + thumb.revision"
                 title="${thumb.title}"
                 alt="Not Found"

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -32,6 +32,7 @@
 
         <div>
             <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper">
+              <!-- show placeholder 1 x 1 px png if no thumb.url -->
               <img id="${'img-thumb-' + thumb.id}"
                 class="${image_config.image_info.image_id === thumb.id ? 'selected' : ''}
                     ${thumb.id ? '' : 'transparent'}"

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -35,9 +35,9 @@
               <img id="${'img-thumb-' + thumb.id}"
                 class="${image_config.image_info.image_id === thumb.id ? 'selected' : ''}
                     ${thumb.id ? '' : 'transparent'}"
-                src.bind="thumb.url + '?version=' + thumb.revision"
+                src.bind="thumb.url ? thumb.url + '?version=' + thumb.revision : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII='"
                 title="${thumb.title}"
-                alt="Not Found"
+                alt=""
                 click.delegate="onClick(thumb.id)"
                 dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
             </div>

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -24,26 +24,24 @@
          click.delegate="refreshThumbnails()"
          title="Refresh thumbnails">
     </div>
-    <div show.bind="thumbnails_start_index > 0"
-         click.delegate="requestMoreThumbnails(false, false)"
-         class='collapse-up thumbnail-collapse'
-         title="Show more images">
-    </div>
+
     <div class="thumbnail-scroll-panel"
-        show.bind="!requesting_thumbnail_data">
-        <img id="${'img-thumb-' + thumb.id}" repeat.for="thumb of thumbnails"
-             css="${image_config.image_info.image_id === thumb.id ?
-                 'border: 5px solid rgba(0,60,136,0.5)' : 'border: none'}"
-             src.bind="thumb.url + '?version=' + thumb.revision"
-             title="${thumb.title}"
-             alt="Not Found"
-             click.delegate="onClick(thumb.id)"
-             dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
-    </div>
-    <div show.bind="thumbnails_end_index < thumbnails_count"
-         click.delegate="requestMoreThumbnails(false, true)"
-         class='expand-down thumbnail-collapse'
-         title="Show more images">
+        show.bind="!requesting_thumbnail_data"
+        scroll.trigger="handleScrollEvent($event)">
+
+        <div css="height: ${ (thumbnails_count * 50) }px">
+            Count: ${ thumbnails_count } ${ thumbnails_count * 10 }
+            <img id="${'img-thumb-' + thumb.id}" repeat.for="thumb of thumbnails"
+                css="${image_config.image_info.image_id === thumb.id ?
+                    'border: 5px solid rgba(0,60,136,0.5)' : 'border: none'}"
+                src.bind="thumb.url + '?version=' + thumb.revision"
+                title="${thumb.title}"
+                alt="Not Found"
+                click.delegate="onClick(thumb.id)"
+                dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
+
+        </div>
+
     </div>
     <div class="disabled-color" style="position: relative;top: 40%;"
          show.bind="requesting_thumbnail_data">

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -27,7 +27,7 @@
 
     <div class="thumbnail-scroll-panel"
         show.bind="!requesting_thumbnail_data"
-        scroll.trigger="handleScrollEvent($event)">
+        scroll.trigger="handleScrollEvent($event) & debounce:10">
 
         <div>
             <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper">

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -290,7 +290,6 @@ export default class ThumbnailSlider extends EventSubscriber {
      */
     initializeThumbnails(refresh = false) {
         // standard case: we are an image
-        console.log("initializeThumbnails", refresh, this.context.initial_type);
         if (this.context.initial_type === INITIAL_TYPES.IMAGES) {
             if (this.context.initial_ids.length > 1) {
                 // we are a list of images
@@ -316,7 +315,6 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @memberof ThumbnailSlider
      */
     gatherThumbnailMetaInfo(image_id) {
-        console.log("gatherThumbnailMetaInfo", image_id);
         let url =
             this.context.server + this.webclient_prefix + "/api/paths_to_object/?" +
             "image=" + image_id + "&page_size=" + this.thumbnails_request_size;
@@ -358,28 +356,16 @@ export default class ThumbnailSlider extends EventSubscriber {
                     }
                 }
 
-                console.log("imgInf.parent_type, imgInf.parent_id", imgInf.parent_type, imgInf.parent_id);
-
                 if (imgInf.parent_id === null) {
                     this.hideMe();
                     return;
                 }
 
-                // let initialize = (parent === null);
-                // TODO: why would initialize not be true here?
-                let initialize = true;
-                console.log('parent', parent);
-
                 let start_index = 0;
                 if (parent) {
-                    // set count, start and end indices (if count > limit)
-                    // this.setThumbnailsCount(parent.childCount);  --
-                    // if (this.thumbnails.length > this.thumbnails_request_size) {
-                        // start_index = (parent.childPage - 1) * this.thumbnails_request_size;
-                        start_index = parent.childIndex;
-                        console.log('parent.childIndex', parent.childIndex);
-                    // }
+                    start_index = parent.childIndex;
                 }
+                let initialize = true;
                 this.requestMoreThumbnails(initialize, false, start_index);
             },
             error : (response) => this.requestMoreThumbnails(true)
@@ -414,12 +400,9 @@ export default class ThumbnailSlider extends EventSubscriber {
             if (panel)
             scrollTop = panel.scrollTop;
         }
-        console.log('loadVisibleThumbnails scrollTop:', scrollTop);
 
         let thumb_start_index = parseInt(scrollTop / this.thumbnail_size);
         let thumb_end_index = parseInt((scrollTop + this.slider_height) / this.thumbnail_size);
-        console.log('this.thumbnail_size', this.slider_height);
-        console.log('scrolled to thumb_index...', thumb_start_index, thumb_end_index);
 
         let unloaded = [];
         for (var idx=thumb_start_index; idx<=thumb_end_index; idx++){
@@ -430,7 +413,6 @@ export default class ThumbnailSlider extends EventSubscriber {
         if (unloaded.length > 0) {
             thumb_start_index = unloaded[0];
             thumb_end_index = unloaded[unloaded.length-1];
-            console.log('unloaded thumbs: thumb_start_index, thumb_end_index', thumb_start_index, thumb_end_index);
             this.requestMoreThumbnails(init, refresh, thumb_start_index, thumb_end_index);
         }
     }
@@ -464,7 +446,6 @@ export default class ThumbnailSlider extends EventSubscriber {
             limit = thumb_end_index - offset;
         }
 
-        console.log("requestMoreThumbnails... offset, limit", offset, limit);
 
         let url = this.context.server;
         if (this.context.initial_type === INITIAL_TYPES.DATASET ||
@@ -484,7 +465,6 @@ export default class ThumbnailSlider extends EventSubscriber {
             {url : url,
             success : (response) => {
                 this.requesting_thumbnail_data = false;
-                console.log("...requestMoreThumbnails init", init, this.thumbnails.length);
                 if (init) {
                     // we want the total count
                     if (typeof response !== 'object' || response === null ||
@@ -540,7 +520,6 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @memberof ThumbnailSlider
      */
     addThumbnails(thumbnails, start_index) {
-        console.log('addThumbnails...');
         // if we are remote we include the server
         let thumbPrefix =
             (this.context.server !== "" ? this.context.server + "/" : "") +
@@ -574,14 +553,13 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @memberof ThumbnailSlider
      */
     scrollToThumbnail(index) {
+        // Queue the task to happen after the UI renders
         // https://github.com/aurelia/templating/issues/79
-        console.log("SCROLLING to ", index);
         this.taskQueue.queueMicroTask(() => {
             const target = (index) * this.thumbnail_size;
 
             // If we didn't do ajax call to load thumbnails, ?image=1&image=2
             // the scroll-panel might not be ready yet.
-            console.log('scroll to top...', target)
             let scroll_panel = document.querySelector('.thumbnail-scroll-panel');
             if (scroll_panel) {
                 scroll_panel.scrollTop = target;
@@ -733,11 +711,14 @@ export default class ThumbnailSlider extends EventSubscriber {
         return false;
     }
 
+    /**
+     * Thumbnail scroll handler. Loads any unloaded visible thumbnails
+     *
+     * @memberof ThumbnailSlider
+     * @param {Object} Scroll event
+     */
     handleScrollEvent(event) {
-
-        console.log('scroll', event.target.scrollTop, this.thumbnail_size, event.target.scrollTop / this.thumbnail_size)
         // find index of any visible thumbnails that aren't loaded...
-
         this.loadVisibleThumbnails(event.target.scrollTop);
     }
 
@@ -748,7 +729,6 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {Object} params the parameter object received by the event
      */
     updateThumbnails(params = {}) {
-        console.log('updateThumbnails', params);
         if (typeof params !== 'object' ||
             !Misc.isArray(params.ids) && params.ids.length > 0) return;
 
@@ -786,7 +766,6 @@ export default class ThumbnailSlider extends EventSubscriber {
     }
 
     setThumbnailsCount(count) {
-        console.log('setThumbnailsCount:', count, 'was:', this.thumbnails.length);
         if (typeof count !== 'number') {
             count = 0;
         }

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -66,11 +66,11 @@ export default class ThumbnailSlider extends EventSubscriber {
     web_api_base = '';
 
     /**
-     * a possible gateway prefix for the urls
+     * webclient prefix for the urls
      * @memberof ThumbnailSlider
      * @type {string}
      */
-    gateway_prefix = '';
+    webclient_prefix = '';
 
     /**
      * observer watching for changes in the selected image
@@ -153,7 +153,7 @@ export default class ThumbnailSlider extends EventSubscriber {
 
         // get webgateway prefix and web api base
         this.web_api_base = this.context.getPrefixedURI(WEB_API_BASE);
-        this.gateway_prefix = this.context.getPrefixedURI(WEBGATEWAY);
+        this.webclient_prefix = this.context.getPrefixedURI(WEBCLIENT);
     }
 
     /**
@@ -317,9 +317,8 @@ export default class ThumbnailSlider extends EventSubscriber {
      */
     gatherThumbnailMetaInfo(image_id) {
         console.log("gatherThumbnailMetaInfo", image_id);
-        let webclient_prefix = this.context.getPrefixedURI(WEBCLIENT);
         let url =
-            this.context.server + webclient_prefix + "/api/paths_to_object/?" +
+            this.context.server + this.webclient_prefix + "/api/paths_to_object/?" +
             "image=" + image_id + "&page_size=" + this.thumbnails_request_size;
 
         $.ajax(
@@ -545,7 +544,7 @@ export default class ThumbnailSlider extends EventSubscriber {
         // if we are remote we include the server
         let thumbPrefix =
             (this.context.server !== "" ? this.context.server + "/" : "") +
-            this.gateway_prefix + "/render_thumbnail/";
+            this.webclient_prefix + "/render_thumbnail/";
 
         let new_index = 0;
         this.thumbnails = this.thumbnails.map((thumb, idx) => {

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -108,7 +108,8 @@ export default class ThumbnailSlider extends EventSubscriber {
     thumbnail_size = 90;
 
     /**
-     * height of slider, so we which thumbs have scrolled into view
+     * height of slider, so we know which thumbs have scrolled into view.
+     * This is set in attached() and when window resizes.
      * @memberof ThumbnailSlider
      * @type {number}
      */
@@ -143,6 +144,7 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @constructor
      * @param {Context} context the application context (injected)
      * @param {BindingEngine} bindingEngine the BindingEngine (injected)
+     * @param {TaskQueue} Aurelia taskQueue for post-render tasks
      */
     constructor(context, element, bindingEngine, taskQueue) {
         super(context.eventbus)
@@ -392,6 +394,8 @@ export default class ThumbnailSlider extends EventSubscriber {
      * Loads unloaded thumbnails that scrolled into the thumbnail panel
      *
      * @param {number} scrollTop Current scroll position of the panel
+     * @param {boolean} init if true we have to perform some init tasks/checks
+     * @param {boolean} refresh true if the user hit the refresh icon
      * @memberof ThumbnailSlider
      */
     loadVisibleThumbnails(scrollTop, init = false, refresh = false) {
@@ -512,7 +516,7 @@ export default class ThumbnailSlider extends EventSubscriber {
     /**
      * Adds thumbnails with Image IDs to this.thumbnails array.
      * We create a new list from old, replacing the thumbnails (instead of
-     * modifying the old list) to make sure the changes is observed and
+     * modifying the old list) to make sure the changes are observed and
      * UI updates.
      *
      * @param {Array.<Object>} thumbnails the thumbnails to be added
@@ -545,11 +549,10 @@ export default class ThumbnailSlider extends EventSubscriber {
     /**
      * Adds thumbnails with Image IDs to this.thumbnails array.
      * We create a new list from old, replacing the thumbnails (instead of
-     * modifying the old list) to make sure the changes is observed and
+     * modifying the old list) to make sure the changes are observed and
      * UI updates.
      *
-     * @param {Array.<Object>} thumbnails the thumbnails to be added
-     * @param {number} start_index Index to start replacing
+     * @param {number} index  Index of thumbnail we want to scroll to.
      * @memberof ThumbnailSlider
      */
     scrollToThumbnail(index) {

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -748,12 +748,13 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {Object} params the parameter object received by the event
      */
     updateThumbnails(params = {}) {
+        console.log('updateThumbnails', params);
         if (typeof params !== 'object' ||
             !Misc.isArray(params.ids) && params.ids.length > 0) return;
 
         // turn array into object for easier lookup
         let updatedIds = {};
-        params.ids.map((id) => updatedIds[id] = null);
+        params.ids.forEach((id) => updatedIds[id] = null);
 
         let position = 0;
         // we update in batches

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -791,7 +791,10 @@ export default class ThumbnailSlider extends EventSubscriber {
             count = 0;
         }
         this.thumbnails.length = count;
-        this.thumbnails.fill({'version': 0, 'title': 'unloaded'});
+        // IE doesn't support fill()
+        for (let i=0; i<count; i++) {
+            this.thumbnails[i] = {'version': 0, 'title': 'unloaded'};
+        }
     }
 
     /**

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -354,7 +354,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                         imgInf.parent_type = INITIAL_TYPES.DATASET
                     } else if (parent.type === 'well') {
                         imgInf.parent_type = INITIAL_TYPES.WELL;
-                        imgInf.parent_id = wells[0].id;
+                        imgInf.parent_id = parent.id;
                     }
                 }
 

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -174,14 +174,26 @@ export default class ThumbnailSlider extends EventSubscriber {
         this.subscribe();
     }
 
+    /**
+     * Overridden aurelia lifecycle method:
+     * Used to get initial height of panel
+     *
+     * @memberof ThumbnailSlider
+     */
     attached() {
         this.slider_height =
-            document.querySelector('.thumbnail-scroll-panel').clientHeight
+            document.querySelector('.thumbnail-scroll-panel').clientHeight;
     }
 
+    /**
+     * Handle resize of the browse window.
+     * Updates height of panel
+     *
+     * @memberof ThumbnailSlider
+     */
     resizeViewer() {
         this.slider_height =
-            document.querySelector('.thumbnail-scroll-panel').clientHeight
+            document.querySelector('.thumbnail-scroll-panel').clientHeight;
     }
 
     /**

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -657,6 +657,10 @@ export default class ThumbnailSlider extends EventSubscriber {
         return false;
     }
 
+    handleScrollEvent(event) {
+        console.log(event.target.scrollTop);
+    }
+
     /**
      * Updates one or more thumbnails
      *


### PR DESCRIPTION
See https://trello.com/c/JLpfTbmW/4-improve-thumbnails-loading-display

Instead of clicking up/down to load more thumbnails, the thumbnail panel is created at the full size (with only the visible thumbnails loaded) and more thumbnails are loaded when we scroll.
There are lots of different cases to handle and a lot has changed so everything needs testing:

 - Expected behaviour: any thumbnails that appear in the panel should be loaded (no empty grey squares).
 - While actually scrolling we don't load thumbnails, since that would load the whole dataset if you scroll fast from one end to the other. Instead, wait until scrolling slows / stops, then load thumbs for visible thumbnails.
 - You can see when loading is happening in the devtools Network tab.
 - In all scenarios below, check thumbs on load, then scroll about, then refresh thumbs (when scrollbar is in various locations).
 - Check that IE works.

**Scenarios to test:**

 - Single image in 1 or more Datasets, double-clicked in webclient. url like ```/webclient/img_detail/4413/?dataset=1301```
        - Check that thumbs loaded from *current* parent Dataset (not a different Dataset that the image is in)
        - Try double-clicking images in webclient near the start of the Dataset and at the end. Thumb panel in iviewer should scroll to the show the selected image.
        - Try with a small Dataset (< 5 images) and as large as possible.
        - Remove the ```?datasets=ID``` from the URL and reload. If image is in single Dataset, thumbs should be loaded. If more than 1 Dataset, thumbnail panel hidden.
 - Multiple selected images > Open with iviewer. Url like ```/iviewer/?images=4402,4403,4404,4405 ```
 - Orphaned image, double-clicked in webclient. e.g. ```webclient/img_detail/57012/``` should hide thumbnail panel.
 - Well - openwith > iviewer.  Url ```/iviewer/?well=148``` First image should be selected.
 - Datasets - openwith > iviewer. ```/iviewer/?dataset=10480``` First image selected.