### PR TITLE
Fix centreOnGeometry for Point or Ellipse

### DIFF
--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -21,6 +21,7 @@ import MapEventType from 'ol/MapEventType';
 import Geometry from 'ol/geom/Geometry';
 import GeometryType from 'ol/geom/GeometryType';
 import Polygon from 'ol/geom/Polygon';
+import {fromExtent as polygonFromExtent} from 'ol/geom/Polygon.js';
 import {listen, unlistenByKey} from 'ol/events';
 import Collection from 'ol/Collection';
 import Feature from 'ol/Feature';
@@ -852,7 +853,7 @@ class Viewer extends OlObject {
         var rot = this.viewer_.getView().getRotation();
         if (geometry.getType() === GeometryType.CIRCLE) {
             var ext = geometry.getExtent();
-            geometry = Polygon.fromExtent(ext);
+            geometry = polygonFromExtent(ext);
             geometry.rotate(rot, getCenter(ext));
         }
         var coords = geometry.getFlatCoordinates();


### PR DESCRIPTION
Probably a bug that was introduced in the big OpenLayers-5 update.
To test:
 - In the ROI table, click on a Point and/or Ellipse that isn't visible in the viewer
 - The viewer should pan to show the shape in the centre