### PR TITLE
Always show ROI/Shape owner. Unsaved if no shape ID

### DIFF
--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -79,7 +79,8 @@
                     <div if.bind="(roi.shapes.size - roi.deleted) > 1 &&
                                    roi.shapes.size > 1 && $first"
                         id="${'roi-' + roi_id}"
-                        title="ROI: ${roi_id} - Shape: ${shape_id}"
+                        title="${(shape_id > 0 ? 'ROI: ' + roi_id + ', Shape: ' + shape_id : 'Unsaved') +
+                                    (shape.owner ? '\nOwner: ' + shape.owner : '')}"
                         class="regions-table-row"
                         click.delegate="selectShape(roi_id, true, $event, true)">
                         <div class="regions-table-col roi-toggle">
@@ -104,11 +105,9 @@
                     </div>
                     <div if.bind="!(shape.deleted && shape.is_new) &&
                                    !(roi.shapes.size > 1 && !roi.show)"
-                        title="${'ROI: ' + roi_id + ' - Shape: ' + shape_id +
-                                    (hasPermissions(shape) ?
-                                        (shape.type === 'mask' ?
-                                            '\nMasks cannot be edited' : '') :
-                                        '\nOwner: ' + shape.owner)}"
+                        title="${(shape_id > 0 ? 'ROI: ' + roi_id + ', Shape: ' + shape_id : 'Unsaved') +
+                                    (shape.owner ? '\nOwner: ' + shape.owner : '') +
+                                    (shape.type === 'mask' ? '\nMasks cannot be edited' : '')}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"
                         css="${shape.selected ? 'background-color: #d0d0ff;' : ''}


### PR DESCRIPTION
See https://trello.com/c/gWqOfidt/61-show-better-tooltips-on-rois

This change displays the Owner of the Shape even if that is the current user or the current user is able to edit the ROI (e.g. admin). Previously we only showed owner if they couldn't edit the Shape.

Also, if the shape is unsaved, tooltip show "Unsaved" instead of showing negative ROI and Shape IDs.

To test:
 - check the tooltip on Shapes you own (and others)
 - check tooltip on unsaved vv saved shapes.
 - check tooltip on multiple shapes within ROI (created in Insight)