### PR TITLE
Fix resize rectangle

### DIFF
--- a/src/viewers/viewer/interaction/Modify.js
+++ b/src/viewers/viewer/interaction/Modify.js
@@ -493,8 +493,8 @@ const handleDragEvent_ = function(mapBrowserEvent) {
                 if (dragVertexIndex > 2) dragVertexIndex++;
                 var oppVertexIndex = (dragVertexIndex + 2)  % 5;
                 this.oppVertBeingDragged = [
-                    geometry.initial_coords_[oppVertexIndex*2],
-                    geometry.initial_coords_[oppVertexIndex*2+1]
+                    coordinates[0][oppVertexIndex][0],
+                    coordinates[0][oppVertexIndex][1]
                 ];
             }
 


### PR DESCRIPTION
I noticed this a while back, and again while testing #218.

To test:
 - In select mode, select a Rectangle and drag it
 - Then pick a corner of the selected Rectangle and resize it
 - This should behave as expected (doesn't snap back to pre-drag coordinates)
 - Test with newly-created Rectangles and previously saved ones, moving between various Rectangles etc.