### PR TITLE
correctly capitalize "GitHub" on Help menu

### DIFF
--- a/src/app/header.html
+++ b/src/app/header.html
@@ -117,7 +117,7 @@
                     <li>
                         <a  target="_blank"
                             href="https://github.com/ome/omero-iviewer">
-                            OMERO.iviewer on Github
+                            OMERO.iviewer on GitHub
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
see "Help" menu and compare with GitHub branding