### PR TITLE
Remove doubleClick zoom workaround

### DIFF
--- a/ol3-viewer/src/ome/ol3/globals.js
+++ b/ol3-viewer/src/ome/ol3/globals.js
@@ -360,11 +360,9 @@ ome.ol3.AVAILABLE_VIEWER_INTERACTIONS = {
         {"clazz" : ol.interaction.DragZoom,
          "options": {"zoomDuration" : null},
          "defaults": true, "enabled": false, "links" : []},
-    // NB: The delta option is strangely ignored for some reason
-    // So we manually re-create this class below...
     "doubleClickZoom" :
         {"clazz" : ol.interaction.DoubleClickZoom,
-         "options": {duration : 1000, delta: 10},
+         "options": {duration : 250, delta: 10},
          "defaults": true, "enabled": true, "links" : []},
     "pinchRotate" :
         {"clazz" : ol.interaction.PinchRotate,
@@ -430,18 +428,6 @@ ome.ol3.defaultInteractions = function() {
                     "ref": new Constructor(V['options']),
                     "defaults" : V["defaults"]
                 };
-                // For some reason, calling new ol.interaction.DoubleClickZoom({"delta": 10})
-                // here, the 'delta' option is ignored. But if we create a defaults collection
-                // the same class is created and the {'delta': zoomDelta} is not ignored.
-                // We use altShiftDragRotate: false so that doubleClickZoom should be
-                // the first item in the ol.Collection.
-                if (K === "doubleClickZoom") {
-                    let defaults = ol.interaction.defaults({
-                        altShiftDragRotate: false,
-                        zoomDelta: 10,
-                    });
-                    ret[K]["ref"] = defaults.item(0);
-                }
             } catch(bad) {
                 // this could happen because the clazz does not point to a valid
                 // function definition, a ClassNotFound in a way ...


### PR DESCRIPTION
Hoping that removing the workaround from #210 but keeping the double-click zoom behaviour the same.