### PR TITLE
drag and drop to open image

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -508,6 +508,10 @@ a.ui-button:active,
     z-index: 0;
 }
 
+.viewer-mdi.drag_enter {
+    border-style: dashed;
+}
+
 .show-zSlider .viewer {
     padding-left: 35px;
 }

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -738,7 +738,7 @@ export default class Context {
         let selImgConf = this.getSelectedImageConfig();
         let hasSameImageSelected =
             selImgConf && selImgConf.image_info.image_id === image_id;
-        // show dialogues for modified rois
+        // show dialogs for modified rois
         if (image_config &&
             image_config.regions_info &&
             (image_config.regions_info.hasBeenModified() ||

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -672,6 +672,31 @@ export default class Context {
     }
 
     /**
+     * Get the parent e.g. {type:'dataset', id:123} for example used to
+     * load additional thumbnails.
+     */
+    getParentTypeAndId() {
+        let image_config = this.getSelectedImageConfig();
+        // Dataset ID or Well ID or Image ID
+        let parent_id = null;
+        if (this.initial_type === INITIAL_TYPES.DATASET ||
+            this.initial_type === INITIAL_TYPES.WELL) {
+                parent_id = this.initial_ids[0];
+        } else if (this.initial_type === INITIAL_TYPES.IMAGES &&
+            this.initial_ids.length === 1 &&
+            image_config !== null &&
+            typeof image_config.image_info.parent_id === 'number'){
+                parent_id = image_config.image_info.parent_id;
+        }
+        let parent_type = INITIAL_TYPES.NONE;
+        if (parent_id) {
+            parent_type = this.initial_type === INITIAL_TYPES.IMAGES ?
+                    image_config.image_info.parent_type : this.initial_type;
+        }
+        return {type: parent_type, id: parent_id};
+    }
+
+    /**
      * Click Handler for single/double clicks to converge on:
      * Opens images in single and multi viewer mode
      *
@@ -684,20 +709,11 @@ export default class Context {
         let image_config = context.getSelectedImageConfig();
         let navigateToNewImage = () => {
             context.rememberImageConfigChange(image_id);
-            let parent_id =
-                context.initial_type === INITIAL_TYPES.DATASET ||
-                context.initial_type === INITIAL_TYPES.WELL ?
-                    context.initial_ids[0] :
-                        context.initial_type === INITIAL_TYPES.IMAGES &&
-                        context.initial_ids.length === 1 &&
-                        image_config !== null &&
-                        typeof image_config.image_info.parent_id === 'number' ?
-                            image_config.image_info.parent_id : null;
-            let parent_type =
-                parent_id === null ? INITIAL_TYPES.NONE :
-                    context.initial_type === INITIAL_TYPES.IMAGES ?
-                        image_config.image_info.parent_type :
-                        context.initial_type;
+            // Dataset ID or Well ID or Image ID
+            let parent = this.getParentTypeAndId();
+            let parent_id = parent.id;
+            let parent_type = parent.type;
+            console.log(parent_id, parent_type);
             // single click in mdi will need to 'replace' image config
             if (context.useMDI && !is_double_click) {
                     let oldPosition = Object.assign({}, image_config.position);

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -66,8 +66,9 @@
             <img src="../../css/images/collapse-left.png"/>
         </div>
 
-        <div drop.delegate="handleDrop($event)"
-            dragover.delegate="handleDragover($event)"class="frame col-xs-12">
+        <div class="frame col-xs-12"
+            drop.delegate="handleDrop($event)"
+            dragover.delegate="handleDragover($event)">
             <div class="${context.useMDI && context.image_configs.size > 1 ?
                             'viewer-mdi' : 'viewer'}
                         ${context.useMDI && context.selected_config === id &&

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -66,7 +66,8 @@
             <img src="../../css/images/collapse-left.png"/>
         </div>
 
-        <div class="frame col-xs-12">
+        <div drop.delegate="handleDrop($event)"
+            dragover.delegate="handleDragover($event)"class="frame col-xs-12">
             <div class="${context.useMDI && context.image_configs.size > 1 ?
                             'viewer-mdi' : 'viewer'}
                         ${context.useMDI && context.selected_config === id &&

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -251,6 +251,27 @@ export class Index  {
     }
 
     /**
+     * Handle dropping of a thumbnail on to the centre panel.
+     * Opens the image in Multi-Display mode
+     *
+     * @param {Object} event Drop event
+     */
+    handleDrop(event) {
+        var image_id = parseInt(event.dataTransfer.getData("id"), 10);
+        this.context.useMDI = true;
+        this.context.addImageConfig(image_id);
+    }
+
+    /**
+     * Simply preventDefault() to allow drop here
+     *
+     * @param {Object} event Dragover event
+     */
+    handleDragover(event) {
+        event.preventDefault();
+    }
+
+    /**
      * Overridden aurelia lifecycle method:
      * called when the view and its elemetns are detached from the PAL
      * (dom abstraction)

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -259,7 +259,8 @@ export class Index  {
     handleDrop(event) {
         var image_id = parseInt(event.dataTransfer.getData("id"), 10);
         this.context.useMDI = true;
-        this.context.addImageConfig(image_id);
+        // similar behaviour to double-clicking
+        this.context.onClicks(image_id, true);
     }
 
     /**

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -31,9 +31,12 @@
         scroll.trigger="handleScrollEvent($event) & debounce:100">
 
         <div>
-            <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper">
+            <!-- Both the div and the img have data-id for drag-n-drop -->
+            <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper"
+                data-id="${thumb.id}"
+                draggable="true" dragstart.delegate="handleDragStart($event)">
               <!-- show placeholder 1 x 1 px png if no thumb.url -->
-              <img id="${'img-thumb-' + thumb.id}"
+              <img id="${'img-thumb-' + thumb.id}" data-id="${thumb.id}"
                 class="${image_config.image_info.image_id === thumb.id ? 'selected' : ''}
                     ${thumb.id ? '' : 'transparent'}"
                 src.bind="thumb.url ? thumb.url + '?version=' + thumb.revision : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII='"

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -584,103 +584,6 @@ export default class ThumbnailSlider extends EventSubscriber {
     }
 
     /**
-     * Click Handler for single/double clicks to converge on:
-     * Opens images in single and multi viewer mode
-     *
-     * @memberof ThumbnailSlider
-     * @param {number} image_id the image id for the clicked thumbnail
-     * @param {boolean} is_double_click true if triggered by a double click
-     */
-    onClicks(image_id, is_double_click = false) {
-        let navigateToNewImage = () => {
-            this.context.rememberImageConfigChange(image_id);
-            let parent_id =
-                this.context.initial_type === INITIAL_TYPES.DATASET ||
-                this.context.initial_type === INITIAL_TYPES.WELL ?
-                    this.context.initial_ids[0] :
-                        this.context.initial_type === INITIAL_TYPES.IMAGES &&
-                        this.context.initial_ids.length === 1 &&
-                        this.image_config !== null &&
-                        typeof this.image_config.image_info.parent_id === 'number' ?
-                            this.image_config.image_info.parent_id : null;
-            let parent_type =
-                parent_id === null ? INITIAL_TYPES.NONE :
-                    this.context.initial_type === INITIAL_TYPES.IMAGES ?
-                        this.image_config.image_info.parent_type :
-                        this.context.initial_type;
-            // single click in mdi will need to 'replace' image config
-            if (this.context.useMDI && !is_double_click) {
-                    let oldPosition = Object.assign({}, this.image_config.position);
-                    let oldSize = Object.assign({}, this.image_config.size);
-                    this.context.removeImageConfig(this.image_config, true);
-                    this.context.addImageConfig(image_id, parent_id, parent_type);
-                    let selImgConf = this.context.getSelectedImageConfig();
-                    if (selImgConf !== null) {
-                        selImgConf.position = oldPosition;
-                        selImgConf.size = oldSize;
-                    }
-            } else this.context.addImageConfig(image_id, parent_id, parent_type);
-        };
-
-        let modifiedConfs = this.context.useMDI ?
-            this.context.findConfigsWithModifiedRegionsForGivenImage(
-                image_id) : [];
-        let selImgConf = this.context.getSelectedImageConfig();
-        let hasSameImageSelected =
-            selImgConf && selImgConf.image_info.image_id === image_id;
-        // show dialogues for modified rois
-        if (this.image_config &&
-            this.image_config.regions_info &&
-            (this.image_config.regions_info.hasBeenModified() ||
-             modifiedConfs.length > 0) &&
-             (!is_double_click || (is_double_click && !hasSameImageSelected)) &&
-            !Misc.useJsonp(this.context.server) &&
-            this.image_config.regions_info.image_info.can_annotate) {
-                let modalText =
-                    !this.context.useMDI ||
-                    this.image_config.regions_info.hasBeenModified() ?
-                        'You have new/deleted/modified ROI(s).<br>' +
-                        'Do you want to save your changes?' :
-                        'You have changed ROI(s) on an image ' +
-                        'that\'s been opened multiple times.<br>' +
-                        'Do you want to save now to avoid ' +
-                        'inconsistence (and a potential loss ' +
-                        'of some of your changes)?';
-                let saveHandler =
-                    !this.context.useMDI ||
-                    (!is_double_click &&
-                     this.image_config.regions_info.hasBeenModified()) ?
-                        () => {
-                            let tmpSub =
-                                this.context.eventbus.subscribe(
-                                    REGIONS_STORED_SHAPES,
-                                    (params={}) => {
-                                        tmpSub.dispose();
-                                        if (params.omit_client_update)
-                                            navigateToNewImage();
-                                });
-                            setTimeout(()=>
-                                this.context.publish(
-                                    REGIONS_STORE_SHAPES,
-                                    {config_id : this.image_config.id,
-                                     omit_client_update: true}), 20);
-                        } :
-                        () => {
-                            this.context.publish(
-                                REGIONS_STORE_SHAPES,
-                                {config_id :
-                                    this.image_config.regions_info.hasBeenModified() ?
-                                    this.image_config.id : modifiedConfs[0],
-                                 omit_client_update: false});
-                            navigateToNewImage();
-                        };
-                UI.showConfirmationDialog(
-                    'Save ROIs?', modalText,
-                    saveHandler, () => navigateToNewImage());
-        } else navigateToNewImage();
-    }
-
-    /**
      * hacky solution to allow double - single click distinction
      *
      * @memberof ThumbnailSlider
@@ -691,7 +594,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             clearTimeout(this.click_handle);
             this.click_handle = null;
         }
-        this.click_handle = setTimeout(() => this.onClicks(image_id), 250);
+        this.click_handle = setTimeout(() => this.context.onClicks(image_id), 250);
     }
 
     /**
@@ -709,7 +612,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             this.click_handle = null;
         }
         this.context.useMDI = true;
-        this.onClicks(image_id, true);
+        this.context.onClicks(image_id, true);
 
         return false;
     }

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -780,6 +780,17 @@ export default class ThumbnailSlider extends EventSubscriber {
     }
 
     /**
+     * Handle Drag Start, coming from the thumbnail img itself or the parent div
+     * Both should have the data-id attribute for the image ID.
+     *
+     * @param {Object} event Drag start event
+     */
+    handleDragStart(event) {
+        event.dataTransfer.setData("id", event.target.dataset.id);
+        return true;
+    }
+
+    /**
      * Refresh thumbnail slider contents by reinitialization
      *
      * @memberof ThumbnailSlider

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -25,7 +25,8 @@
                 ${image_config.image_info.dimensions.max_t > 1 ? 'show-tSlider' : ''}
                 ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}"
             drop.delegate="handleDrop($event)"
-            dragover.delegate="handleDragover($event)"    
+            dragover.delegate="handleDragover($event)"
+            dragleave.delegate="handleDragleave($event)"
             >
         <dimension-slider
             if.bind="image_config.image_info.dimensions.max_z > 1"

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -23,7 +23,10 @@
     <div class="${context.useMDI && context.image_configs.size > 1 ?
                     'center-row1-mdi' : 'center-row1'}
                 ${image_config.image_info.dimensions.max_t > 1 ? 'show-tSlider' : ''}
-                ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}">
+                ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}"
+            drop.delegate="handleDrop($event)"
+            dragover.delegate="handleDragover($event)"    
+            >
         <dimension-slider
             if.bind="image_config.image_info.dimensions.max_z > 1"
             image_config.bind="image_config"

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1521,18 +1521,9 @@ export default class Ol3Viewer extends EventSubscriber {
             this.context.useMDI = true;
             this.context.onClicks(image_id, true);
         } else {
+            // similar behaviour to single-click:
             // replace this image_config with new one
-            // NB: we don't check for unsaved ROIs before closing old image
-            let parent = this.context.getParentTypeAndId();
-            let oldPosition = Object.assign({}, this.image_config.position);
-            let oldSize = Object.assign({}, this.image_config.size);
-            this.context.removeImageConfig(this.image_config, true);
-            this.context.addImageConfig(image_id, parent.id, parent.type);
-            let selImgConf = this.context.getSelectedImageConfig();
-            if (selImgConf !== null) {
-                selImgConf.position = oldPosition;
-                selImgConf.size = oldSize;
-            }
+            this.context.onClicks(image_id, false, this.image_config);
         }
     }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1502,4 +1502,46 @@ export default class Ol3Viewer extends EventSubscriber {
             this.image_config.show_controls = false;
         }
     }
+
+    /**
+     * Handle dropping of a thumbnail on to the centre panel.
+     * Opens the image in Multi-Display mode
+     *
+     * @param {Object} event Drop event
+     */
+    handleDrop(event) {
+        // prevent event bubbling up to parent .frame
+        event.stopPropagation();
+
+        var image_id = parseInt(event.dataTransfer.getData("id"), 10);
+
+        // If we are not in multi-viewer mode, enter multi-viewer mode
+        if (!this.context.useMDI) {
+            // similar behaviour to double-clicking
+            this.context.useMDI = true;
+            this.context.onClicks(image_id, true);
+        } else {
+            // replace this image_config with new one
+            // NB: we don't check for unsaved ROIs before closing old image
+            let parent = this.context.getParentTypeAndId();
+            let oldPosition = Object.assign({}, this.image_config.position);
+            let oldSize = Object.assign({}, this.image_config.size);
+            this.context.removeImageConfig(this.image_config, true);
+            this.context.addImageConfig(image_id, parent.id, parent.type);
+            let selImgConf = this.context.getSelectedImageConfig();
+            if (selImgConf !== null) {
+                selImgConf.position = oldPosition;
+                selImgConf.size = oldSize;
+            }
+        }
+    }
+
+    /**
+     * Simply preventDefault() to allow drop here
+     *
+     * @param {Object} event Dragover event
+     */
+    handleDragover(event) {
+        event.preventDefault();
+    }
 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1510,6 +1510,7 @@ export default class Ol3Viewer extends EventSubscriber {
      * @param {Object} event Drop event
      */
     handleDrop(event) {
+        document.getElementById(this.image_config.id).classList.remove("drag_enter");
         // prevent event bubbling up to parent .frame
         event.stopPropagation();
 
@@ -1533,6 +1534,21 @@ export default class Ol3Viewer extends EventSubscriber {
      * @param {Object} event Dragover event
      */
     handleDragover(event) {
+        // Need preventDefault() to allow drop action
         event.preventDefault();
+        // Make sure ONLY this viewer has the 'drag_enter' class
+        // We don't use dragenter/leave events as they are too fickle
+        $(".viewer-mdi").removeClass("drag_enter");
+        document.getElementById(this.image_config.id).classList.add("drag_enter");
+    }
+
+    /**
+     * Simply preventDefault() to allow drop here
+     *
+     * @param {Object} event Dragover event
+     */
+    handleDragleave(event) {
+        // We don't use dragenter/leave events as they are too fickle
+        $(".viewer-mdi").removeClass("drag_enter");
     }
 }


### PR DESCRIPTION
Drag and drop a thumbnail onto centre panel to open image.

To test:
 - Drag a thumbnail into the centre panel of iviewer to perform same behaviour as double-clicking the thumbnail. You will enter multi-viewer mode (if you are not already in it)
 - If you are in multi-viewer mode, you can drag onto an existing viewer to replace the image there OR drag over the outer frame to open a new image viewer. See demo in https://twitter.com/will_j_moore/status/1093349075720626177



NB: Found some potential issues with current double-click behaviour (need to review in another PR):
If you have unsaved ROIs and you double-click or drag to open a different image to the one currently open, you will get a "Save ROIs" dialog etc. But, if you double-click or drag to open the *same* image that is currently open then you don't get a dialog until after the image has opened, so you have 2 viewers of the same image: the original one with unsaved ROIs and the new one with saved ROIs. This seems wrong to me, but the code and use-cases are quite convoluted so I don't want to start tackling that in this PR. Need to define supported workflows.
