### PR TITLE
Fix click to select viewer

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -77,7 +77,7 @@
                         ';left:' + conf.position.left +
                         ';width:' + conf.size.width +
                         ';height:' + conf.size.height : ''}"
-                 mousedown.delegate="context.selectConfig(id)">
+                 click.delegate="context.selectConfig(id)">
                  <div class="config-linking"
                       show.bind="context.useMDI && context.image_configs.size > 1">
                      <div class="dropdown dropdown-image-config"


### PR DESCRIPTION
This fixes an issue noticed by @pwalczysko at https://github.com/ome/omero-iviewer/pull/233#issuecomment-463654086

To test:
 - In multi-viewer mode, clicking on a viewer anywhere is enough to select it (don't have to click on frame).