### PR TITLE
Add deployment to PyPI using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,10 @@ before_install:
 
 script:
   - .omero/docker app
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  on:
+    tags: true


### PR DESCRIPTION
See https://docs.travis-ci.com/user/deployment/pypi/ for more information

As we are nearing the release of OMERO.iviewer 0.7.0 (or pre-releases), this updates the Travis CI configuration to include PyPI deployment on tags. The matching environment variables have been set up in https://travis-ci.org/ome/omero-iviewer/.

See also https://github.com/ome/omero-cli-render/pull/25 and https://github.com/ome/omero-prometheus-tools/pull/6 