### PR TITLE
Fix thumbnail panel scroll to selected image

### DIFF
--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -214,7 +214,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             // scroll to image thumb
             UI.scrollContainer(
                 'img-thumb-' + this.image_config.image_info.image_id,
-                '.thumbnail-panel');
+                '.thumbnail-scroll-panel');
             // no need to initialize twice
             return;
         }


### PR DESCRIPTION
To test:

 - Open an image within a Dataset with a bunch of images (so that the iviewer thumbnail panel has a reasonable scroll range)
 - Double-click to open multiple images in centre of iviewer
 - Scroll the thumbnail panel so that opened image(s) are no-longer visible
 - Select the image viewer - when selection changes, the thumbnail panel should scroll to show the selected image thumbnail.