### PR TITLE
Fix request params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Supported URLs
 ==============
 
 If you have configured OMERO.iviewer as your default viewer (see install) then
-double-clicking an Image in OMERO.webclient will open OMERO.iviewer as the OMERO.webclient viewer, passing the current Dataset if the Image is in a Dataset::
+double-clicking an Image in OMERO.web will open OMERO.iviewer as the OMERO.web viewer, passing the current Dataset if the Image is in a Dataset::
 
     /webclient/img_detail/1/?dataset=2
 

--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,12 @@ can be found in the `OMERO.iviewer README <plugin/omero_iviewer/README.rst>`_.
 Supported URLs
 ==============
 
-If you've configured OMERO.iviewer as your default viewer (see install) then
-double-clicking an Image in webclient will open iviewer as the webclient viewer,
-passing the current Dataset::
+If you have configured OMERO.iviewer as your default viewer (see install) then
+double-clicking an Image in OMERO.webclient will open OMERO.iviewer as the OMERO.webclient viewer, passing the current Dataset if the Image is in a Dataset::
 
     /webclient/img_detail/1/?dataset=2
 
-You use the webclient's 'Open with...' menu to open multiple selected Images
+You use the OMERO.webclient's 'Open with...' menu to open multiple selected Images
 or a Dataset or a Well in OMERO.iviewer directly::
 
     /iviewer/?images=1,2,3
@@ -66,7 +65,7 @@ You can also specify the rendering Model (greyscale or color) and
 Z-Projection (maximum intensity or normal)::
 
     ?m=g            # g for greyscale, c for color
-    ?p=intmax       # intmax for Maximum intensity normal for no projection
+    ?p=intmax       # intmax for Maximum intensity projection, normal for no projection
 
 The Z and/or T plane, X/Y center position and zoom can be defined by::
 

--- a/README.rst
+++ b/README.rst
@@ -62,13 +62,16 @@ first image, including channels in the form of ``index|start:end$colour``::
 
     ?c=1|100:600$00FF00,-2|0:1500$FF0000      # Channel -2 is off
 
-You can also specify the rendering Model (``?m=g`` for greyscale or ``?m=c``
-for color) and Z-Projection ``?p=intmax`` for Maximum intensity or ``?p=normal``.
+You can also specify the rendering Model (greyscale or colour) and
+Z-Projection (maximum intensity or normal)::
 
-The Z or T plane, X/Y position and zoom can be defined by::
+    ?m=g            # g for greyscale, c for colour
+    ?p=intmax       # intmax for Maximum intensity normal for no projection
+
+The Z and/or T plane, X/Y center position and zoom can be defined by::
 
     ?z=10&t=20          # can use z or t on their own
-    ?x=500&y=400        # need to specify x AND y to centre
+    ?x=500&y=400        # need to specify center with x AND y
     ?zm=100             # percent
 
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,37 @@ Install
 Instructions on how to add the OMERO.iviewer app to your installed OMERO.web apps
 can be found in the `OMERO.iviewer README <plugin/omero_iviewer/README.rst>`_.
 
+Supported URLs
+==============
+
+If you've configured OMERO.iviewer as your default viewer (see install) then
+double-clicking an Image in webclient will open iviewer as the webclient viewer,
+passing the current Dataset::
+
+    /webclient/img_detail/1/?dataset=2
+
+You use the webclient's 'Open with...' menu to open multiple selected Images
+or a Dataset or a Well in OMERO.iviewer directly::
+
+    /iviewer/?images=1,2,3
+    /iviewer/?dataset=4
+    /iviewer/?well=5
+
+Other query parameters can be used to set the rendering settings for the
+first image, including channels in the form of ``index|start:end$colour``::
+
+    ?c=1|100:600$00FF00,-2|0:1500$FF0000      # Channel -2 is off
+
+You can also specify the rendering Model (``?m=g`` for greyscale or ``?m=c``
+for color) and Z-Projection ``?p=intmax`` for Maximum intensity or ``?p=normal``.
+
+The Z or T plane, X/Y position and zoom can be defined by::
+
+    ?z=10&t=20          # can use z or t on their own
+    ?x=500&y=400        # need to specify x AND y to centre
+    ?zm=100             # percent
+
+
 Development
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,10 @@ For more details on testing, see https://github.com/ome/omero-iviewer/tree/maste
 Documentation
 =============
 
-To build the html in build/docs, run:
+A high-level description of the OMERO.iviewer application can be found at
+https://github.com/ome/omero-iviewer/tree/master/docs.
+
+To build the JavaScript code documentation in build/docs, run:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -58,14 +58,14 @@ or a Dataset or a Well in OMERO.iviewer directly::
     /iviewer/?well=5
 
 Other query parameters can be used to set the rendering settings for the
-first image, including channels in the form of ``index|start:end$colour``::
+first image, including channels in the form of ``index|start:end$color``::
 
     ?c=1|100:600$00FF00,-2|0:1500$FF0000      # Channel -2 is off
 
-You can also specify the rendering Model (greyscale or colour) and
+You can also specify the rendering Model (greyscale or color) and
 Z-Projection (maximum intensity or normal)::
 
-    ?m=g            # g for greyscale, c for colour
+    ?m=g            # g for greyscale, c for color
     ?p=intmax       # intmax for Maximum intensity normal for no projection
 
 The Z and/or T plane, X/Y center position and zoom can be defined by::

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -430,7 +430,7 @@ class Viewer extends OlObject {
         };
 
         // determine the center
-        var imgCenter = [dims['width'] / 2, -dims['height'] / 2];
+        var defaultImgCenter = [dims['width'] / 2, -dims['height'] / 2];
         // pixel size
         var pixelSize =
         typeof this.image_info_['pixel_size'] === "object" &&
@@ -446,37 +446,31 @@ class Viewer extends OlObject {
         });
 
         // we might have some requested defaults
-        var initialTime =
-        this.getInitialRequestParam(REQUEST_PARAMS.TIME);
-        initialTime =
-        initialTime !== null ? (parseInt(initialTime)-1) :
+        var initialTime = this.getInitialRequestParam(REQUEST_PARAMS.TIME);
+        initialTime = initialTime !== null ? (parseInt(initialTime)-1) :
         this.image_info_['rdefs']['defaultT'];
         if (initialTime < 0) initialTime = 0;
         if (initialTime >= dims.t) initialTime =  dims.t-1;
-        var initialPlane =
-        this.getInitialRequestParam(REQUEST_PARAMS.PLANE);
-        initialPlane =
-        initialPlane !== null ? (parseInt(initialPlane)-1) :
+        var initialPlane = this.getInitialRequestParam(REQUEST_PARAMS.PLANE);
+        initialPlane = initialPlane !== null ? (parseInt(initialPlane)-1) :
             this.image_info_['rdefs']['defaultZ'];
         if (initialPlane < 0) initialPlane = 0;
         if (initialPlane >= dims.z) initialPlane =  dims.z-1;
-        var initialCenterX =
-        this.getInitialRequestParam(REQUEST_PARAMS.CENTER_X);
-        var initialCenterY =
-        this.getInitialRequestParam(REQUEST_PARAMS.CENTER_Y);
+        var initialCenterX = this.getInitialRequestParam(REQUEST_PARAMS.CENTER_X);
+        var initialCenterY = this.getInitialRequestParam(REQUEST_PARAMS.CENTER_Y);
+        let imgCenter;
         if (initialCenterX && !isNaN(parseFloat(initialCenterX)) &&
-        initialCenterY && !isNaN(parseFloat(initialCenterY))) {
-        initialCenterX = parseFloat(initialCenterX);
-        initialCenterY = parseFloat(initialCenterY);
-        if (initialCenterY > 0) initialCenterY = -initialCenterY;
-        if (initialCenterX >=0 && initialCenterX <= dims['width'] &&
-            -initialCenterY >=0 && -initialCenterX <= dims['height'])
-        imgCenter = [initialCenterX, initialCenterY];
+                    initialCenterY && !isNaN(parseFloat(initialCenterY))) {
+            initialCenterX = parseFloat(initialCenterX);
+            initialCenterY = parseFloat(initialCenterY);
+            if (initialCenterY > 0) initialCenterY = -initialCenterY;
+            if (initialCenterX >=0 && initialCenterX <= dims['width'] &&
+                    -initialCenterY >=0 && -initialCenterX <= dims['height']) {
+                imgCenter = [initialCenterX, initialCenterY];
+            }
         }
-        var initialChannels =
-        this.getInitialRequestParam(REQUEST_PARAMS.CHANNELS);
-        var initialMaps =
-        this.getInitialRequestParam(REQUEST_PARAMS.MAPS);
+        var initialChannels = this.getInitialRequestParam(REQUEST_PARAMS.CHANNELS);
+        var initialMaps = this.getInitialRequestParam(REQUEST_PARAMS.MAPS);
         initialChannels = parseChannelParameters(initialChannels, initialMaps);
 
         // copy needed channels info
@@ -528,43 +522,45 @@ class Viewer extends OlObject {
         });
         source.changeChannelRange(initialChannels, false);
 
-        var actualZoom = zoom > 1 ? zoomLevelScaling[0] : 1;
-        var initialZoom =
-        this.getInitialRequestParam(REQUEST_PARAMS.ZOOM);
+        var defaultZoom = zoom > 1 ? zoomLevelScaling[0] : 1;
+        var actualZoom;
+        var initialZoom = this.getInitialRequestParam(REQUEST_PARAMS.ZOOM);
         var possibleResolutions = prepareResolutions(zoomLevelScaling);
         if (initialZoom && !isNaN(parseFloat(initialZoom))) {
-        initialZoom = (1 / (parseFloat(initialZoom) / 100));
-        var posLen = possibleResolutions.length;
-        if (posLen > 1) {
-            if (initialZoom >= possibleResolutions[0])
-                actualZoom = possibleResolutions[0];
-            else if (initialZoom <= possibleResolutions[posLen-1])
-                actualZoom = possibleResolutions[posLen-1];
-            else {
-                // find nearest resolution
-                for (var r=0;r<posLen-1;r++) {
-                    if (initialZoom < possibleResolutions[r+1])
-                        continue;
-                    var d1 =
-                        Math.abs(possibleResolutions[r] - initialZoom);
-                    var d2 =
-                        Math.abs(possibleResolutions[r+1] - initialZoom);
-                    if (d1 < d2)
-                        actualZoom = possibleResolutions[r];
-                    else actualZoom = possibleResolutions[r+1];
-                    break;
+            initialZoom = (1 / (parseFloat(initialZoom) / 100));
+            var posLen = possibleResolutions.length;
+            if (posLen > 1) {
+                if (initialZoom >= possibleResolutions[0])
+                    actualZoom = possibleResolutions[0];
+                else if (initialZoom <= possibleResolutions[posLen-1])
+                    actualZoom = possibleResolutions[posLen-1];
+                else {
+                    // find nearest resolution
+                    for (var r=0;r<posLen-1;r++) {
+                        if (initialZoom < possibleResolutions[r+1])
+                            continue;
+                        var d1 =
+                            Math.abs(possibleResolutions[r] - initialZoom);
+                        var d2 =
+                            Math.abs(possibleResolutions[r+1] - initialZoom);
+                        if (d1 < d2)
+                            actualZoom = possibleResolutions[r];
+                        else actualZoom = possibleResolutions[r+1];
+                        break;
+                    }
                 }
+            } else {
+                actualZoom = 1;
             }
-        } else actualZoom = 1;
         }
 
         // we need a View object for the map
         var view = new View({
             projection: proj,
-            center: imgCenter,
+            center: defaultImgCenter,
             extent: [0, -dims['height'], dims['width'], 0],
             resolutions : possibleResolutions,
-            resolution : actualZoom,
+            resolution : defaultZoom,
             maxZoom: possibleResolutions.length-1
         });
 
@@ -625,9 +621,10 @@ class Viewer extends OlObject {
         };
 
         // get cached initial viewer center etc.
-        if (this.image_info_['center'] || this.image_info_['resolution'] || this.image_info_['rotation']) {
-            let center = this.image_info_['center'];
-            let resolution = this.image_info_['resolution'];
+        if (this.image_info_['center'] || imgCenter || this.image_info_['resolution']
+                || this.image_info_['rotation'] || actualZoom) {
+            let center = this.image_info_['center'] || imgCenter;
+            let resolution = this.image_info_['resolution'] || actualZoom;
             let rotation = this.image_info_['rotation'];
             // Need to wait for viewer to be built before this works:
             setTimeout(function() {

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -463,11 +463,10 @@ class Viewer extends OlObject {
                     initialCenterY && !isNaN(parseFloat(initialCenterY))) {
             initialCenterX = parseFloat(initialCenterX);
             initialCenterY = parseFloat(initialCenterY);
-            if (initialCenterY > 0) initialCenterY = -initialCenterY;
-            if (initialCenterX >=0 && initialCenterX <= dims['width'] &&
-                    -initialCenterY >=0 && -initialCenterX <= dims['height']) {
-                imgCenter = [initialCenterX, initialCenterY];
-            }
+            // Restrict centre to within image bounds
+            initialCenterX = Math.min(Math.max(0, initialCenterX), dims['width']);
+            initialCenterY = Math.min(Math.max(0, initialCenterY), dims['height']);
+            imgCenter = [initialCenterX, -initialCenterY];
         }
         var initialChannels = this.getInitialRequestParam(REQUEST_PARAMS.CHANNELS);
         var initialMaps = this.getInitialRequestParam(REQUEST_PARAMS.MAPS);


### PR DESCRIPTION
See https://github.com/ome/omero-iviewer/issues/219

In looking to document the supported request parameters, I found that x, y and zoom weren't working.
This fixes that and documents their usage on the README.
See https://github.com/will-moore/omero-iviewer/tree/fix_request_params#supported-urls

To test: e.g. go to http://web-dev-merge.openmicroscopy.org/webclient/img_detail/160953/?dataset=27801&zm=50&x=25000&y=15000 (user-3):
 - Check that e.g. ```?x=200&y=500``` centres the image at those coordinates
 - Check that e.g. ```?zm=100``` sets the zoom for Big images and non-tiled images. (for Big images it may pick the closest supported zoom level)

Re: Also found bug in opening iviewer from webclient: https://github.com/openmicroscopy/openmicroscopy/pull/5953
