### PR TITLE
Shape coordinates as tooltip

### DIFF
--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -107,6 +107,7 @@
                                    !(roi.shapes.size > 1 && !roi.show)"
                         title="${(shape_id > 0 ? 'ROI: ' + roi_id + ', Shape: ' + shape_id : 'Unsaved') +
                                     (shape.owner ? '\nOwner: ' + shape.owner : '') +
+                                    '\n' + formatCoords(shape) + ' ' + (shape.modified ? 'mod' : '') +
                                     (shape.type === 'mask' ? '\nMasks cannot be edited' : '')}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -79,7 +79,8 @@
                     <div if.bind="(roi.shapes.size - roi.deleted) > 1 &&
                                    roi.shapes.size > 1 && $first"
                         id="${'roi-' + roi_id}"
-                        title="ROI: ${roi_id} - Shape: ${shape_id}"
+                        title="${(shape_id > 0 ? 'ROI: ' + roi_id + ', Shape: ' + shape_id : 'Unsaved') +
+                                    (shape.owner ? '\nOwner: ' + shape.owner : '')}"
                         class="regions-table-row"
                         click.delegate="selectShape(roi_id, true, $event, true)">
                         <div class="regions-table-col roi-toggle">
@@ -104,11 +105,9 @@
                     </div>
                     <div if.bind="!(shape.deleted && shape.is_new) &&
                                    !(roi.shapes.size > 1 && !roi.show)"
-                        title="${'ROI: ' + roi_id + ' - Shape: ' + shape_id +
-                                    (hasPermissions(shape) ?
-                                        (shape.type === 'mask' ?
-                                            '\nMasks cannot be edited' : '') :
-                                        '\nOwner: ' + shape.owner)}"
+                        title="${(shape_id > 0 ? 'ROI: ' + roi_id + ', Shape: ' + shape_id : 'Unsaved') +
+                                    (shape.owner ? '\nOwner: ' + shape.owner : '') +
+                                    (shape.type === 'mask' ? '\nMasks cannot be edited' : '')}"
                         id="${'roi-' + shape.shape_id}"
                         class="regions-table-row"
                         css="${shape.selected ? 'background-color: #d0d0ff;' : ''}

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -460,6 +460,33 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
+     * Returns a string to show shape coordinates.
+     * E.g. for Rectangle "x: 100.01 y: 210 width: 1010 height: 123"
+     * (Helper method for template only!)
+     *
+     * @private
+     * @param {Object} shape a shape
+     * @return {String} to show shape coordinates
+     * @memberof RegionsList
+     */
+    formatCoords(shape) {
+        const f = (n) => n.toFixed(1);
+        let coords = ""
+        let attrs = {
+            rectangle: ['X', 'Y', 'Width', 'Height'],
+            line: ['X1', 'Y1', 'X2', 'Y2'],
+            ellipse: ['X', 'Y', 'RadiusX', 'RadiusY'],
+            point: ['X', 'Y']
+        }
+        if (attrs[shape.type]) {
+            coords = attrs[shape.type].map(a => `${a}: ${f(shape[a])}`).join(" ");
+        } else {
+            coords = "";
+        }
+        return coords;
+    }
+
+    /**
      * Overridden aurelia lifecycle method:
      * called whenever the view is unbound within aurelia
      * in other words a 'destruction' hook that happens after 'detached'


### PR DESCRIPTION
See https://trello.com/c/gWqOfidt/61-show-better-tooltips-on-rois

This adds coordinates for Line, Rectangle, Ellipse and Point to the shape tooltip.
However, the tooltip is not yet updated when the coordinates change, which means that they are not useful when adjusting the shape.

I tried adding ```shape.modified``` into the tooltip so that the tooltip is re-rendered when this flag changes. This works (tooltip is re-created) but unfortunately the coordinates are not updated at this time AND the tooltip is not re-rendered again on subsequent edits.