### PR TITLE
Roi tiles

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -642,24 +642,16 @@ thumbnail-slider img {
     flex: 0 0 auto;
 }
 
-/* Only contains .regions-list2 */
+/* Contains .pagination-controls, .regions-header and .regions-table */
 .regions-list {
     flex: 1 1 auto;
     float: left;
     overflow: hidden;
     width: 100%;
-    display: flex;
-    flex-direction: column;
-    position: relative;
-}
-
-/* Contains .pagination-controls, .regions-header and .regions-table */
-.regions-list2 {
-    position: relative;
     height: 100%;
-    overflow-y: auto;
     display: flex;
     flex-direction: column;
+    position: relative;
 }
 
 .pagination-controls {

--- a/css/app.css
+++ b/css/app.css
@@ -594,12 +594,27 @@ thumbnail-slider img {
     text-align: left;
 }
 
+/* Top-level container for right-hand-panel
+    Contains .nav-tabs (tabs) and .regions-tabs (content) */
 .right-hand-panel {
     width: 350px;
     max-width: 1000px;
     overflow-y: hidden;
     display: flex;
     flex-direction: column;
+}
+
+.nav-tabs {
+    background-color: #f8f8f8;
+    flex: 0 0 auto;
+}
+
+/* Container for each .tab-pane for tab content */
+.regions-tabs {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    position: relative;
+    height: 100%;
 }
 
 .tab-pane {
@@ -611,10 +626,68 @@ thumbnail-slider img {
     position: absolute;
 }
 
-.nav-tabs {
-    background-color: #f8f8f8;
+/* Main ROI tab. Contains .regions-tools and .regions-list */
+.regions-container {
+    height: 100%;
+    width: 100%;
+    min-width: 330px;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    position: relative;
+}
+
+.regions-tools {
+    width: 100%;
     flex: 0 0 auto;
 }
+
+/* Only contains .regions-list2 */
+.regions-list {
+    flex: 1 1 auto;
+    float: left;
+    overflow: hidden;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+/* Contains .pagination-controls, .regions-header and .regions-table */
+.regions-list2 {
+    position: relative;
+    height: 100%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.pagination-controls {
+    flex: 0 0 auto;
+}
+
+.regions-header {
+    position: relative;
+    flex: 0 0 auto;
+    width: 330px;
+    background-color: #fff;
+    height: 40px;
+    line-height: 36px;
+    font-weight: bold;
+    font-size: 13px;
+    border-bottom: solid #ddd 1px;
+    z-index: 1;
+}
+
+.regions-table {
+    flex: 1 1 auto;
+    border-collapse: collapse;
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
+    position: relative;
+}
+
 #settings {
     overflow-y: auto;
     overflow-x: hidden;
@@ -792,67 +865,6 @@ thumbnail-slider img {
 .user-setting img {
     max-width: 100px;
     max-height: 100px;
-}
-
-.regions-tabs {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    position: relative;
-    height: 100%;
-}
-
-.regions-container {
-    height: 100%;
-    width: 100%;
-    min-width: 330px;
-    display: flex;
-    flex-direction: column;
-    overflow-y: auto;
-    position: relative;
-}
-
-.regions-list {
-    flex: 1 1 auto;
-    float: left;
-    overflow: hidden;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    position: relative;
-}
-
-.regions-list2 {
-    position: relative;
-    height: 100%;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-}
-
-.pagination-controls {
-    flex: 0 0 auto;
-}
-
-.regions-header {
-    position: relative;
-    flex: 0 0 auto;
-    width: 330px;
-    background-color: #fff;
-    height: 40px;
-    line-height: 36px;
-    font-weight: bold;
-    font-size: 13px;
-    border-bottom: solid #ddd 1px;
-    z-index: 1;
-}
-
-.regions-table {
-    flex: 1 1 auto;
-    border-collapse: collapse;
-    overflow-y: auto;
-    overflow-x: hidden;
-    height: 100%;
-    position: relative;
 }
 
 .regions-table-row {
@@ -1034,10 +1046,6 @@ thumbnail-slider img {
 }
 .rois-dropdown, .regions-tools {
     float: left;
-}
-.regions-tools {
-    width: 100%;
-    flex: 0 0 auto;
 }
 
 .rois-dropdown>.dropdown-menu>li>a:hover,

--- a/css/app.css
+++ b/css/app.css
@@ -662,7 +662,6 @@ thumbnail-slider img {
 .regions-header {
     position: relative;
     flex: 0 0 auto;
-    width: 330px;
     background-color: #fff;
     height: 40px;
     line-height: 36px;
@@ -868,7 +867,9 @@ thumbnail-slider img {
     float: left;
     line-height: 25px;
     height: 25px;
-    width: 100%;
+    min-width: 100%;
+    display: flex;
+    flex-direction: row;
 }
 .regions-table-row * {
     height: 100%;
@@ -889,6 +890,7 @@ thumbnail-slider img {
     border-width: 0px 1px 0px 1px;
     font-size: 13px;
     overflow: hidden;
+    flex: 0 0 auto;
 }
 .loading-text {
     float: left;
@@ -899,34 +901,29 @@ thumbnail-slider img {
 }
 
 .roi-toggle {
-    min-width: 5%;
-    max-width: 5%;
+    width: 17px;
+}
+.shape-show {
+    width: 49px;
 }
 .shape-z, .shape-t, .shape-c {
-    min-width: 8%;
-    max-width: 8%;
+    width: 27px;
 }
 .shape-type {
-    min-width: 9%;
-    max-width: 9%;
+    width: 27px;
     background-repeat: no-repeat;
     background-position: center;
 }
 .shape-comment {
-    min-width: 47%;
-    max-width: 47%;
+    flex: 1 1 auto;
 }
 .shape-area {
-    min-width: 20%;
-    max-width: 20%;
+    width: 64px;
+    flex: 0 0 auto;
 }
 .shape-length {
-    min-width: 25%;
-    max-width: 25%;
-}
-.shape-show {
-    min-width: 15%;
-    max-width: 15%;
+    width: 80px;
+    flex: 0 0 auto;
 }
 
 .rectangle-icon {

--- a/css/app.css
+++ b/css/app.css
@@ -680,6 +680,10 @@ thumbnail-slider img {
     position: relative;
 }
 
+.roi_page_number {
+    width: 30px;
+}
+
 #settings {
     overflow-y: auto;
     overflow-x: hidden;

--- a/css/app.css
+++ b/css/app.css
@@ -623,6 +623,7 @@ thumbnail-slider img {
     background-color: #fff;
     overflow-y: auto;
     height: 100%;
+    width: 100%;
     position: absolute;
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -804,6 +804,7 @@ thumbnail-slider img {
 
 .regions-header {
     position: fixed;
+    width: 330px;
     background-color: #fff;
     height: 40px;
     line-height: 36px;

--- a/css/app.css
+++ b/css/app.css
@@ -598,15 +598,22 @@ thumbnail-slider img {
     width: 350px;
     max-width: 1000px;
     overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .tab-pane {
     padding: 10px;
+    padding-bottom: 0;
     background-color: #fff;
+    overflow-y: auto;
+    height: 100%;
+    position: absolute;
 }
 
 .nav-tabs {
     background-color: #f8f8f8;
+    flex: 0 0 auto;
 }
 #settings {
     overflow-y: auto;
@@ -787,23 +794,48 @@ thumbnail-slider img {
     max-height: 100px;
 }
 
-.regions-tabs, .regions-tabs .tab-pane, .regions-container {
+.regions-tabs {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    position: relative;
     height: 100%;
 }
+
 .regions-container {
+    height: 100%;
     width: 100%;
     min-width: 330px;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    position: relative;
 }
 
 .regions-list {
+    flex: 1 1 auto;
     float: left;
     overflow: hidden;
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+.regions-list2 {
+    position: relative;
     height: 100%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.pagination-controls {
+    flex: 0 0 auto;
 }
 
 .regions-header {
-    position: fixed;
+    position: relative;
+    flex: 0 0 auto;
     width: 330px;
     background-color: #fff;
     height: 40px;
@@ -815,16 +847,12 @@ thumbnail-slider img {
 }
 
 .regions-table {
+    flex: 1 1 auto;
     border-collapse: collapse;
     overflow-y: auto;
     overflow-x: hidden;
     height: 100%;
     position: relative;
-}
-
-.regions-table .regions-table-first-row {
-    line-height: 36px;
-    height: 40px;
 }
 
 .regions-table-row {
@@ -1009,6 +1037,7 @@ thumbnail-slider img {
 }
 .regions-tools {
     width: 100%;
+    flex: 0 0 auto;
 }
 
 .rois-dropdown>.dropdown-menu>li>a:hover,

--- a/plugin/omero_iviewer/iviewer_settings.py
+++ b/plugin/omero_iviewer/iviewer_settings.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Settings for the OMERO.iviewer app."""
+
+import sys
+from omeroweb.settings import process_custom_settings, report_settings
+
+# load settings
+IVIEWER_SETTINGS_MAPPING = {
+
+    "omero.web.iviewer.roi_page_size":
+        ["ROI_PAGE_SIZE",
+         500,
+         int,
+         "Page size for ROI pagination."],
+}
+
+process_custom_settings(sys.modules[__name__], 'IVIEWER_SETTINGS_MAPPING')
+report_settings(sys.modules[__name__])

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -45,4 +45,6 @@ urlpatterns = patterns(
     url(r'^shapes_by_region/(?P<image_id>[0-9]+)/'
         r'(?P<the_z>[0-9]+)/(?P<the_t>[0-9]+)/$', views.shapes_by_region,
         name='omero_iviewer_shapes_by_region'),
+    url(r'^all_roi_ids/(?P<image_id>[0-9]+)/$', views.all_roi_ids,
+        name='omero_iviewer_all_roi_ids'),
 )

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -42,4 +42,7 @@ urlpatterns = patterns(
         r'(?P<the_z>[0-9]+)(?:-(?P<z_end>[0-9]+))?/'
         r'(?P<the_t>[0-9:]+)(?:-(?P<t_end>[0-9]+))?/$',
         views.rois_by_plane, name='omero_iviewer_rois_by_plane'),
+    url(r'^shapes_by_region/(?P<image_id>[0-9]+)/'
+        r'(?P<the_z>[0-9]+)/(?P<the_t>[0-9]+)/$', views.shapes_by_region,
+        name='omero_iviewer_shapes_by_region'),
 )

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -36,4 +36,8 @@ urlpatterns = patterns(
     url(r'^get_intensity/?$', views.get_intensity,
         name='omero_iviewer_get_intensity'),
     url(r'^shape_stats/?$', views.shape_stats,
-        name='omero_iviewer_shape_stats'))
+        name='omero_iviewer_shape_stats'),
+    url(r'^rois_by_plane/(?P<image_id>[0-9]+)/'
+        r'(?P<the_z>[0-9]+)/(?P<the_t>[0-9]+)/$', views.rois_by_plane,
+        name='omero_iviewer_rois_by_plane'),
+)

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -37,7 +37,9 @@ urlpatterns = patterns(
         name='omero_iviewer_get_intensity'),
     url(r'^shape_stats/?$', views.shape_stats,
         name='omero_iviewer_shape_stats'),
+    # optional z or t range e.g. iid/0-10/2-5/
     url(r'^rois_by_plane/(?P<image_id>[0-9]+)/'
-        r'(?P<the_z>[0-9]+)/(?P<the_t>[0-9]+)/$', views.rois_by_plane,
-        name='omero_iviewer_rois_by_plane'),
+        r'(?P<the_z>[0-9]+)(?:-(?P<z_end>[0-9]+))?/'
+        r'(?P<the_t>[0-9:]+)(?:-(?P<t_end>[0-9]+))?/$',
+        views.rois_by_plane, name='omero_iviewer_rois_by_plane'),
 )

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -361,6 +361,21 @@ def shapes_by_region(request, image_id, the_z, the_t, conn=None, **kwargs):
 
 
 @login_required()
+def all_roi_ids(request, image_id, conn=None, **kwargs):
+    """
+    Return all the ROI IDs for an Image, sorted by ID.
+    This allows iviewer to know which page of ROIs a particular ROI is on.
+    """
+    qs = conn.getQueryService()
+    params = omero.sys.ParametersI()
+    params.addId(image_id)
+    query = """select roi.id from Roi roi where roi.image.id = :id
+        order by roi.id"""
+    iids = [i[0].val for i in qs.projection(query, params)]
+    return JsonResponse({"data": iids})
+
+
+@login_required()
 def image_data(request, image_id, conn=None, **kwargs):
 
     image = conn.getObject("Image", image_id)

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -39,8 +39,13 @@ import omero.util.pixelstypetopython as pixelstypetopython
 from version import __version__
 from omero_version import omero_version
 
+from . import iviewer_settings
+
 WEB_API_VERSION = 0
 MAX_LIMIT = max(1, API_MAX_LIMIT)
+
+ROI_PAGE_SIZE = getattr(iviewer_settings, 'ROI_PAGE_SIZE')
+ROI_PAGE_SIZE = min(MAX_LIMIT, ROI_PAGE_SIZE)
 
 PROJECTIONS = {
     'normal': -1,
@@ -77,6 +82,7 @@ def index(request, iid=None, conn=None, **kwargs):
         'api_base', kwargs={'api_version': WEB_API_VERSION})
     if settings.FORCE_SCRIPT_NAME is not None:
         params['URI_PREFIX'] = settings.FORCE_SCRIPT_NAME
+    params['ROI_PAGE_SIZE'] = ROI_PAGE_SIZE
 
     return render(
         request, 'omero_iviewer/index.html',

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -206,6 +206,7 @@ def persist_rois(request, conn=None, **kwargs):
 
     return JsonResponse(ret)
 
+
 @login_required()
 def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
                   conn=None, **kwargs):
@@ -275,7 +276,7 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
         if encoder is not None:
             marshalled.append(encoder.encode(r))
 
-    return JsonResponse({'data': marshalled, 'meta': meta});
+    return JsonResponse({'data': marshalled, 'meta': meta})
 
 
 @login_required()

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -210,23 +210,21 @@ def persist_rois(request, conn=None, **kwargs):
 def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
                   conn=None, **kwargs):
     """
-    Get ROIs with Shapes where Shapes are on the specified Z and T plane.
+    Get ROIs with all Shapes where any Shapes are on the given Z and T plane.
 
     Includes Shapes where Z or T are null.
-    If z_end or t_end are not None, we get all Shapes within the
+    If z_end or t_end are not None, we filter by any shape within the
     range (inclusive of z/t_end)
     """
 
+    # First load ALL ROIs (no pagination) filtering by Z/T to get totalCount
+    # NB: IF we tried to load shapes here we'd get None for shapes
+    # that weren't on the correct Z/T plane
     params = omero.sys.ParametersI()
     params.addId(image_id)
-    filter = omero.sys.Filter()
-    filter.offset = rint(request.GET.get("offset", 0))
-    filter.limit = rint(request.GET.get("limit", 1000))
-    params.theFilter = filter
 
     where_z = "shapes.theZ = %s or shapes.theZ is null" % the_z
     where_t = "shapes.theT = %s or shapes.theT is null" % the_t
-
     if z_end is not None:
         where_z = """(shapes.theZ >= %s and shapes.theZ <= %s)
             or shapes.theZ is null""" % (the_z, z_end)
@@ -235,30 +233,40 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
             or shapes.theT is null""" % (the_t, t_end)
 
     query = """
-        select roi from Roi roi
-        join fetch roi.details.owner as owner
-        join fetch roi.details.creationEvent
-        left outer join fetch roi.shapes as shapes
+        select distinct(roi) from Roi roi
+        join roi.shapes as shapes
         where (%s) and (%s)
-        and roi.image.id = :id order by roi.id""" % (where_z, where_t)
+        and roi.image.id = :id order by roi.id
+    """ % (where_z, where_t)
 
     query_service = conn.getQueryService()
     rois = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+    roi_ids = [roi.id for roi in rois]
 
+    # Now we load ROIs with ALL their shapes loaded (even shapes that
+    # are not on the_z or the_t we filtered by above)
+    params = omero.sys.ParametersI()
+    params.addIds(roi_ids)
+    filter = omero.sys.Filter()
+    filter.offset = rint(request.GET.get("offset", 0))
+    filter.limit = rint(request.GET.get("limit", 1000))
+    params.theFilter = filter
+
+    query = """
+        select roi from Roi roi
+        join fetch roi.details.owner join fetch roi.details.creationEvent
+        left outer join fetch roi.shapes
+        where roi.id in (:ids)
+    """
+
+    rois = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
     marshalled = []
     for r in rois:
         encoder = omero_marshal.get_encoder(r.__class__)
         if encoder is not None:
             marshalled.append(encoder.encode(r))
 
-    # Modify query to only select count() and NOT paginate
-    query = query.replace("select roi ", "select count(distinct roi) ")
-    query = query.replace("fetch", "")
-    query = query.split("order by")[0]
-    params = omero.sys.ParametersI()
-    params.addId(image_id)
-    result = query_service.projection(query, params, conn.SERVICE_OPTS)
-    meta = {"totalCount": result[0][0].val}
+    meta = {"totalCount": len(roi_ids)}
 
     return JsonResponse({'data': marshalled, 'meta': meta});
 

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -260,10 +260,6 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
     # are not on the_z or the_t we filtered by above)
     params = omero.sys.ParametersI()
     params.addIds(roi_ids)
-    filter = omero.sys.Filter()
-    filter.offset = rint(request.GET.get("offset", 0))
-    filter.limit = rint(request.GET.get("limit", 1000))
-    params.theFilter = filter
 
     query = """
         select roi from Roi roi

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -24,7 +24,7 @@ import ImageInfo from '../model/image_info';
 import RegionsInfo from '../model/regions_info';
 import {
     IMAGE_SETTINGS_REFRESH, IMAGE_VIEWER_CONTROLS_VISIBILITY,
-    SAVE_ACTIVE_IMAGE_SETTINGS, THUMBNAILS_UPDATE
+    THUMBNAILS_UPDATE
 } from '../events/events';
 import {
     APP_NAME, IMAGE_CONFIG_RELOAD, IVIEWER, INITIAL_TYPES, LUTS_NAMES,
@@ -434,6 +434,7 @@ export default class Context {
                 this.initParams[REQUEST_PARAMS.INTERPOLATE].toLowerCase() : 'true';
         this.interpolate = (interpolate === 'true');
         this.version = this.getInitialRequestParam(REQUEST_PARAMS.VERSION);
+        this.roi_page_size = this.initParams[REQUEST_PARAMS.ROI_PAGE_SIZE] || 500;
     }
 
     /**

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -24,7 +24,7 @@ import ImageInfo from '../model/image_info';
 import RegionsInfo from '../model/regions_info';
 import {
     IMAGE_SETTINGS_REFRESH, IMAGE_VIEWER_CONTROLS_VISIBILITY,
-    THUMBNAILS_UPDATE
+    SAVE_ACTIVE_IMAGE_SETTINGS, THUMBNAILS_UPDATE
 } from '../events/events';
 import {
     APP_NAME, IMAGE_CONFIG_RELOAD, IVIEWER, INITIAL_TYPES, LUTS_NAMES,

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -76,7 +76,8 @@ export class RightHandPanel {
                 this.context, 'selected_config').subscribe(
                     (newValue, oldValue) => {
                         this.image_config = this.context.getSelectedImageConfig();
-                        // In multi-view mode, may need to load ROIs for selected image
+                        // If multi-view mode (image data is already loaded),
+                        // may need to load ROIs for selected image.
                         this.makeInitialRoisRequestIfRoisTabIsActive();
                 });
     }
@@ -113,13 +114,18 @@ export class RightHandPanel {
 
     /**
      * Requests rois if tab is active and rois have not yet been requested
+     * and image_info is ready.
      *
      * @memberof RightHandPanel
      */
     makeInitialRoisRequestIfRoisTabIsActive() {
-        // we don't allow an active regions tab if we are in spit view
         if (this.context.isRoisTabActive()) {
+            // If image_info is not yet ready (still loading) then ROIs will be
+            // requested when image_info is loaded. We don't want to load ROIs
+            // before image_info since we won't know image_info.roi_count
+            // (don't know if we need to paginate ROIs)
             if (this.image_config === null ||
+                !this.image_config.image_info.ready ||
                 this.image_config.regions_info === null) return;
 
             this.image_config.regions_info.requestData();

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -75,9 +75,7 @@ export class RightHandPanel {
             this.bindingEngine.propertyObserver(
                 this.context, 'selected_config').subscribe(
                     (newValue, oldValue) => {
-                        this.image_config =
-                            this.context.getSelectedImageConfig();
-                        this.makeInitialRoisRequestIfRoisTabIsActive();
+                        this.image_config = this.context.getSelectedImageConfig();
                 });
     }
 

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -76,6 +76,8 @@ export class RightHandPanel {
                 this.context, 'selected_config').subscribe(
                     (newValue, oldValue) => {
                         this.image_config = this.context.getSelectedImageConfig();
+                        // In multi-view mode, may need to load ROIs for selected image
+                        this.makeInitialRoisRequestIfRoisTabIsActive();
                 });
     }
 

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -19,6 +19,7 @@
 import Context from '../app/context';
 import {inject,customElement, bindable, BindingEngine} from 'aurelia-framework';
 import Misc from '../utils/misc';
+import Ui from '../utils/ui';
 import {UNTILED_RETRIEVAL_LIMIT} from '../viewers/viewer/globals';
 import {slider} from 'jquery-ui/ui/widgets/slider';
 import {PROJECTION} from '../utils/constants';
@@ -332,6 +333,13 @@ export default class DimensionSlider {
             options.change =
                 (event, ui) => {
                     if (event.originalEvent) {
+                        if (!this.checkForUnsavedRoiLoss()) {
+                            // reset the slider position
+                            $(this.elSelector).slider(
+                                {values: [imgInf.projection_opts.start,
+                                          imgInf.projection_opts.end]});
+                            return;
+                        }
                         this.add_projection_history = true;
                         imgInf.projection_opts.synced = false;
                         this.changeProjection(ui.values);
@@ -344,8 +352,15 @@ export default class DimensionSlider {
         } else {
             options.value = imgInf.dimensions[this.dim];
             options.change =
-                (event, ui) => this.onChange(ui.value,
-                                    event.originalEvent ? true : false);
+                (event, ui) => {
+                    // If slider event from user, check for unsaved ROIs
+                    if (event.originalEvent && !this.checkForUnsavedRoiLoss()) {
+                        // reset the slider position
+                        $(this.elSelector).slider({value: imgInf.dimensions[this.dim]});
+                        return;
+                    }
+                    this.onChange(ui.value, event.originalEvent ? true : false);
+                }
         }
 
         $(this.elSelector).slider(options);
@@ -454,6 +469,9 @@ export default class DimensionSlider {
                                         this.player_info.forwards)) {
             return;
         }
+        if (!this.checkForUnsavedRoiLoss()) {
+            return;
+        }
 
         let imgInf = this.image_config.image_info;
         imgInf.projection_opts.start = 0;
@@ -488,5 +506,24 @@ export default class DimensionSlider {
     getZProjectionDisabled(handle, forwards) {
         let dims = this.image_config.image_info.dimensions;
         return (handle !== null && forwards || (dims.max_x * dims.max_y) > UNTILED_RETRIEVAL_LIMIT);
+    }
+
+    /**
+     * Any change in Z/T or projection will cause ROIs to reload if we are
+     * paginating ROIs by Z/T plane.
+     * Returns true if we are paginating ROIs by plane AND we have unsaved
+     * changes to ROIs.
+     */
+    checkForUnsavedRoiLoss() {
+        if (this.image_config.regions_info.isRoiLoadingPaginatedByPlane() &&
+                this.image_config.regions_info.hasBeenModified()) {
+            Ui.showModalMessage(
+                "You have unsaved ROI changes. Please Save or Undo " +
+                "before moving to a new plane.",
+                "OK");
+            return false;
+        } else {
+            return true;
+        }
     }
 }

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -442,7 +442,9 @@ export default class DimensionSlider {
      * @memberof DimensionSlider
      */
     onArrowClick(step) {
-        if (this.player_info.handle !== null) return;
+        if (this.player_info.handle !== null || !this.checkForUnsavedRoiLoss()) {
+            return;
+        }
         let oldVal = $(this.elSelector).slider('value');
         $(this.elSelector).slider('value',  oldVal + step);
     }

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -54,6 +54,8 @@ export const REGIONS_CHANGE_MODES = "REGIONS_CHANGE_MODES";
 export const REGIONS_SHOW_COMMENTS = "REGIONS_SHOW_COMMENTS";
 /** whenever shapes ought to be generated */
 export const REGIONS_GENERATE_SHAPES = "REGIONS_GENERATE_SHAPES";
+/** whenever shape selected from TiledRegions to create new shape on Regions layer */
+export const REGIONS_GENERATE_SHAPES_FROM_TILED = "REGIONS_GENERATE_SHAPES_FROM_TILED";
 /** whenever shapes are stored */
 export const REGIONS_STORE_SHAPES = "REGIONS_STORE_SHAPES";
 /** after modified/new/deleted shapes were stored */

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -42,6 +42,8 @@ export const IMAGE_VIEWPORT_CAPTURE = "IMAGE_VIEWPORT_CAPTURE";
 export const REGIONS_SET_PROPERTY = "REGIONS_SET_PROPERTY";
 /** whenever a region property change is received, e.g. selection, modification */
 export const REGIONS_PROPERTY_CHANGED = "REGIONS_PROPERTY_CHANGED";
+/** sometimes handle property change differently from Tiled Regions e.g. selection */
+export const TILED_REGIONS_PROPERTY_CHANGED = "TILED_REGIONS_PROPERTY_CHANGED";
 /** whenever a new shape has been drawn */
 export const REGIONS_DRAW_SHAPE = "REGIONS_DRAW_SHAPE";
 /** whenever a new shape has been generated/drawn */

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -33,7 +33,8 @@
         window.INITIAL_REQUEST_PARAMS = {
                 'VERSION': "DEV_SERVER",
                 'WEB_API_BASE': 'api/v0/',
-                'IMAGES': "4420",   // "4420" // "73537",
+                'ROI_PAGE_SIZE': 500,
+                'IMAGES': "79833",   // "4420" // "73537",
                 // 'DATASET': "1",
                 //'WELL': "1"
         };

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -25,7 +25,7 @@ import {
 } from '../events/events';
 import {
     IVIEWER, REGIONS_DRAWING_MODE, REGIONS_MODE, REGIONS_REQUEST_URL,
-    WEB_API_BASE, REGIONS_PAGE_SIZE,
+    WEB_API_BASE,
 } from '../utils/constants';
 
 /**
@@ -56,6 +56,15 @@ export default class RegionsInfo  {
      * @type {Map}
      */
     data = new Map();
+
+    /**
+     * Page size for ROIs to support pagination.
+     * Configured with bin/omero config set omero.web.iviewer.roi_page_size 500
+     *
+     * @memberof RegionsInfo
+     * @type {number}
+     */
+    roi_page_size = 500;
 
     /**
      * Current page number of ROIs to support pagination
@@ -183,6 +192,8 @@ export default class RegionsInfo  {
         this.syncCopiedShapesWithLocalStorage();
         // init default shape colors
         this.resetShapeDefaults();
+
+        this.roi_page_size = this.image_info.context.roi_page_size;
     }
 
     /**
@@ -292,17 +303,17 @@ export default class RegionsInfo  {
      * on current plane.
      */
     getPageCount() {
-        return Math.ceil(this.roi_count_on_current_plane/REGIONS_PAGE_SIZE);
+        return Math.ceil(this.roi_count_on_current_plane/this.roi_page_size);
     }
 
     /**
-     * If the total number of ROIs is more than REGIONS_PAGE_SIZE,
+     * If the total number of ROIs is more than this.roi_page_size,
      * we load ROIs by Z/T plane.
-     * If there are still more on a plane than REGIONS_PAGE_SIZE then we
+     * If there are still more on a plane than this.roi_page_size then we
      * paginate within a plane.
      */
     isRoiLoadingPaginatedByPlane() {
-        return this.image_info.roi_count > REGIONS_PAGE_SIZE;
+        return this.image_info.roi_count > this.roi_page_size;
     }
 
     /**
@@ -334,8 +345,8 @@ export default class RegionsInfo  {
                 '&';
         }
 
-        url += 'limit=' + REGIONS_PAGE_SIZE +
-                '&offset=' + (this.roi_page_number * REGIONS_PAGE_SIZE);
+        url += 'limit=' + this.roi_page_size +
+                '&offset=' + (this.roi_page_number * this.roi_page_size);
         return url;
     }
 

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -275,7 +275,8 @@ export default class RegionsInfo  {
     setPageAndReload(zeroBasedPageNumber) {
         if (typeof(zeroBasedPageNumber) !== "number" ||
             zeroBasedPageNumber < 0 ||
-            zeroBasedPageNumber >= this.getPageCount()) return;
+            zeroBasedPageNumber >= this.getPageCount() ||
+            this.is_pending) return;
 
         this.roi_page_number = zeroBasedPageNumber;
         this.requestData(true);

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -75,6 +75,11 @@ export default class RegionsInfo  {
     number_of_shapes = 0;
 
     /**
+     * When we load ROIs by Z/T plane, we also get the total count
+     */
+    roi_count_on_current_plane = 0;
+
+    /**
      * @memberof RegionsInfo
      * @type {RegionsHistory}
      */
@@ -286,7 +291,7 @@ export default class RegionsInfo  {
      * Get the number of pages needed to show all paginated ROIs
      */
     getPageCount() {
-        return Math.ceil(this.image_info.roi_count/REGIONS_PAGE_SIZE);
+        return Math.ceil(this.roi_count_on_current_plane/REGIONS_PAGE_SIZE);
     }
 
     /**
@@ -305,12 +310,15 @@ export default class RegionsInfo  {
         // send request
         $.ajax({
             url : this.image_info.context.server +
-                  this.image_info.context.getPrefixedURI(WEB_API_BASE) +
-                  REGIONS_REQUEST_URL + '/?image=' + this.image_info.image_id +
-                  '&limit=' + REGIONS_PAGE_SIZE +
+                  this.image_info.context.getPrefixedURI(IVIEWER) +
+                  '/rois_by_plane/' + this.image_info.image_id + '/' +
+                  this.image_info.dimensions.z + '/' +
+                  this.image_info.dimensions.t + '/' +
+                  '?limit=' + REGIONS_PAGE_SIZE +
                   '&offset=' + (this.roi_page_number * REGIONS_PAGE_SIZE),
             success : (response) => {
-                if (this.is_pending) this.setData(response.data)
+                if (this.is_pending) this.setData(response.data);
+                this.roi_count_on_current_plane = response.meta.totalCount;
             }, error : (error) => {
                 this.is_pending = false;
                 console.error("Failed to load Rois: " + error)

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -439,6 +439,7 @@ export default class RegionsInfo  {
             this.data.clear();
         }
         this.number_of_shapes = 0;
+        this.selected_shapes = [];
     }
 
     /**

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -307,12 +307,23 @@ export default class RegionsInfo  {
         this.resetRegionsInfo();
         this.is_pending = true;
 
+        let z_start = this.image_info.dimensions.z;
+        let z_end;
+        if (this.image_info.projection && this.image_info.projection != "normal") {
+            if (this.image_info.projection_opts.start) {
+                z_start = this.image_info.projection_opts.start;
+            }
+            if (this.image_info.projection_opts.end) {
+                z_end = this.image_info.projection_opts.end;
+            }
+        }
+
         // send request
         $.ajax({
             url : this.image_info.context.server +
                   this.image_info.context.getPrefixedURI(IVIEWER) +
                   '/rois_by_plane/' + this.image_info.image_id + '/' +
-                  this.image_info.dimensions.z + '/' +
+                  z_start + (z_end ? '-' + z_end : '') + '/' +
                   this.image_info.dimensions.t + '/' +
                   '?limit=' + REGIONS_PAGE_SIZE +
                   '&offset=' + (this.roi_page_number * REGIONS_PAGE_SIZE),

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -330,6 +330,18 @@ export default class RegionsInfo  {
     }
 
     /**
+     * If the total number of ROIs is more than this.roi_page_size,
+     * AND we have a single-plane image,
+     * then we load ROIs by Tile onto the image instead of loading them
+     * into the ROI table first.
+     */
+    isRoiLoadingByTile() {
+        return (this.isRoiLoadingPaginatedByPlane() &&
+            this.image_info.dimensions.max_t === 1 &&
+            this.image_info.dimensions.max_z === 1);
+    }
+
+    /**
      * Get the URL for loading ROIs.
      * If isRoiLoadingPaginatedByPlane() then we filter by Z/T plane
      */
@@ -385,12 +397,11 @@ export default class RegionsInfo  {
         this.is_pending = true;
 
         // if lots of ROIs on a single plane, don't load ROIs (use tiled regions)
-        if (this.isRoiLoadingPaginatedByPlane() &&
-            this.image_info.dimensions.max_t === 1 && this.image_info.dimensions.max_z === 1) {
-                this.ready = true;
-                this.is_pending = false;
-                return;
-            }
+        if (this.isRoiLoadingByTile()) {
+            this.ready = true;
+            this.is_pending = false;
+            return;
+        }
 
         // send request
         $.ajax({

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -281,7 +281,7 @@ export default class RegionsInfo  {
         if (typeof(zeroBasedPageNumber) !== "number" ||
             zeroBasedPageNumber < 0 ||
             zeroBasedPageNumber >= this.getPageCount() ||
-            this.is_pending) return;
+            this.is_pending) return false;
 
         this.roi_page_number = zeroBasedPageNumber;
         this.requestData(true);

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -384,6 +384,14 @@ export default class RegionsInfo  {
         this.resetRegionsInfo();
         this.is_pending = true;
 
+        // if lots of ROIs on a single plane, don't load ROIs (use tiled regions)
+        if (this.isRoiLoadingPaginatedByPlane() &&
+            this.image_info.dimensions.max_t === 1 && this.image_info.dimensions.max_z === 1) {
+                this.ready = true;
+                this.is_pending = false;
+                return;
+            }
+
         // send request
         $.ajax({
             url : this.getRegionsUrl(),

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -371,7 +371,6 @@ export default class RegionsInfo  {
                 }
             }
             this.number_of_shapes = count;
-            this.image_info.roi_count = this.data.size;
             this.tmp_data = data;
         } catch(err) {
             console.error("Failed to sync Rois: " + err);

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -299,6 +299,19 @@ export default class RegionsInfo  {
     }
 
     /**
+     * Find the page that the specified ROI is on and load this page
+     *
+     * @memberof RegionsInfo
+     * @param {number} roi_id
+     */
+    loadRoisPageContainingRoi(roi_id) {
+        if (!this.all_roi_ids || typeof(roi_id) !== "number") return;
+
+        let page = parseInt(this.all_roi_ids.indexOf(roi_id)/this.roi_page_size);
+        this.setPageAndReload(page);
+    }
+
+    /**
      * Get the number of pages needed to show all paginated ROIs
      * on current plane.
      */
@@ -386,6 +399,32 @@ export default class RegionsInfo  {
             }, error : (error) => {
                 this.is_pending = false;
                 console.error("Failed to load Rois: " + error)
+            }
+        });
+
+        // If we don't have all ROI IDs in hand yet, load them for page indexing
+        this.requestAllRoiIdsForPageIndex();
+
+    }
+
+    /**
+     * Load all the ROI IDs for the image so that we can look up which page
+     * a particular ROI is on.
+     */
+    requestAllRoiIdsForPageIndex() {
+        // Only needed if we're paginating.
+        // TODO: *Actually* only needed if a single plane has > roi_page_size
+        if (!this.isRoiLoadingPaginatedByPlane()) return;
+        // check if already loaded
+        if (this.all_roi_ids) return;
+        $.ajax({
+            url : this.image_info.context.server +
+                  this.image_info.context.getPrefixedURI(IVIEWER) +
+                  '/all_roi_ids/' + this.image_info.image_id + '/',
+            success : (response) => {
+                this.all_roi_ids = response.data;
+            }, error : (error) => {
+                console.error("Failed to load AllRoiIdsForPageIndex: " + error)
             }
         });
     }

--- a/src/regions/regions-drawing.html
+++ b/src/regions/regions-drawing.html
@@ -19,6 +19,7 @@
 <template>
     <div class="row regions-drawing">
         <div class="draw-icons draw-select-icon
+                    ${regions_info.is_pending ? 'disabled-color' : ''}
                     ${regions_info.shape_to_be_drawn === null ?
                         'draw-active' : 'draw-inactive'}"
              title="Select shape(s)"
@@ -27,6 +28,7 @@
         </div>
         <div repeat.for="shape of supported_shapes"
             class="draw-icons draw-${shape}-icon
+                ${regions_info.is_pending ? 'disabled-color' : ''}
                 ${regions_info.shape_to_be_drawn === shape ?
                     'draw-active' : 'draw-inactive'}"
             click.delegate="onDrawShape($index)"

--- a/src/regions/regions-drawing.js
+++ b/src/regions/regions-drawing.js
@@ -281,6 +281,9 @@ export default class RegionsDrawing extends EventSubscriber {
      * @param {number} index the index matching an entry in the supported_shapes array
      */
     onDrawShape(index) {
+        if (this.regions_info.is_pending) {
+            return;
+        }
         // combined abort (index = -1) and bounds check
         let abort = false;
         if (index < 0 || index >= this.supported_shapes.length) {

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -826,6 +826,11 @@ export default class RegionsEdit extends EventSubscriber {
         let showDeleteDisabled =
                 (this.regions_info.selected_shapes.length >= 1 && !canDelete);
 
+        if (this.regions_info.is_pending) {
+            showEditDisabled = true;
+            showDeleteDisabled = true;
+        }
+
         // break up adjustment into individual sections
         this.adjustCommentEdit(canEdit, showEditDisabled);
         this.adjustAttachmentEdit(canEdit, showEditDisabled);

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -675,8 +675,8 @@ export default class RegionsEdit extends EventSubscriber {
      * @memberof RegionsEdit
      */
     adjustStrokeEdit(canDo=false, showDisabled=true) {
-        let type =
-            this.last_selected ? this.last_selected.type.toLowerCase() : null;
+        let type = (this.last_selected && this.last_selected.type) ?
+                this.last_selected.type.toLowerCase() : null;
 
         let strokeOptions =
             this.getColorPickerOptions(false, this.last_selected);

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -604,8 +604,10 @@ export default class RegionsEdit extends EventSubscriber {
                                 respectiveDimensionInput.prop("disabled", false);
                     }
                     if (showDisabled) {
+                        respectiveDimensionInput.prop('disabled', true);
                         respectiveDimensionInput.attr(
                             "title", PERMISSION_TOOLTIPS.CANNOT_EDIT);
+                        respectiveAttachementLock.addClass("disabled-color");
                         respectiveAttachementLock.attr(
                             "title", PERMISSION_TOOLTIPS.CANNOT_EDIT);
                     }

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -18,7 +18,12 @@
 <template>
         <div if.bind="regions_info.image_info.roi_count > regions_info.roi_page_size"
             class="pagination-controls">
-            Current Z/T plane has ${ regions_info.roi_count_on_current_plane } ROIs
+            <span if.bind="regions_info.isRoiLoadingByTile()">
+                Click ROIs on the image to show below
+            </span>
+            <span if.bind="!regions_info.isRoiLoadingByTile()">
+                Current Z/T plane has ${ regions_info.roi_count_on_current_plane } ROIs
+            </span>
         </div>
         <div if.bind="regions_info.roi_count_on_current_plane > regions_info.roi_page_size"
             class="pagination-controls">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -17,10 +17,10 @@
 -->
 <template>
     <div class="regions-list">
-        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE">
+        <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE">
             <div style="display: inline-block; width: 165px; white-space: nowrap;">
                 Showing page: ${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 : regions_info.roi_page_number + 1}
-                of ${regions_info.getPageCount()}
+                of ${pageCount}
             </div>
             <div class="glyphicon glyphicon-chevron-left"
                 click.delegate="setPage(regions_info.roi_page_number - 1)">
@@ -28,7 +28,7 @@
            <input disabled.bind="regions_info.is_pending" type="range"
              input.delegate="handlePageRangeSlide($event)"
              change.delegate="handlePageRange($event)"
-            min="0" value="${regions_info.roi_page_number}" max="${regions_info.getPageCount() - 1}"
+            min="0" value="${regions_info.roi_page_number}" max="${pageCount - 1}"
             style="position: relative; top: 2px; width: 100px; display: inline-block"/>
             <div class="glyphicon glyphicon-chevron-right"
                 click.delegate="setPage(regions_info.roi_page_number + 1)">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -17,6 +17,9 @@
 -->
 <template>
     <div class="regions-list">
+        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE">
+            Current Z/T plane has ${ regions_info.roi_count_on_current_plane } ROIs
+        </div>
         <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE">
             <div style="display: inline-block; width: 165px; white-space: nowrap;">
                 Showing page: ${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 : regions_info.roi_page_number + 1}

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -18,14 +18,18 @@
 <template>
     <div class="regions-list">
         <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE">
-            Showing page: ${regions_info.roi_page_number + 1}
-            of ${regions_info.getPageCount()}
+            <div style="display: inline-block; width: 165px; white-space: nowrap;">
+                Showing page: ${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 : regions_info.roi_page_number + 1}
+                of ${regions_info.getPageCount()}
+            </div>
             <div class="glyphicon glyphicon-chevron-left"
                 click.delegate="setPage(regions_info.roi_page_number - 1)">
             </div>
-           <input type="range" change.delegate="handlePageRange($event)"
+           <input disabled.bind="regions_info.is_pending" type="range"
+             input.delegate="handlePageRangeSlide($event)"
+             change.delegate="handlePageRange($event)"
             min="0" value="${regions_info.roi_page_number}" max="${regions_info.getPageCount() - 1}"
-            style="width: 100px; display: inline-block"/>
+            style="position: relative; top: 2px; width: 100px; display: inline-block"/>
             <div class="glyphicon glyphicon-chevron-right"
                 click.delegate="setPage(regions_info.roi_page_number + 1)">
            </div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -16,11 +16,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE"
+        <div if.bind="regions_info.image_info.roi_count > regions_info.roi_page_size"
             class="pagination-controls">
             Current Z/T plane has ${ regions_info.roi_count_on_current_plane } ROIs
         </div>
-        <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE"
+        <div if.bind="regions_info.roi_count_on_current_plane > regions_info.roi_page_size"
             class="pagination-controls">
             <div style="display: inline-block; width: 165px; white-space: nowrap;">
                 Showing page:

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -16,11 +16,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-    <div class="regions-list">
-        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE">
+        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE"
+            class="pagination-controls">
             Current Z/T plane has ${ regions_info.roi_count_on_current_plane } ROIs
         </div>
-        <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE">
+        <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE"
+            class="pagination-controls">
             <div style="display: inline-block; width: 165px; white-space: nowrap;">
                 Showing page: ${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 : regions_info.roi_page_number + 1}
                 of ${pageCount}
@@ -37,63 +38,61 @@
                 click.delegate="setPage(regions_info.roi_page_number + 1)">
            </div>
         </div>
-        <div class="regions-table">
-            <div class="regions-header">
-                <div class="columns-dropdown dropdown">
-                    <button type="button"
-                        class="btn btn-default btn-sm dropdown-toggle
-                               glyphicon glyphicon-option-vertical"
-                        style="padding: 0px; top: -2px; right: 2px;"
-                        data-toggle="dropdown">
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li click.delegate="showColumn('comments')">
-                            <span class="show_comments">
-                                ${active_column === 'comments' ? '&#10003;' : '&nbsp;'}
-                            </span>
-                            <a href="#">Show Comments</a>
-                        </li>
-                        <li click.delegate="showColumn('measurements')">
-                            <span class="show_measurements">
-                                ${active_column === 'measurements' ? '&#10003;' : '&nbsp;'}
-                            </span>
-                            <a href="#">Show Area/Length</a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="regions-table-col roi-toggle">
-                    <input id="shapes_visibility_toggler"
-                           title="Show/Hide all rois"
-                           checked.one-way="regions_info.visibility_toggles === 0"
-                           show.bind="regions_info.number_of_shapes > 0"
-                           change.delegate="toggleAllShapesVisibility($event)"
-                           type="checkbox" />
-                </div>
-                <div class="regions-table-col shape-show">
-                    <label for="shapes_visibility_toggler"
-                           show.bind="regions_info.number_of_shapes > 0">Show</label>
-                </div>
-                <div class="regions-table-col shape-type">&nbsp;</div>
-                <div class="regions-table-col shape-z">Z</div>
-                <div class="regions-table-col shape-t">T</div>
-                <div class="regions-table-col shape-c">C</div>
-                <div class="regions-table-col shape-comment"
-                     show.bind="active_column === 'comments'">Comment
-                 </div>
-                <div class="regions-table-col shape-area"
-                     show.bind="active_column === 'measurements'">
-                     Area (${regions_info.image_info.image_pixels_size.symbol_x ||
-                             'px'}&#178;)
-                 </div>
-                <div class="regions-table-col shape-length"
-                     show.bind="active_column === 'measurements'">
-                     Length (${regions_info.image_info.image_pixels_size.symbol_x ||
-                               'px'})
-                 </div>
+        <div class="regions-header">
+            <div class="columns-dropdown dropdown">
+                <button type="button"
+                    class="btn btn-default btn-sm dropdown-toggle
+                            glyphicon glyphicon-option-vertical"
+                    style="padding: 0px; top: -2px; right: 2px;"
+                    data-toggle="dropdown">
+                </button>
+                <ul class="dropdown-menu">
+                    <li click.delegate="showColumn('comments')">
+                        <span class="show_comments">
+                            ${active_column === 'comments' ? '&#10003;' : '&nbsp;'}
+                        </span>
+                        <a href="#">Show Comments</a>
+                    </li>
+                    <li click.delegate="showColumn('measurements')">
+                        <span class="show_measurements">
+                            ${active_column === 'measurements' ? '&#10003;' : '&nbsp;'}
+                        </span>
+                        <a href="#">Show Area/Length</a>
+                    </li>
+                </ul>
             </div>
+            <div class="regions-table-col roi-toggle">
+                <input id="shapes_visibility_toggler"
+                        title="Show/Hide all rois"
+                        checked.one-way="regions_info.visibility_toggles === 0"
+                        show.bind="regions_info.number_of_shapes > 0"
+                        change.delegate="toggleAllShapesVisibility($event)"
+                        type="checkbox" />
+            </div>
+            <div class="regions-table-col shape-show">
+                <label for="shapes_visibility_toggler"
+                        show.bind="regions_info.number_of_shapes > 0">Show</label>
+            </div>
+            <div class="regions-table-col shape-type">&nbsp;</div>
+            <div class="regions-table-col shape-z">Z</div>
+            <div class="regions-table-col shape-t">T</div>
+            <div class="regions-table-col shape-c">C</div>
+            <div class="regions-table-col shape-comment"
+                    show.bind="active_column === 'comments'">Comment
+                </div>
+            <div class="regions-table-col shape-area"
+                    show.bind="active_column === 'measurements'">
+                    Area (${regions_info.image_info.image_pixels_size.symbol_x ||
+                            'px'}&#178;)
+                </div>
+            <div class="regions-table-col shape-length"
+                    show.bind="active_column === 'measurements'">
+                    Length (${regions_info.image_info.image_pixels_size.symbol_x ||
+                            'px'})
+                </div>
+        </div>
 
-            <div class="regions-table-row regions-table-first-row"></div>
-
+        <div class="regions-table">
             <template repeat.for="[roi_id, roi] of regions_info.data">
                 <template repeat.for="[shape_id, shape] of roi.shapes">
                     <div if.bind="(roi.shapes.size - roi.deleted) > 1 &&
@@ -172,5 +171,4 @@
                 </template>
             </template>
         </div>
-    </div>
 </template>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -92,7 +92,10 @@
                 </div>
         </div>
 
-        <div class="regions-table">
+        <div class="disabled-color loading-text"
+            show.bind="!regions_info.ready">Loading Regions...</div>
+
+        <div class="regions-table" show.bind="regions_info.ready">
             <template repeat.for="[roi_id, roi] of regions_info.data">
                 <template repeat.for="[shape_id, shape] of roi.shapes">
                     <div if.bind="(roi.shapes.size - roi.deleted) > 1 &&

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -17,6 +17,19 @@
 -->
 <template>
     <div class="regions-list">
+        <div if.bind="regions_info.image_info.roi_count > REGIONS_PAGE_SIZE">
+            Showing page: ${regions_info.roi_page_number + 1}
+            of ${regions_info.getPageCount()}
+            <div class="glyphicon glyphicon-chevron-left"
+                click.delegate="setPage(regions_info.roi_page_number - 1)">
+            </div>
+           <input type="range" change.delegate="handlePageRange($event)"
+            min="0" value="${regions_info.roi_page_number}" max="${regions_info.getPageCount() - 1}"
+            style="width: 100px; display: inline-block"/>
+            <div class="glyphicon glyphicon-chevron-right"
+                click.delegate="setPage(regions_info.roi_page_number + 1)">
+           </div>
+        </div>
         <div class="regions-table">
             <div class="regions-header">
                 <div class="columns-dropdown dropdown">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -23,7 +23,11 @@
         <div if.bind="regions_info.roi_count_on_current_plane > REGIONS_PAGE_SIZE"
             class="pagination-controls">
             <div style="display: inline-block; width: 165px; white-space: nowrap;">
-                Showing page: ${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 : regions_info.roi_page_number + 1}
+                Showing page:
+                <input class="roi_page_number"
+                    change.delegate="handlePageInput($event)"
+                    value="${temp_sliding_page_number !== undefined ? temp_sliding_page_number + 1 :
+                    regions_info.roi_page_number + 1}" />
                 of ${pageCount}
             </div>
             <div class="glyphicon glyphicon-chevron-left"

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -22,7 +22,8 @@ import Misc from '../utils/misc';
 import Ui from '../utils/ui';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {
-    REGIONS_SET_PROPERTY, IMAGE_VIEWER_RESIZE, EventSubscriber
+    REGIONS_SET_PROPERTY, IMAGE_VIEWER_RESIZE, EventSubscriber,
+    IMAGE_DIMENSION_CHANGE
 } from '../events/events';
 import {REGIONS_PAGE_SIZE} from '../utils/constants';
 
@@ -90,8 +91,12 @@ export default class RegionsList extends EventSubscriber {
      * @memberof RegionsList
      * @type {Array.<string,function>}
      */
-    sub_list = [[IMAGE_VIEWER_RESIZE,
-                    (params={}) => setTimeout(() => this.setHeaderWidth(), 50)]];
+    sub_list = [
+        [IMAGE_VIEWER_RESIZE,
+            (params={}) => setTimeout(() => this.setHeaderWidth(), 50)],
+        [IMAGE_DIMENSION_CHANGE,
+            (params={}) => this.changeDimension(params)],
+    ];
 
     /**
      * @constructor
@@ -113,6 +118,15 @@ export default class RegionsList extends EventSubscriber {
      */
     bind() {
         this.waitForRegionsInfoReady();
+    }
+
+    /**
+     * Gets page count for current plane.
+     * Allows view to show page count and automatically binds change in
+     * roi_count_on_current_plane
+     */
+    get pageCount() {
+        return Math.ceil(this.regions_info.roi_count_on_current_plane/REGIONS_PAGE_SIZE)
     }
 
     /**
@@ -271,6 +285,17 @@ export default class RegionsList extends EventSubscriber {
         } else {
             this.regions_info.setPageAndReload(zeroBasedPageNumber);
             return true;
+        }
+    }
+
+    /**
+     * Listen for Z/T changes and re-load ROIs for the new plane.
+     *
+     * @param {Object} params Event params
+     */
+    changeDimension(params) {
+        if (params.dim === "t" || params.dim == "z") {
+            this.regions_info.requestData(true);
         }
     }
 

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -22,7 +22,7 @@ import Misc from '../utils/misc';
 import Ui from '../utils/ui';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {
-    REGIONS_SET_PROPERTY, IMAGE_VIEWER_RESIZE, EventSubscriber,
+    REGIONS_SET_PROPERTY, EventSubscriber,
     IMAGE_DIMENSION_CHANGE,
     IMAGE_SETTINGS_CHANGE
 } from '../events/events';
@@ -93,8 +93,6 @@ export default class RegionsList extends EventSubscriber {
      * @type {Array.<string,function>}
      */
     sub_list = [
-        [IMAGE_VIEWER_RESIZE,
-            (params={}) => setTimeout(() => this.setHeaderWidth(), 50)],
         [IMAGE_DIMENSION_CHANGE,
             (params={}) => this.changeDimension(params)],
         [IMAGE_SETTINGS_CHANGE,
@@ -146,7 +144,6 @@ export default class RegionsList extends EventSubscriber {
             this.registerObservers();
             // event subscriptions
             this.subscribe();
-            setTimeout(() => this.setTableHeight(), 50);
         };
 
         // tear down old observers
@@ -174,16 +171,6 @@ export default class RegionsList extends EventSubscriber {
             this.bindingEngine.collectionObserver(
                 this.regions_info.selected_shapes).subscribe(
                     (newValue, oldValue) => this.actUponSelectionChange()));
-        this.observers.push(
-            this.bindingEngine.propertyObserver(
-                this.regions_info, 'number_of_shapes').subscribe(
-                    (newValue, oldValue) =>
-                        setTimeout(() => this.setHeaderWidth(), 50)));
-        this.observers.push(
-            this.bindingEngine.propertyObserver(
-                this.context, 'selected_tab').subscribe(
-                    (newValue, oldValue) =>
-                        setTimeout(() => this.setTableHeight(), 50)));
         this.observers.push(
             this.bindingEngine.propertyObserver(
                 this.regions_info, 'visibility_toggles').subscribe(
@@ -246,23 +233,6 @@ export default class RegionsList extends EventSubscriber {
             $('.regions-list-toggler').removeClass('expand-down');
             $('.regions-list-toggler').addClass('collapse-up');
         }
-    }
-
-    /**
-     * Gives the header the row width to avoid scalebar adjustment nonsense
-     * @memberof RegionsList
-     */
-    setHeaderWidth() {
-        $('.regions-header').width($('.regions-table-first-row').width());
-    }
-
-    /**
-     * Sets the table height
-     * @memberof RegionsList
-     */
-    setTableHeight() {
-        if (!this.context.isRoisTabActive()) return;
-        this.setHeaderWidth();
     }
 
     /**
@@ -496,8 +466,6 @@ export default class RegionsList extends EventSubscriber {
         let roi = this.regions_info.data.get(roi_id);
         if (typeof roi === 'undefined') return;
         roi.show = !roi.show;
-
-        setTimeout(() => this.setHeaderWidth(), 25);
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -79,6 +79,13 @@ export default class RegionsList extends EventSubscriber {
     regions_ready_observer = null;
 
     /**
+     * Set this while range slider is sliding to show in UI
+     * @memberof RegionsList
+     * @type {number}
+     */
+    temp_sliding_page_number = undefined;
+
+    /**
      * events we subscribe to
      * @memberof RegionsList
      * @type {Array.<string,function>}
@@ -252,6 +259,7 @@ export default class RegionsList extends EventSubscriber {
      * @param {number} zeroBasedPageNumber New page number
      */
     setPage(zeroBasedPageNumber=0) {
+        this.temp_sliding_page_number = undefined;
         this.regions_info.setPageAndReload(zeroBasedPageNumber);
     }
 
@@ -262,7 +270,17 @@ export default class RegionsList extends EventSubscriber {
      */
     handlePageRange(event) {
         let page = parseInt(event.target.value, 10);
-        this.regions_info.setPageAndReload(page);
+        this.setPage(page);
+    }
+
+    /**
+     * Handle slide event for input range slider to choose page
+     *
+     * @param {object} event change event from pagination range input
+     */
+    handlePageRangeSlide(event) {
+        let page = parseInt(event.target.value, 10);
+        this.temp_sliding_page_number = page;
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -24,6 +24,7 @@ import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework'
 import {
     REGIONS_SET_PROPERTY, IMAGE_VIEWER_RESIZE, EventSubscriber
 } from '../events/events';
+import {REGIONS_PAGE_SIZE} from '../utils/constants';
 
 /**
  * Represents the regions list/table in the regions settings/tab
@@ -42,6 +43,12 @@ export default class RegionsList extends EventSubscriber {
     regions_infoChanged(newVal, oldVal) {
         this.waitForRegionsInfoReady();
     }
+
+    /**
+     * Expose this constant to the UI
+     * @type {number}
+     */
+    REGIONS_PAGE_SIZE = REGIONS_PAGE_SIZE;
 
     /**
      * the column showing (only one - mutually exclusive for now)
@@ -237,6 +244,25 @@ export default class RegionsList extends EventSubscriber {
             'max-height', 'calc(100% - ' +
                 ($(".regions-tools").outerHeight() +
                 $("#panel-tabs").outerHeight()) + 'px)');
+    }
+
+    /**
+     * Set the pagination number of the ROI table and reload
+     *
+     * @param {number} zeroBasedPageNumber New page number
+     */
+    setPage(zeroBasedPageNumber=0) {
+        this.regions_info.setPageAndReload(zeroBasedPageNumber);
+    }
+
+    /**
+     * Handle change event for input range slider to choose page
+     *
+     * @param {object} event change event from pagination range input
+     */
+    handlePageRange(event) {
+        let page = parseInt(event.target.value, 10);
+        this.regions_info.setPageAndReload(page);
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -214,8 +214,7 @@ export default class RegionsList extends EventSubscriber {
          if (idOflastEntry !== lastSelShape.shape_id && !lastCanEdit) return;
 
          Ui.scrollContainer(
-             'roi-' + lastSelShape.shape_id, '.regions-table',
-            $('.regions-header').outerHeight());
+             'roi-' + lastSelShape.shape_id, '.regions-table');
      }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -251,8 +251,7 @@ export default class RegionsList extends EventSubscriber {
                 "OK");
             return false;
         } else {
-            this.regions_info.setPageAndReload(zeroBasedPageNumber);
-            return true;
+            return this.regions_info.setPageAndReload(zeroBasedPageNumber);
         }
     }
 
@@ -301,6 +300,25 @@ export default class RegionsList extends EventSubscriber {
         if (!changed) {
             // reset slider handle
             event.target.value = this.regions_info.roi_page_number;
+        }
+    }
+
+    /**
+     * Handle change event for input range slider to choose page
+     *
+     * @param {object} event change event from pagination range input
+     */
+    handlePageInput(event) {
+        let page = parseInt(event.target.value, 10);
+        if (isNaN(page)) {
+            event.target.value = this.regions_info.roi_page_number + 1;
+            return;
+        }
+        // UI input is 1-based, but we set 0-based
+        let changed = this.setPage(page - 1);
+        if (!changed) {
+            // reset slider handle
+            event.target.value = this.regions_info.roi_page_number + 1;
         }
     }
 

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -260,7 +260,18 @@ export default class RegionsList extends EventSubscriber {
      */
     setPage(zeroBasedPageNumber=0) {
         this.temp_sliding_page_number = undefined;
-        this.regions_info.setPageAndReload(zeroBasedPageNumber);
+        if (this.regions_info.is_pending) return;
+
+        if (this.regions_info.hasBeenModified()) {
+            Ui.showModalMessage(
+                "You have unsaved ROI changes. Please Save or Undo " +
+                "before going to next page.",
+                "OK");
+            return false;
+        } else {
+            this.regions_info.setPageAndReload(zeroBasedPageNumber);
+            return true;
+        }
     }
 
     /**
@@ -270,7 +281,11 @@ export default class RegionsList extends EventSubscriber {
      */
     handlePageRange(event) {
         let page = parseInt(event.target.value, 10);
-        this.setPage(page);
+        let changed = this.setPage(page);
+        if (!changed) {
+            // reset slider handle
+            event.target.value = this.regions_info.roi_page_number;
+        }
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -262,12 +262,7 @@ export default class RegionsList extends EventSubscriber {
      */
     setTableHeight() {
         if (!this.context.isRoisTabActive()) return;
-
         this.setHeaderWidth();
-        $(".regions-table").css(
-            'max-height', 'calc(100% - ' +
-                ($(".regions-tools").outerHeight() +
-                $("#panel-tabs").outerHeight()) + 'px)');
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -23,7 +23,8 @@ import Ui from '../utils/ui';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import {
     REGIONS_SET_PROPERTY, IMAGE_VIEWER_RESIZE, EventSubscriber,
-    IMAGE_DIMENSION_CHANGE
+    IMAGE_DIMENSION_CHANGE,
+    IMAGE_SETTINGS_CHANGE
 } from '../events/events';
 import {REGIONS_PAGE_SIZE} from '../utils/constants';
 
@@ -96,6 +97,8 @@ export default class RegionsList extends EventSubscriber {
             (params={}) => setTimeout(() => this.setHeaderWidth(), 50)],
         [IMAGE_DIMENSION_CHANGE,
             (params={}) => this.changeDimension(params)],
+        [IMAGE_SETTINGS_CHANGE,
+            (params={}) => this.changeImageSettings(params)],
     ];
 
     /**
@@ -295,6 +298,17 @@ export default class RegionsList extends EventSubscriber {
      */
     changeDimension(params) {
         if (params.dim === "t" || params.dim == "z") {
+            this.regions_info.requestData(true);
+        }
+    }
+
+    /**
+     * Listen for Z projection changes and re-load ROIs.
+     *
+     * @param {Object} params Event params
+     */
+    changeImageSettings(params) {
+        if (params.projection) {
             this.regions_info.requestData(true);
         }
     }

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -27,7 +27,6 @@ import {
     IMAGE_SETTINGS_CHANGE,
     IMAGE_DIMENSION_PLAY
 } from '../events/events';
-import {REGIONS_PAGE_SIZE} from '../utils/constants';
 
 /**
  * Represents the regions list/table in the regions settings/tab
@@ -46,12 +45,6 @@ export default class RegionsList extends EventSubscriber {
     regions_infoChanged(newVal, oldVal) {
         this.waitForRegionsInfoReady();
     }
-
-    /**
-     * Expose this constant to the UI
-     * @type {number}
-     */
-    REGIONS_PAGE_SIZE = REGIONS_PAGE_SIZE;
 
     /**
      * the column showing (only one - mutually exclusive for now)
@@ -130,7 +123,8 @@ export default class RegionsList extends EventSubscriber {
      * roi_count_on_current_plane
      */
     get pageCount() {
-        return Math.ceil(this.regions_info.roi_count_on_current_plane/REGIONS_PAGE_SIZE)
+        return Math.ceil(this.regions_info.roi_count_on_current_plane/
+                            this.regions_info.roi_page_size)
     }
 
     /**

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -292,22 +292,30 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
-     * Listen for Z/T changes and re-load ROIs for the new plane.
+     * Listen for Z/T changes and re-load ROIs for the new plane
+     * IF we're filtering ROIs by current plane
      *
      * @param {Object} params Event params
      */
     changeDimension(params) {
+        if (!this.regions_info.isRoiLoadingPaginatedByPlane()) {
+            return;
+        }
         if (params.dim === "t" || params.dim == "z") {
             this.regions_info.requestData(true);
         }
     }
 
     /**
-     * Listen for Z projection changes and re-load ROIs.
+     * Listen for Z projection changes and re-load ROIs
+     * IF we're filtering ROIs by current plane
      *
      * @param {Object} params Event params
      */
     changeImageSettings(params) {
+        if (!this.regions_info.isRoiLoadingPaginatedByPlane()) {
+            return;
+        }
         if (params.projection) {
             this.regions_info.requestData(true);
         }

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -257,33 +257,37 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
-     * Listen for Z/T changes and re-load ROIs for the new plane
-     * IF we're filtering ROIs by current plane
+     * Listen for Z/T changes and re-load ROIs for the new plane if needed
      *
      * @param {Object} params Event params
      */
     changeDimension(params) {
-        if (!this.regions_info.isRoiLoadingPaginatedByPlane()) {
-            return;
-        }
         if (params.dim === "t" || params.dim == "z") {
-            this.regions_info.requestData(true);
+            this.requestRoisForNewPlane();
         }
     }
 
     /**
-     * Listen for Z projection changes and re-load ROIs
-     * IF we're filtering ROIs by current plane
-     *
+     * Listen for Z projection changes and re-load ROIs if needed
      * @param {Object} params Event params
      */
     changeImageSettings(params) {
+        if (params.projection) {
+            this.requestRoisForNewPlane();
+        }
+    }
+
+    /**
+     * IF we're filtering ROIs by current plane, reload ROIs after
+     * resetting page to zero
+     */
+    requestRoisForNewPlane() {
         if (!this.regions_info.isRoiLoadingPaginatedByPlane()) {
             return;
         }
-        if (params.projection) {
-            this.regions_info.requestData(true);
-        }
+        // reset page and reload
+        this.regions_info.roi_page_number = 0;
+        this.regions_info.requestData(true);
     }
 
     /**

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -70,8 +70,10 @@
             </regions-drawing>
             <hr />
         </div>
-        <regions-list regions_info.bind="regions_info">
-        </regions-list>
+        <div class="regions-list">
+            <regions-list regions_info.bind="regions_info" class="regions-list2">
+            </regions-list>
+        </div>
         <div class="disabled-color loading-text"
              show.bind="!regions_info.ready">Loading Regions ...</div>
 

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -62,17 +62,15 @@
 
             <regions-edit regions_info.bind="regions_info"></regions-edit>
 
-            <hr show.bind="regions_info !== null && regions_info.ready &&
+            <hr show.bind="regions_info !== null &&
                            regions_info.image_info.can_annotate" />
             <regions-drawing show.bind="regions_info !== null &&
-                                        regions_info.ready &&
                                         regions_info.image_info.can_annotate"
                              regions_info.bind="regions_info">
             </regions-drawing>
             <hr />
         </div>
-        <regions-list show.bind="regions_info.ready"
-                      regions_info.bind="regions_info">
+        <regions-list regions_info.bind="regions_info">
         </regions-list>
         <div class="disabled-color loading-text"
              show.bind="!regions_info.ready">Loading Regions ...</div>

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -72,8 +72,5 @@
         </div>
         <regions-list regions_info.bind="regions_info" class="regions-list">
         </regions-list>
-        <div class="disabled-color loading-text"
-             show.bind="!regions_info.ready">Loading Regions ...</div>
-
     </div>
 </template>

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -70,10 +70,8 @@
             </regions-drawing>
             <hr />
         </div>
-        <div class="regions-list">
-            <regions-list regions_info.bind="regions_info" class="regions-list2">
-            </regions-list>
-        </div>
+        <regions-list regions_info.bind="regions_info" class="regions-list">
+        </regions-list>
         <div class="disabled-color loading-text"
              show.bind="!regions_info.ready">Loading Regions ...</div>
 

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -39,12 +39,12 @@
 
     <div class="btn-group history">
         <button type="button" click.delegate="undo()"
-            disabled.bind="!(image_config.undo_redo_enabled &&
+            disabled.bind="!(!image_config.is_movie_playing &&
                             image_config.history.length > 0 &&
                             image_config.historyPointer >= 0)"
             class="btn btn-default btn-sm">Undo</button>
         <button type="button" click.delegate="redo()"
-            disabled.bind="!(image_config.undo_redo_enabled &&
+            disabled.bind="!(!image_config.is_movie_playing &&
                             image_config.history.length > 0 &&
                             image_config.historyPointer < image_config.history.length-1)"
             class="btn btn-default btn-sm">Redo</button>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -52,6 +52,12 @@ export const DATASETS_REQUEST_URL = "/m/datasets";
 export const REGIONS_REQUEST_URL = "/m/rois";
 
 /**
+ * Page size for regions pagination
+ * @type {number}
+ */
+export const REGIONS_PAGE_SIZE = 500;
+
+/**
  * a convenience string lookup for URI_PREFIX
  * @type {string}
  */

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -52,12 +52,6 @@ export const DATASETS_REQUEST_URL = "/m/datasets";
 export const REGIONS_REQUEST_URL = "/m/rois";
 
 /**
- * Page size for regions pagination
- * @type {number}
- */
-export const REGIONS_PAGE_SIZE = 500;
-
-/**
  * a convenience string lookup for URI_PREFIX
  * @type {string}
  */
@@ -134,7 +128,8 @@ export const REQUEST_PARAMS = {
     TIME: 'T',
     VERSION: 'VERSION',
     WELL_ID: 'WELL',
-    ZOOM: 'ZM'
+    ZOOM: 'ZM',
+    ROI_PAGE_SIZE: 'ROI_PAGE_SIZE',
 }
 
 /**

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -933,6 +933,10 @@ export default class Ol3Viewer extends EventSubscriber {
 
     /**
      * Initializes the ol3 regions layer
+     * If image_config.regions_info.tmp_data is an array of ROIs, these
+     * will be populated as Vector features on the image. Otherwise
+     * the Vector layer and Regions source will be empty but available for
+     * drawing new shapes or editing shapes selected from the TiledRegions layer.
      *
      * @memberof Ol3Viewer
      */
@@ -940,8 +944,7 @@ export default class Ol3Viewer extends EventSubscriber {
         if (this.viewer === null ||
             this.image_config === null ||
             this.image_config.regions_info === null ||
-            !this.image_config.regions_info.ready ||
-            !Misc.isArray(this.image_config.regions_info.tmp_data)) return;
+            !this.image_config.regions_info.ready) return;
 
         // If ROI count is greater than 1 page (we don't have all ROIs in hand)
         // then we add Tiled Regions
@@ -949,7 +952,7 @@ export default class Ol3Viewer extends EventSubscriber {
             this.viewer.addTiledRegions();
         }
 
-        this.viewer.addRegions(this.image_config.regions_info.tmp_data);
+        this.viewer.addRegions(this.image_config.regions_info.tmp_data || []);
         this.changeRegionsModes(
             { modes: this.image_config.regions_info.regions_modes});
         this.viewer.showShapeComments(

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -40,6 +40,7 @@ import {
     REGIONS_GENERATE_SHAPES, REGIONS_HISTORY_ACTION, REGIONS_HISTORY_ENTRY,
     REGIONS_MODIFY_SHAPES, REGIONS_PROPERTY_CHANGED, REGIONS_SET_PROPERTY,
     TILED_REGIONS_PROPERTY_CHANGED,
+    REGIONS_GENERATE_SHAPES_FROM_TILED,
     REGIONS_SHOW_COMMENTS, REGIONS_STORED_SHAPES, REGIONS_STORE_SHAPES,
     VIEWER_IMAGE_SETTINGS, VIEWER_PROJECTIONS_SYNC, VIEWER_SET_SYNC_GROUP,
     EventSubscriber
@@ -150,7 +151,10 @@ export default class Ol3Viewer extends EventSubscriber {
         [VIEWER_SET_SYNC_GROUP,
             (params={}) => this.setSyncGroup(params)],
         [IMAGE_SETTINGS_REFRESH,
-            (params={}) => this.refreshImageSettings(params)]];
+            (params={}) => this.refreshImageSettings(params)],
+        [REGIONS_GENERATE_SHAPES_FROM_TILED,
+            (params={}) => this.generateShapesFromTiled(params)],
+    ];
 
     /**
      * @constructor
@@ -750,6 +754,29 @@ export default class Ol3Viewer extends EventSubscriber {
         else if (prop === 'state')
             this.deleteShapes(params);
      }
+
+    /**
+     * When we want to edit Shapes loaded on the Tiled Regions layer, we
+     * first add them to the Vector Regions layer
+     *
+     * @param {Object} params Event params, should include shapes
+     */
+    generateShapesFromTiled(params = {}) {
+        params.shapes.forEach(shape => {
+            let roiId = parseInt(shape['oldId'].split(':')[0]);
+            shape.is_new = false;
+            shape.visible = true;
+            shape.selected = false;
+            shape.deleted = false;
+            shape.modified = false;
+            this.image_config.regions_info.number_of_shapes++;
+            let shapes = new Map();
+            shapes.set(shape['@id'], shape);
+            this.image_config.regions_info.data.set(roiId, {
+                shapes, show: true, deleted: 0
+            });
+        });
+    }
 
      /**
       * Generates shape for both, pasting and propagation

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1161,10 +1161,6 @@ export default class Ol3Viewer extends EventSubscriber {
             }
         }
 
-        // update roi count
-        this.image_config.image_info.roi_count =
-            this.image_config.regions_info.data.size;
-
         // clear history
         this.image_config.regions_info.history.resetHistory();
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -769,7 +769,10 @@ export default class Ol3Viewer extends EventSubscriber {
             shape.selected = false;
             shape.deleted = false;
             shape.modified = false;
+            // Add helper attributes like 'shape_id' and 'type'
+            Converters.amendShapeDefinition(shape);
             this.image_config.regions_info.number_of_shapes++;
+            // TODO: If ROI already exists in regions_info.data, add shapes to it
             let shapes = new Map();
             shapes.set(shape['@id'], shape);
             this.image_config.regions_info.data.set(roiId, {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1165,8 +1165,10 @@ export default class Ol3Viewer extends EventSubscriber {
         }
 
         // update roi count
-        this.image_config.image_info.roi_count =
-            this.image_config.image_info.roi_count + roi_count_change;
+        this.image_config.regions_info.roi_count =
+            this.image_config.regions_info.roi_count + roi_count_change;
+        this.image_config.regions_info.roi_count_on_current_plane =
+            this.image_config.regions_info.roi_count_on_current_plane + roi_count_change;
 
         // clear history
         this.image_config.regions_info.history.resetHistory();

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1099,6 +1099,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 params.omit_client_update) return;
 
         let ids = [];
+        let roi_count_change = 0;
         // we iterate over the ids given and reset states accordingly
         for (let id in params.shapes) {
             let shape = this.image_config.regions_info.getShape(id);
@@ -1113,6 +1114,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 // new ones are stored under their newly created ids
                 let wasNew = typeof shape.is_new === 'boolean' && shape.is_new;
                 if (wasNew) {
+                    roi_count_change++;
                     let newRoi =
                         this.image_config.regions_info.data.get(
                             newRoiAndShapeId.roi_id);
@@ -1153,6 +1155,7 @@ export default class Ol3Viewer extends EventSubscriber {
                             oldRoiAndShapeId.roi_id);
                     // take out of count if not new
                     if (!wasNew) {
+                        roi_count_change--;
                         if (!shape.visible) // if not visible we correct
                             this.image_config.regions_info.visibility_toggles++;
                         this.image_config.regions_info.number_of_shapes--;
@@ -1160,6 +1163,10 @@ export default class Ol3Viewer extends EventSubscriber {
                 }
             }
         }
+
+        // update roi count
+        this.image_config.image_info.roi_count =
+            this.image_config.image_info.roi_count + roi_count_change;
 
         // clear history
         this.image_config.regions_info.history.resetHistory();

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1311,7 +1311,7 @@ export default class Ol3Viewer extends EventSubscriber {
             this.player_info.dim = null;
             this.player_info.forwards = null;
             this.player_info.handle = null;
-            this.image_config.undo_redo_enabled = true;
+            this.image_config.is_movie_playing = false;
             this.viewer.getRenderStatus(true);
         }).bind(this);
 
@@ -1347,7 +1347,7 @@ export default class Ol3Viewer extends EventSubscriber {
 
         this.player_info.dim = dim;
         this.player_info.forwards = forwards;
-        this.image_config.undo_redo_enabled = false;
+        this.image_config.is_movie_playing = true;
         this.player_info.handle =
             setInterval(
                 () => {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -978,7 +978,7 @@ export default class Ol3Viewer extends EventSubscriber {
 
         // If ROI count is greater than 1 page (we don't have all ROIs in hand)
         // then we add Tiled Regions
-        if (this.image_config.image_info.roi_count > this.image_config.context.roi_page_size) {
+        if (this.image_config.regions_info.isRoiLoadingByTile()) {
             this.viewer.addTiledRegions();
         }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -914,6 +914,12 @@ export default class Ol3Viewer extends EventSubscriber {
             !this.image_config.regions_info.ready ||
             !Misc.isArray(this.image_config.regions_info.tmp_data)) return;
 
+        // If ROI count is greater than 1 page (we don't have all ROIs in hand)
+        // then we add Tiled Regions
+        if (this.image_config.image_info.roi_count > this.image_config.context.roi_page_size) {
+            this.viewer.addTiledRegions();
+        }
+
         this.viewer.addRegions(this.image_config.regions_info.tmp_data);
         this.changeRegionsModes(
             { modes: this.image_config.regions_info.regions_modes});

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -787,10 +787,17 @@ class Viewer extends OlObject {
      */
     showShapeComments(flag) {
         // without a regions layer there will be no regions to hide...
-        var regions = this.getRegions();
-        if (regions && typeof flag === 'boolean') {
-            regions.show_comments_ = flag;
-            regions.changed();
+        if (typeof flag === 'boolean') {
+            var regions = this.getRegions();
+            if (regions) {
+                regions.show_comments_ = flag;
+                regions.changed();
+            }
+            var tiledRegions = this.getTiledRegions();
+            if (tiledRegions) {
+                tiledRegions.show_comments_ = flag;
+                this.redrawTiledRegions();
+            }
         }
     }
 
@@ -1991,6 +1998,16 @@ class Viewer extends OlObject {
 
         zoomDisplay[0].value =
             Math.round((1 / this.viewer_.getView().getResolution()) * 100);
+
+        // When zooming is done, we may need to force redraw of TiledRegions
+        // to update label sizes...
+        if (this.redrawTimeout) {
+            clearTimeout(this.redrawTimeout);
+        }
+        this.redrawTimeout = setTimeout(() => {
+            this.redrawTiledRegions();
+            this.redrawTimeout = undefined;
+        }, 500);
     }
 
     /**

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -1245,10 +1245,37 @@ class Viewer extends OlObject {
         if (!(this.viewer_ instanceof OlMap) || // mandatory viewer presence check
             this.viewer_.getLayers().getLength() < 2) // unfathomable event of layer missing...
             return null;
+        return this.getLayerByName('Regions');
+    }
 
+    /**
+     * Get the Tiled Regions Layer
+     */
+    getTiledRegionsLayer() {
+        return this.getLayerByName('TiledRegions');
+    }
+
+    /**
+     * Force a redraw of the TiledRegions layer, e.g. to be used after
+     * changing the style of features on the layer.
+     */
+    redrawTiledRegions() {
+        let regionsLayer = this.getTiledRegionsLayer();
+        if (regionsLayer) {
+            // force redraw of layer style
+            regionsLayer.setStyle(regionsLayer.getStyle());
+        }
+    }
+
+    /**
+     * Get layer from viewer, identified by name.
+     *
+     * @param {string} name
+     */
+    getLayerByName(name) {
         // Get the 'Regions' layer by name
         let layers = this.viewer_.getLayers().getArray().filter(
-            layer => layer.get('name') === 'Regions');
+            layer => layer.get('name') === name);
         return layers.length > 0 ? layers[0] : null;
     }
 
@@ -1278,6 +1305,14 @@ class Viewer extends OlObject {
         if (regionsLayer) return regionsLayer.getSource();
 
         return null;
+    }
+
+    /**
+     * Get the Tiled Regions source.
+     */
+    getTiledRegions() {
+        let tiledRegionsLayer = this.getTiledRegionsLayer()
+        if (tiledRegionsLayer) return tiledRegionsLayer.getSource();
     }
 
     /**

--- a/src/viewers/viewer/format/OmeJSON.js
+++ b/src/viewers/viewer/format/OmeJSON.js
@@ -1,0 +1,78 @@
+//
+// Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import JSONFeature from 'ol/format/JSONFeature';
+import {createFeatureFromShape} from '../utils/Regions';
+
+/**
+* @classdesc
+* Feature format for reading and writing data in the OME JSON format.
+*
+* @api
+*/
+class OmeJSON extends JSONFeature {
+
+    /**
+    * @param {Options=} opt_options Options.
+    */
+    constructor(opt_options) {
+
+        const options = opt_options ? opt_options : {};
+
+        super();
+
+        this.projection = options.projection;
+
+        this.regions = options.regions;
+
+    }
+
+    /**
+     * Creates Features from JSON response string
+     *
+     * @param {string} source Text response from AJAX call
+     * @param {object} opt_options Options
+     */
+    readFeatures(source, opt_options) {
+        let responseJSON = JSON.parse(source);
+        let shapesJSON = responseJSON.data;
+
+        let features = shapesJSON.map((shape) => {
+            shape.type = shape['@type'].split('#')[1].toLowerCase();
+
+            // create features with a Style function that references Regions
+            let feature = createFeatureFromShape(shape, this.regions);
+            // Feature ID is 'roiId:shapeId'
+            feature.setId(shape['roi']['@id'] + ":" + shape['@id']);
+            return feature;
+        });
+
+        return features;
+    };
+
+    /**
+     * Override this to simply return the OMERO Projection
+     *
+     * @param {*} source
+     */
+    readProjection(source) {
+        return this.projection;
+    }
+}
+
+export default OmeJSON;

--- a/src/viewers/viewer/format/OmeJSON.js
+++ b/src/viewers/viewer/format/OmeJSON.js
@@ -59,6 +59,9 @@ class OmeJSON extends JSONFeature {
             let feature = createFeatureFromShape(shape, this.regions);
             // Feature ID is 'roiId:shapeId'
             feature.setId(shape['roi']['@id'] + ":" + shape['@id']);
+            ['TheZ', 'TheC', 'TheT'].forEach(dim => {
+                feature[dim] = typeof shape[dim] === 'number' ? shape[dim] : -1
+            });
             return feature;
         });
 

--- a/src/viewers/viewer/interaction/Select.js
+++ b/src/viewers/viewer/interaction/Select.js
@@ -134,12 +134,14 @@ class Select extends Interaction {
             let clickedFeature = featuresAtCoords(tiledFeatures);
 
             if (clickedFeature) {
-                this.regions_.addFeaturesFromFeatures([clickedFeature]);
                 shapeId = clickedFeature.getId();
-
-                // Hide the shape in TileRegions layer
-                this.regions_.viewer_.getTiledRegions().setRegionsVisibility([shapeId], false);
-                this.regions_.viewer_.redrawTiledRegions();
+                // Ignore cluster 'roi count' labels from zoomed-out levels
+                if (shapeId != '0:0') {
+                    this.regions_.addFeaturesFromFeatures([clickedFeature]);
+                    // Hide the shape in TileRegions layer
+                    this.regions_.viewer_.getTiledRegions().setRegionsVisibility([shapeId], false);
+                    this.regions_.viewer_.redrawTiledRegions();
+                }
             }
         } else {
             shapeId = selected.getId();

--- a/src/viewers/viewer/source/Regions.js
+++ b/src/viewers/viewer/source/Regions.js
@@ -489,6 +489,15 @@ class Regions extends Vector {
     }
 
     /**
+     * Gets the scale text flag
+     *
+     * @param {ol.Feature} feature In case behaviour is feature dependent (not used)
+     */
+    getScaleText(feature) {
+        return this.scale_text_;
+    }
+
+    /**
      * Sets the rotate text flag
      *
      * @param {boolean} rotateText a flag whether text should be rotated along with the view

--- a/src/viewers/viewer/source/Regions.js
+++ b/src/viewers/viewer/source/Regions.js
@@ -26,6 +26,7 @@ import Modify from '../interaction/Modify';
 import Translate from '../interaction/Translate';
 import {calculateLengthAndArea,
     createFeaturesFromRegionsResponse} from '../utils/Regions';
+import {updateStyleFunction} from '../utils/Style';
 import {isArray,
     getCookie,
     sendEventNotification} from '../utils/Misc';
@@ -508,6 +509,25 @@ class Regions extends Vector {
     };
 
     /**
+     * Creates (clones) the given features and adds them to this layer,
+     * setting the Style function to reference this Regions instance.
+     * Used when we have features loaded by the TiledRegions layer and then
+     * we want to add them to this Vector layer for editing.
+     *
+     * @param {Array of ol.Feature} features Features to add
+     */
+    addFeaturesFromFeatures(features) {
+        features = features.map((f) => {
+            let feature = f.clone();
+            feature.setId(f.getId());
+            feature.type = f.type;
+            updateStyleFunction(feature, this, true);
+            return feature;
+        });
+        this.addFeatures(features);
+    }
+
+    /**
      * This method decides whether a feature is being rendered or not
      * using the following criteria
      * - visibility
@@ -655,6 +675,25 @@ class Regions extends Vector {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Return True if this feature is selected
+     *
+     * @param {ol.Feature} feature The feature
+     */
+    isFeatureSelected(feature) {
+        return feature['selected']
+    }
+
+    /**
+     * Return True if this feature is visible
+     *
+     * @param {ol.Feature} feature The feature
+     */
+    isFeatureVisible(feature) {
+        console.log("Regions isFeatureVisible", feature.getId());
+        return typeof(feature['visible']) !== 'boolean' || feature['visible'];
     }
 
     /**

--- a/src/viewers/viewer/source/TiledRegions.js
+++ b/src/viewers/viewer/source/TiledRegions.js
@@ -1,0 +1,252 @@
+//
+// Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import TileGrid from 'ol/tilegrid/TileGrid.js';
+import VectorTileSource from 'ol/source/VectorTile.js';
+import {getTopLeft} from 'ol/extent';
+
+import {isArray,
+    featuresAtCoords,
+    sendEventNotification} from '../utils/Misc';
+import {PLUGIN_PREFIX} from '../globals';
+import OmeJSON from '../format/OmeJSON';
+
+export const ROI_TILE_SIZE = 256;
+
+class OmeVectorTileSource extends VectorTileSource {
+
+    constructor(viewerReference) {
+
+        let image_info_ = viewerReference.image_info_;
+        let projection = viewerReference.proj_;
+
+        var zoomLevelScaling = null;
+        var dims = image_info_['size'];
+        if (image_info_['zoomLevelScaling']) {
+            var tmp = [];
+            for (var r in image_info_['zoomLevelScaling'])
+                tmp.push(1 / image_info_['zoomLevelScaling'][r]);
+            zoomLevelScaling = tmp.reverse();
+        }
+        var zoom = zoomLevelScaling ? zoomLevelScaling.length : -1;
+        var extent = [0, -dims['height'], dims['width'], 0];
+        var tile_size = image_info_['tile_size']
+        var tile_width = tile_size ? tile_size.width : ROI_TILE_SIZE;
+        var tile_height = tile_size ? tile_size.height : ROI_TILE_SIZE;
+        var tgOpts = {
+            tileSize: [tile_width, tile_height],
+            extent: extent,
+            origin: getTopLeft(extent),
+            resolutions: zoom > 1 ? zoomLevelScaling : [1],
+        }
+        var tileGrid = new TileGrid(tgOpts);
+
+        super({
+            tileGrid: tileGrid,
+        })
+
+        // Load ROIs by tile
+        this.setTileUrlFunction((tileCoord) => {
+            var viewerT = this.viewer_.getDimensionIndex('t');
+            var viewerZ = this.viewer_.getDimensionIndex('z');
+
+            let x = tileCoord[1];
+            let y = -tileCoord[2] - 1;
+            var zoom = zoomLevelScaling ? zoomLevelScaling.length - tileCoord[0] - 1 : 0;
+            var tile = + zoom  + ',' + tileCoord[1] + ',' + (-tileCoord[2]-1);
+            tile = tile + ',' + tile_width + ',' + tile_height;
+            if (zoom > 0) {
+                // We only support ROIs at the 100% zoom level
+                return;
+            }
+            let iviewer = viewerReference.getPrefixedURI(PLUGIN_PREFIX);
+            return `${ iviewer }/shapes_by_region/${ image_info_.id }/${ viewerZ }/${ viewerT }/?tile=${ tile }`;
+        });
+
+        // Format is responsible for creating Features from JSON response shapes
+        // It needs reference to viewer/regions because Features need to
+        // know viewer state to update their Style
+        let omeFormat = new OmeJSON({
+            regions: this,
+            projection: projection
+        });
+        this.format_ = omeFormat;
+
+        /**
+         * Keep track of selected features.
+         * 'roiIdshapId': True
+         *
+         * See https://openlayers.org/en/latest/examples/vector-tile-selection.html
+         */
+        this.selectedFeatures_ = {};
+
+        /**
+         * Keep track of hidden features.
+         * 'roiIdshapId': True
+         */
+        this.hiddenFeatures_ = {};
+
+        /**
+         * a flag that tells us if we'd like for the text to be scaled with resolution
+         * changes of the view. Defaults to true.
+         * NB: No setScaleText() function since it's never used
+         * @type {boolean}
+         */
+        this.scale_text_ = true;
+
+        /**
+         * the viewer reference
+         *
+         * @type {Viewer}
+         * @private
+         */
+        this.viewer_ = viewerReference;
+
+        // Add Select behaviour (single click)
+        let map = this.viewer_.viewer_;
+        // map.on('click', (event) => {
+        //     var features = map.getFeaturesAtPixel(event.pixel);
+        //     console.log("click features", features);
+        //     if (!features) {
+        //       this.viewer_.selectShapes(null, false, true);
+        //       return;
+        //     }
+        //     // Find smallest of features under click pixel
+        //     let feature = featuresAtCoords(features);
+
+        //     var fid = feature.getId();
+        //     this.viewer_.selectShapes([fid], true, true);
+        //   });
+    }
+
+    /**
+     * This overrides the parent class, which otherwise tries to create a
+     * tileGrid for some reason and this doesn't match what we need.
+     */
+    getTileGridForProjection() {
+        return this.tileGrid;
+    }
+
+    /**
+     * Marks given shapes as selected, clearing any previously selected if
+     * clear flag is set.
+     *
+     * @param {Array<string>} roi_shape_ids list in roi_id:shape_id notation
+     * @param {boolean} selected flag whether we should (de)select the rois
+     * @param {boolean} clear flag whether we should clear existing selection beforehand
+     */
+    selectShapes(roi_shape_ids, selected, clear) {
+
+        if (clear) {
+            let toDeselect = [];
+            let properties = [];
+            let values = [];
+            for (let id in this.selectedFeatures_) {
+                toDeselect.push(id);
+                properties.push('selected');
+                values.push(false);
+            }
+            if (toDeselect.length > 0) {
+                sendEventNotification(
+                    this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
+                    {
+                        "properties" : properties,
+                        "shapes": toDeselect,
+                        "values": values,
+                    }, 0);
+            }
+            this.selectedFeatures_ = {};
+        }
+
+        if (!isArray(roi_shape_ids)) return;
+
+        let properties = [];
+        let values = [];
+        roi_shape_ids.forEach(id => {
+            properties.push('selected');
+            values.push(selected);
+            if (selected) {
+                // Store {'roi:shape' : true}
+                // Need to keep 'roi:shape' to notify of deselections
+                this.selectedFeatures_[id] = true;
+            } else if (this.selectedFeatures_[id]) {
+                delete this.selectedFeatures_[id];
+            }
+        });
+
+        sendEventNotification(
+            this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
+            {
+                "properties" : properties,
+                "shapes": roi_shape_ids,
+                "values": values
+            }, 25);
+    }
+
+    /**
+     * Return True if this feature is selected
+     *
+     * @param {ol.Feature} feature The feature
+     */
+    isFeatureSelected(feature) {
+        let roi_shape_id = feature.getId();
+        return this.selectedFeatures_[roi_shape_id];
+    }
+
+    /**
+     * Toggles the visibility of the regions.
+     *
+     * @param {boolean} visible visibitily flag (true for visible)
+     * @param {Array<string>} roi_shape_ids a list of string ids of the form: roi_id:shape_id
+     */
+    setRegionsVisibility(visible, roi_shape_ids) {
+        let properties = [];
+        let values = [];
+        roi_shape_ids.forEach(id => {
+            properties.push('visible');
+            values.push(visible);
+            if (!visible) {
+                // Store {'roi:shape' : true}
+                this.hiddenFeatures_[id] = true;
+            } else if (this.hiddenFeatures_[id]) {
+                delete this.hiddenFeatures_[id];
+            }
+        });
+
+        // this isn't currently used but is consistent behaviour
+        sendEventNotification(
+            this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
+            {
+                "properties" : properties,
+                "shapes": roi_shape_ids,
+                "values": values
+            }, 25);
+    }
+
+    /**
+     * Return True if this feature is visible
+     *
+     * @param {ol.Feature} feature The feature
+     */
+    isFeatureVisible(feature) {
+        let roi_shape_id = feature.getId();
+        return !this.hiddenFeatures_[roi_shape_id];
+    }
+}
+
+export default OmeVectorTileSource;

--- a/src/viewers/viewer/source/TiledRegions.js
+++ b/src/viewers/viewer/source/TiledRegions.js
@@ -112,22 +112,6 @@ class OmeVectorTileSource extends VectorTileSource {
          * @private
          */
         this.viewer_ = viewerReference;
-
-        // Add Select behaviour (single click)
-        let map = this.viewer_.viewer_;
-        // map.on('click', (event) => {
-        //     var features = map.getFeaturesAtPixel(event.pixel);
-        //     console.log("click features", features);
-        //     if (!features) {
-        //       this.viewer_.selectShapes(null, false, true);
-        //       return;
-        //     }
-        //     // Find smallest of features under click pixel
-        //     let feature = featuresAtCoords(features);
-
-        //     var fid = feature.getId();
-        //     this.viewer_.selectShapes([fid], true, true);
-        //   });
     }
 
     /**
@@ -210,7 +194,7 @@ class OmeVectorTileSource extends VectorTileSource {
      * @param {boolean} visible visibitily flag (true for visible)
      * @param {Array<string>} roi_shape_ids a list of string ids of the form: roi_id:shape_id
      */
-    setRegionsVisibility(visible, roi_shape_ids) {
+    setRegionsVisibility(roi_shape_ids, visible) {
         let properties = [];
         let values = [];
         roi_shape_ids.forEach(id => {

--- a/src/viewers/viewer/source/TiledRegions.js
+++ b/src/viewers/viewer/source/TiledRegions.js
@@ -123,62 +123,6 @@ class OmeVectorTileSource extends VectorTileSource {
     }
 
     /**
-     * Marks given shapes as selected, clearing any previously selected if
-     * clear flag is set.
-     *
-     * @param {Array<string>} roi_shape_ids list in roi_id:shape_id notation
-     * @param {boolean} selected flag whether we should (de)select the rois
-     * @param {boolean} clear flag whether we should clear existing selection beforehand
-     */
-    selectShapes(roi_shape_ids, selected, clear) {
-
-        if (clear) {
-            let toDeselect = [];
-            let properties = [];
-            let values = [];
-            for (let id in this.selectedFeatures_) {
-                toDeselect.push(id);
-                properties.push('selected');
-                values.push(false);
-            }
-            if (toDeselect.length > 0) {
-                sendEventNotification(
-                    this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
-                    {
-                        "properties" : properties,
-                        "shapes": toDeselect,
-                        "values": values,
-                    }, 0);
-            }
-            this.selectedFeatures_ = {};
-        }
-
-        if (!isArray(roi_shape_ids)) return;
-
-        let properties = [];
-        let values = [];
-        roi_shape_ids.forEach(id => {
-            properties.push('selected');
-            values.push(selected);
-            if (selected) {
-                // Store {'roi:shape' : true}
-                // Need to keep 'roi:shape' to notify of deselections
-                this.selectedFeatures_[id] = true;
-            } else if (this.selectedFeatures_[id]) {
-                delete this.selectedFeatures_[id];
-            }
-        });
-
-        sendEventNotification(
-            this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
-            {
-                "properties" : properties,
-                "shapes": roi_shape_ids,
-                "values": values
-            }, 25);
-    }
-
-    /**
      * Return True if this feature is selected
      *
      * @param {ol.Feature} feature The feature
@@ -190,6 +134,8 @@ class OmeVectorTileSource extends VectorTileSource {
 
     /**
      * Toggles the visibility of the regions.
+     * Used to hide a TiledRegion feature when that feature is selected and
+     * converted into a new Vector Regions feature.
      *
      * @param {boolean} visible visibitily flag (true for visible)
      * @param {Array<string>} roi_shape_ids a list of string ids of the form: roi_id:shape_id
@@ -207,15 +153,6 @@ class OmeVectorTileSource extends VectorTileSource {
                 delete this.hiddenFeatures_[id];
             }
         });
-
-        // this isn't currently used but is consistent behaviour
-        sendEventNotification(
-            this.viewer_, "TILED_REGIONS_PROPERTY_CHANGED",
-            {
-                "properties" : properties,
-                "shapes": roi_shape_ids,
-                "values": values
-            }, 25);
     }
 
     /**

--- a/src/viewers/viewer/source/TiledRegions.js
+++ b/src/viewers/viewer/source/TiledRegions.js
@@ -70,10 +70,6 @@ class OmeVectorTileSource extends VectorTileSource {
             var zoom = zoomLevelScaling ? zoomLevelScaling.length - tileCoord[0] - 1 : 0;
             var tile = + zoom  + ',' + tileCoord[1] + ',' + (-tileCoord[2]-1);
             tile = tile + ',' + tile_width + ',' + tile_height;
-            if (zoom > 0) {
-                // We only support ROIs at the 100% zoom level
-                return;
-            }
             let iviewer = viewerReference.getPrefixedURI(PLUGIN_PREFIX);
             return `${ iviewer }/shapes_by_region/${ image_info_.id }/${ viewerZ }/${ viewerT }/?tile=${ tile }`;
         });
@@ -107,7 +103,7 @@ class OmeVectorTileSource extends VectorTileSource {
          * NB: No setScaleText() function since it's never used
          * @type {boolean}
          */
-        this.scale_text_ = true;
+        this.scale_text_ = false;
 
         /**
          * the viewer reference

--- a/src/viewers/viewer/source/TiledRegions.js
+++ b/src/viewers/viewer/source/TiledRegions.js
@@ -28,7 +28,7 @@ import OmeJSON from '../format/OmeJSON';
 
 export const ROI_TILE_SIZE = 256;
 
-class OmeVectorTileSource extends VectorTileSource {
+class TiledRegions extends VectorTileSource {
 
     constructor(viewerReference) {
 
@@ -84,14 +84,6 @@ class OmeVectorTileSource extends VectorTileSource {
         this.format_ = omeFormat;
 
         /**
-         * Keep track of selected features.
-         * 'roiIdshapId': True
-         *
-         * See https://openlayers.org/en/latest/examples/vector-tile-selection.html
-         */
-        this.selectedFeatures_ = {};
-
-        /**
          * Keep track of hidden features.
          * 'roiIdshapId': True
          */
@@ -103,7 +95,15 @@ class OmeVectorTileSource extends VectorTileSource {
          * NB: No setScaleText() function since it's never used
          * @type {boolean}
          */
-        this.scale_text_ = false;
+        this.scale_text_ = true;
+
+        /**
+         * this flag determines whether text is displayed for shapes other than labels
+         * Defauls to false
+         * @type {boolean}
+         * @private
+         */
+        this.show_comments_ = false;
 
         /**
          * the viewer reference
@@ -123,13 +123,15 @@ class OmeVectorTileSource extends VectorTileSource {
     }
 
     /**
-     * Return True if this feature is selected
+     * Gets the scale text flag
+     * Will return false for clustering roi count labels
      *
-     * @param {ol.Feature} feature The feature
+     * @param {ol.Feature} feature Behaviour may be feature dependent
      */
-    isFeatureSelected(feature) {
-        let roi_shape_id = feature.getId();
-        return this.selectedFeatures_[roi_shape_id];
+    getScaleText(feature) {
+        // We don't scale clustering roi_count labels
+        if (feature.getId() === "0:0") return false;
+        return this.scale_text_;
     }
 
     /**
@@ -166,4 +168,4 @@ class OmeVectorTileSource extends VectorTileSource {
     }
 }
 
-export default OmeVectorTileSource;
+export default TiledRegions;

--- a/src/viewers/viewer/utils/Style.js
+++ b/src/viewers/viewer/utils/Style.js
@@ -235,6 +235,11 @@ export const updateStyleFunction =
 
         // replace style function
         feature.setStyle(function(featureToStyle, actual_resolution) {
+            if (regions_reference instanceof TiledRegions) {
+                // Tiled Regions need to have more dynamic resolution info
+                actual_resolution = regions_reference.viewer_.viewer_.getView().getResolution();
+            }
+
             // fetch view via regions reference
             var regions = feature['regions'];
             if (!(regions instanceof Regions || regions instanceof TiledRegions))
@@ -257,7 +262,7 @@ export const updateStyleFunction =
 
             var geom = feature.getGeometry();
             // find present flags for scaling/rotating text
-            var scale_text = regions.scale_text_;
+            var scale_text = regions.getScaleText(feature);
             var rotate_text = regions.rotate_text_;
             // get present rotation
             var rotation = viewRef.getRotation();

--- a/src/viewers/viewer/utils/Style.js
+++ b/src/viewers/viewer/utils/Style.js
@@ -247,6 +247,14 @@ export const updateStyleFunction =
             }
 
             var regions = feature['regions'];
+
+            // We should ONLY need this for TiledRegions, since for Vector Regions
+            // the Regions.renderFeature(f) will return false if feature isn't
+            // visible so we won't ever get to this point for hidden features
+            if (!regions.isFeatureVisible(feature)) {
+                return new Style({renderer: () => {}});
+            }
+
             var geom = feature.getGeometry();
             // find present flags for scaling/rotating text
             var scale_text = regions.scale_text_;

--- a/src/viewers/viewer/utils/Style.js
+++ b/src/viewers/viewer/utils/Style.js
@@ -30,6 +30,7 @@ import {WEBGATEWAY,
     DEFAULT_MITER_LIMIT} from '../globals';
 import {TRANSPARENT_PLACEHOLDER} from './Conversion';
 import Regions from '../source/Regions';
+import TiledRegions from '../source/TiledRegions';
 import Label from '../geom/Label';
 import Line from '../geom/Line';
 import Mask from '../geom/Mask';
@@ -173,8 +174,9 @@ export const updateStyleFunction =
         if (!(feature instanceof Feature))
             console.error("A style function requires an instance of a feature!");
 
-        if (!(regions_reference instanceof Regions))
+        if (!(regions_reference instanceof Regions || regions_reference instanceof TiledRegions)) {
             console.error("A style function requires an instance of Regions!");
+        }
 
         // all this makes only sense with a style really
         var oldStyle = feature.getStyle();
@@ -234,7 +236,8 @@ export const updateStyleFunction =
         // replace style function
         feature.setStyle(function(featureToStyle, actual_resolution) {
             // fetch view via regions reference
-            if (!(feature['regions'] instanceof Regions))
+            var regions = feature['regions'];
+            if (!(regions instanceof Regions || regions instanceof TiledRegions))
                 return oldStyle; // we are screwed, return old setStyle
 
             // OpenLayers5 doesn't allow you to drag (Translate) if no fill


### PR DESCRIPTION
This uses Tile-based ROIs on single-plane images with > 500 ROIs.
On multi-plane images, if there are more than 500 ROIs on any plane, simple pagination is used.

Instead of the previous strategy #227 of replacing the existing Vector Regions layer with Tiled Regions layer, this tries to use both alongside each other. This means that we can still use the existing Regions layer for editing ROIs we have loaded in the ROI table (as in #231) but we can browse Tiled ROIs on the image.
If you click a Tile-based ROI on the image, it loads the ROI into the Table (and the Vector Regions layer) so you can edit them.

If we wanted to pursue this strategy, other TODOs:
 - Remove unused ```all_roi_ids```
 - Consider what to do for multi-plane images with > 500 ROIs per plane.
 - Need proper backend support for querying shapes by region. See https://trello.com/c/Tsv0yVe1/97-query-shapes-by-geometry