### PR TITLE
Add textStatus to ajax error message.

### DIFF
--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -312,7 +312,7 @@ export default class ImageInfo {
                 if (this.context.isRoisTabActive())
                     conf.regions_info.requestData();
             },
-            error : (error) => {
+            error : (error, textStatus) => {
                 this.ready = false;
                 this.error = true;
                 if (typeof error.responseText === 'string')
@@ -323,7 +323,8 @@ export default class ImageInfo {
                 // show message in case of error
                 let errMsg =
                     error.status === 404 ?
-                        "Image not found" : "Failed to get image data";
+                        "Image not found" :
+                        `Failed to get image data: '${textStatus}'`;
                 Ui.showModalMessage(errMsg, 'OK');
             }
         });


### PR DESCRIPTION
This could help users reporting problems with image loading.

During investigation of https://trello.com/c/X5egtRjc/3-iviewer-fails-to-load-images-with-pixel-size-nan-or-inf it would have been more useful to get the extra info on why image loading failed, in this case the ```textStatus``` was "parsererror":

<img width="342" alt="screen shot 2019-01-07 at 03 57 34" src="https://user-images.githubusercontent.com/900055/50748273-6c869400-1230-11e9-802d-f3322d83f2da.png">

This can be tested by opening http://web-dev-merge.openmicroscopy.org/webclient/?show=image-24401 in iviewer (user-3)