### PR TITLE
Plane roi grid

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -748,6 +748,7 @@ thumbnail-slider img {
     border: solid white 1px;
     text-align: center;
     overflow: visible;
+    user-select: none;
 }
 .grid_cell.selected {
     border: solid rgb(90, 135, 248) 3px;

--- a/css/app.css
+++ b/css/app.css
@@ -744,6 +744,9 @@ thumbnail-slider img {
     text-align: center;
     overflow: visible;
 }
+.grid_cell.selected {
+    border: solid rgb(90, 135, 248) 3px;
+}
 
 .y_axis, .x_axis {
     font-size: 10px;

--- a/css/app.css
+++ b/css/app.css
@@ -755,6 +755,9 @@ thumbnail-slider img {
 .x_axis {
     color: transparent;
 }
+.y_axis {
+    width: 25px
+}
 
 /* Show the first '1' x_axis label... */
 .col:nth-of-type(2) .x_axis {

--- a/css/app.css
+++ b/css/app.css
@@ -720,6 +720,44 @@ thumbnail-slider img {
     width: 100%;
 }
 
+/* Grid to show Shape counts per plane */
+.grid_table>div {
+    display: inline-block;
+    border-top: solid grey 1px;
+    border-bottom: solid grey 1px;
+    margin-bottom: 8px;
+}
+
+.grid_table>div:first-child {
+    border-left: solid grey 1px;
+}
+
+.grid_table>div:last-child {
+    border-right: solid grey 1px;
+}
+
+.grid_cell {
+    width: 15px;
+    height: 15px;
+    border: solid white 1px;
+    text-align: center;
+    overflow: visible;
+}
+
+.y_axis, .x_axis {
+    font-size: 10px;
+    border-color: transparent;
+}
+.x_axis {
+    color: white;
+}
+.col:nth-of-type(5n+1) .x_axis {
+    color: black;
+}
+.col:nth-of-type(2) .x_axis {
+    color: black;
+}
+
 .left-hand-panel-hidden {
     margin-left: -5px;
     padding-left: 5px;

--- a/css/app.css
+++ b/css/app.css
@@ -726,6 +726,7 @@ thumbnail-slider img {
     border-top: solid grey 1px;
     border-bottom: solid grey 1px;
     margin-bottom: 8px;
+    background-color: #f0f0f0;
 }
 
 .grid_table>div:first-child {
@@ -751,11 +752,18 @@ thumbnail-slider img {
 .x_axis {
     color: transparent;
 }
-.col:nth-of-type(5n+1) .x_axis {
-    color: black;
-}
+
+/* Show the first '1' x_axis label... */
 .col:nth-of-type(2) .x_axis {
     color: black;
+    z-index: 10;
+    position: relative;
+}
+/* ...and every 5th label */
+.col:nth-of-type(5n+1) .x_axis {
+    color: black;
+    z-index: 10;
+    position: relative;
 }
 
 .left-hand-panel-hidden {

--- a/css/app.css
+++ b/css/app.css
@@ -737,9 +737,14 @@ thumbnail-slider img {
     border-right: solid grey 1px;
 }
 
+.grid_table>div:last-child .x_axis{
+    width: 20px;
+    text-align: left;
+}
+
 .grid_cell {
-    width: 15px;
-    height: 15px;
+    width: 14px;
+    height: 14px;
     border: solid white 1px;
     text-align: center;
     overflow: visible;

--- a/css/app.css
+++ b/css/app.css
@@ -753,10 +753,14 @@ thumbnail-slider img {
 .grid_cell.selected {
     border: solid rgb(90, 135, 248) 3px;
 }
+.pointer .grid_cell {
+    cursor: pointer;
+}
 
 .y_axis, .x_axis {
     font-size: 10px;
     border-color: transparent;
+    cursor: default !important;
 }
 .x_axis {
     color: transparent;

--- a/css/app.css
+++ b/css/app.css
@@ -608,9 +608,13 @@ thumbnail-slider img {
     flex-direction: column;
 }
 
-.nav-tabs {
+#panel-tabs {
     background-color: #f8f8f8;
     flex: 0 0 auto;
+}
+
+.small-tabs>li>a {
+    padding: 7px 10px;
 }
 
 /* Container for each .tab-pane for tab content */
@@ -631,7 +635,12 @@ thumbnail-slider img {
     position: absolute;
 }
 
-/* Main ROI tab. Contains .regions-tools and .regions-list */
+#regions-tabs-content .tab-pane {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+/* Main ROI tab. Contains .regions-tools #regions-tabs and #regions-tabs-content */
 .regions-container {
     height: 100%;
     width: 100%;
@@ -645,6 +654,17 @@ thumbnail-slider img {
 .regions-tools {
     width: 100%;
     flex: 0 0 auto;
+}
+
+#regions-tabs {
+    flex: 0 0 auto;
+}
+
+/* Sub ROI tabs-container. Contains .regions-list and */
+#regions-tabs-content {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    position: relative;
 }
 
 /* Contains .pagination-controls, .regions-header and .regions-table */

--- a/css/app.css
+++ b/css/app.css
@@ -749,7 +749,7 @@ thumbnail-slider img {
     border-color: transparent;
 }
 .x_axis {
-    color: white;
+    color: transparent;
 }
 .col:nth-of-type(5n+1) .x_axis {
     color: black;

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -42,4 +42,6 @@ urlpatterns = patterns(
         r'(?P<the_z>[0-9]+)(?:-(?P<z_end>[0-9]+))?/'
         r'(?P<the_t>[0-9:]+)(?:-(?P<t_end>[0-9]+))?/$',
         views.rois_by_plane, name='omero_iviewer_rois_by_plane'),
+    url(r'^plane_shape_counts/(?P<image_id>[0-9]+)/$', views.plane_shape_counts,
+        name='omero_iviewer_plane_shape_counts'),
 )

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -42,6 +42,6 @@ urlpatterns = patterns(
         r'(?P<the_z>[0-9]+)(?:-(?P<z_end>[0-9]+))?/'
         r'(?P<the_t>[0-9:]+)(?:-(?P<t_end>[0-9]+))?/$',
         views.rois_by_plane, name='omero_iviewer_rois_by_plane'),
-    url(r'^plane_shape_counts/(?P<image_id>[0-9]+)/$', views.plane_shape_counts,
-        name='omero_iviewer_plane_shape_counts'),
+    url(r'^plane_shape_counts/(?P<image_id>[0-9]+)/$',
+        views.plane_shape_counts, name='omero_iviewer_plane_shape_counts'),
 )

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -21,6 +21,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from os.path import splitext
+from collections import defaultdict
 from struct import unpack
 
 from omeroweb.api.api_settings import API_MAX_LIMIT
@@ -32,7 +33,7 @@ from omeroweb.webgateway.templatetags.common_filters import lengthformat,\
 import json
 import omero_marshal
 import omero
-from omero.rtypes import rint, rlong
+from omero.rtypes import rint, rlong, unwrap
 from omero_sys_ParametersI import ParametersI
 import omero.util.pixelstypetopython as pixelstypetopython
 
@@ -277,6 +278,70 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
 
     return JsonResponse({'data': marshalled, 'meta': meta})
 
+@login_required()
+def plane_shape_counts(request, image_id, conn=None, **kwargs):
+    """
+    Get the number of shapes that will be visible on each plane.
+
+    Shapes that have theZ or theT unset will show up on all planes.
+    """
+
+    image = conn.getObject("Image", image_id)
+    if image is None:
+        return JsonResponse({"error": "Image not found"}, status=404)
+
+    query_service = conn.getQueryService()
+    params = omero.sys.ParametersI()
+    params.addId(image_id)
+    counts = []
+
+    # Attempt to load counts for each Z/T index.
+    # Unfortunately this is too slow. Use alternative approach (see below)
+    # query = """
+    #     select count(distinct shape) from Shape shape
+    #     join shape.roi as roi
+    #     where (shape.theZ = %s or shape.theZ is null)
+    #     and (shape.theT = %s or shape.theT is null)
+    #     and roi.image.id = :id
+    # """
+    # for z in range(image.getSizeZ()):
+    #     t_counts = []
+    #     for t in range(image.getSizeT()):
+    #         result = query_service.projection(query % (z, t), params,
+    #                                           conn.SERVICE_OPTS)
+    #         t_counts.append(result[0][0].val)
+    #     counts.append(t_counts)
+
+    size_t = image.getSizeT()
+    size_z = image.getSizeZ()
+    counts = [[0] * size_t for z in range(size_z)]
+
+    query = """
+        select shape.theZ, shape.theT from Shape shape
+        join shape.roi as roi where roi.image.id = :id
+    """
+    # key is 'z:t' for unattached shapes, e.g. {'none:5':3}
+    unattached_counts = defaultdict(int)
+    result = query_service.projection(query, params, conn.SERVICE_OPTS)
+    for shape in result:
+        z = unwrap(shape[0])
+        t = unwrap(shape[1])
+        if z is not None and t is not None:
+            counts[z][t] += 1
+        else:
+            key = "%s:%s" % (z, t)
+            unattached_counts[key] += 1
+
+    for key, count in unattached_counts.items():
+        z = key.split(':')[0]
+        t = key.split(':')[1]
+        z_range = range(size_z) if z == 'None' else [int(z)]
+        t_range = range(size_t) if t == 'None' else [int(t)]
+        for the_z in z_range:
+            for the_t in t_range:
+                counts[the_z][the_t] += count
+
+    return JsonResponse({'data': counts})
 
 @login_required()
 def image_data(request, image_id, conn=None, **kwargs):

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -278,6 +278,7 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
 
     return JsonResponse({'data': marshalled, 'meta': meta})
 
+
 @login_required()
 def plane_shape_counts(request, image_id, conn=None, **kwargs):
     """
@@ -342,6 +343,7 @@ def plane_shape_counts(request, image_id, conn=None, **kwargs):
                 counts[the_z][the_t] += count
 
     return JsonResponse({'data': counts})
+
 
 @login_required()
 def image_data(request, image_id, conn=None, **kwargs):

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -223,18 +223,28 @@ export default class DimensionSlider {
                                      dim: this.dim,
                                      value: [newValue]});
                         }));
-        this.observers.push(
-            this.bindingEngine.propertyObserver(
-                this.image_config.image_info, 'projection')
-                    .subscribe(
-                        (newValue, oldValue) => this.initSlider(true)));
-        this.observers.push(
-            this.bindingEngine.propertyObserver(
-                this.image_config.image_info, 'projection_opts')
-                    .subscribe(
-                        (newValue, oldValue) =>
-                            this.changeProjection(
-                                [newValue.start, newValue.end], false)));
+        // Only need to listen for projection changes if we are Z-slider
+        if (this.dim === 'z') {
+            this.observers.push(
+                this.bindingEngine.propertyObserver(
+                    this.image_config.image_info, 'projection')
+                        .subscribe(
+                            (newValue, oldValue) => this.initSlider(true)));
+            this.observers.push(
+                this.bindingEngine.propertyObserver(
+                    this.image_config.image_info.projection_opts, 'start')
+                        .subscribe(
+                            (newValue, oldValue) => {
+                                this.changeProjection(
+                                    [newValue, this.image_config.image_info.projection_opts.end], false)}));
+            this.observers.push(
+                this.bindingEngine.propertyObserver(
+                    this.image_config.image_info.projection_opts, 'end')
+                        .subscribe(
+                            (newValue, oldValue) => {
+                                this.changeProjection(
+                                    [this.image_config.image_info.projection_opts.start, newValue], false)}));
+        }
     }
 
     /**

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -58,6 +58,11 @@ export default class RegionsInfo  {
     data = new Map();
 
     /**
+     * 2D array of [t][z] shapes counts
+     */
+    plane_shape_counts = null;
+
+    /**
      * Page size for ROIs to support pagination.
      * Configured with bin/omero config set omero.web.iviewer.roi_page_size 500
      *

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -33,7 +33,7 @@
     <div show.bind="!is_pending">
         <!-- If sizeT > 1 we have outer loop through T and inner loop through Z -->
         <!-- We wrap T into multiple tables of 20 columns -->
-        <div if.bind="plane_shape_counts.length>1" class="grid_table" repeat.for="i of ceil(plane_shape_counts.length/20)">
+        <div if.bind="plane_shape_counts.length>1" class="grid_table pointer" repeat.for="i of ceil(plane_shape_counts.length/20)">
             <!-- Each table has a Y axis showing Z index -->
             <div class="col">
                 <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">
@@ -61,7 +61,7 @@
         </div>
 
         <!-- Alternative layout if single T-index -->
-        <div if.bind="plane_shape_counts.length===1" class="grid_table" repeat.for="i of ceil(plane_shape_counts[0].length/20)">
+        <div if.bind="plane_shape_counts.length===1" class="grid_table pointer" repeat.for="i of ceil(plane_shape_counts[0].length/20)">
             <div class="col">
                 <div class="grid_cell y_axis">
                 </div>

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -30,25 +30,55 @@
         <span>${max_shape_count}</span>
     </div>
 
-    <div show.bind="!is_pending" class="grid_table">
-        <div class="col">
-            <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">
-                ${plane_shape_counts[0].length - $index}
+    <div show.bind="!is_pending">
+        <!-- If sizeT > 1 we have outer loop through T and inner loop through Z -->
+        <!-- We wrap T into multiple tables of 20 columns -->
+        <div if.bind="plane_shape_counts.length>1" class="grid_table" repeat.for="i of ceil(plane_shape_counts.length/20)">
+            <!-- Each table has a Y axis showing Z index -->
+            <div class="col">
+                <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">
+                    ${plane_shape_counts[0].length - $index}
+                </div>
+                <div class="grid_cell x_axis">
+                    T:
+                </div>
+            <!-- Then we iterate through T... -->
+            </div><div repeat.for="t_col of slice(plane_shape_counts, i*20, (i+1)*20)" class="col"
+                    ref="t_index" t-index="${ (i*20) + $index }">
+                <!-- go through Z -->
+                <div repeat.for="zt_value of reverse(t_col)"
+                    class="grid_cell ${t_index.tIndex == regions_info.image_info.dimensions.t && selectedZ.indexOf(t_col.length - $index - 1) > -1 ? 'selected' : ''}"
+                    ref="z_index" z-index="${ t_col.length - $index - 1 }"
+                    css="background: ${ getColor(zt_value) }"
+                    title="${zt_value} Shapes T: ${ toInt(t_index.tIndex) + 1}, Z: ${ t_col.length - $index }"
+                    click.delegate="handleGridClick($event, z_index.zIndex, t_index.tIndex)">
+                </div>
+                <!-- show T index -->
+                <div class="grid_cell x_axis">
+                    ${toInt(t_index.tIndex) + 1}
+                </div>
             </div>
-            <div class="grid_cell x_axis">
-                T:
-            </div>
-        </div><div repeat.for="t_col of plane_shape_counts" class="col"
-                ref="t_index" t-index="${ $index }">
-            <div repeat.for="zt_value of reverse(t_col)"
-                class="grid_cell ${t_index.tIndex == regions_info.image_info.dimensions.t && selectedZ.indexOf(t_col.length - $index - 1) > -1 ? 'selected' : ''}"
-                ref="z_index" z-index="${ t_col.length - $index - 1 }"
-                css="background: ${ getColor(zt_value) }"
-                title="${zt_value} Shapes T: ${ toInt(t_index.tIndex) + 1}, Z: ${ t_col.length - $index }"
-                click.delegate="handleGridClick($event, z_index.zIndex, t_index.tIndex)">
-            </div>
-            <div class="grid_cell x_axis">
-                ${$index + 1}
+        </div>
+
+        <!-- Alternative layout if single T-index -->
+        <div if.bind="plane_shape_counts.length===1" class="grid_table" repeat.for="i of ceil(plane_shape_counts[0].length/20)">
+            <div class="col">
+                <div class="grid_cell y_axis">
+                </div>
+                <div class="grid_cell x_axis">
+                    Z:
+                </div>
+            </div><div repeat.for="zt_value of slice(plane_shape_counts[0], i*20, (i+1)*20)" class="col"
+                    ref="z_index" z-index="${ (i*20) + $index }">
+                <div
+                    class="grid_cell ${selectedZ.indexOf((i*20) + $index) > -1 ? 'selected' : ''}"
+                    css="background: ${ getColor(zt_value) }"
+                    title="${zt_value} Shapes"
+                    click.delegate="handleGridClick($event, z_index.zIndex, 0)">
+                </div>
+                <div class="grid_cell x_axis">
+                    ${toInt(z_index.zIndex) + 1}
+                </div>
             </div>
         </div>
     </div>

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -23,7 +23,7 @@
         <div class="grid_table" style="display: inline-block; position: relative; top: 4px">
             <div repeat.for="i of 5" class="col" style="margin-bottom: 0">
                 <div class="grid_cell" title="${ min_shape_count + (i * (max_shape_count - min_shape_count) /4) }"
-                    style="background: ${ getColor(min_shape_count + (i * (max_shape_count - min_shape_count) /4)) }">
+                    css="background: ${ getColor(min_shape_count + (i * (max_shape_count - min_shape_count) /4)) }">
                 </div>
             </div>
         </div>
@@ -43,7 +43,7 @@
             <div repeat.for="zt_value of reverse(t_col)"
                 class="grid_cell ${t_index.tIndex == regions_info.image_info.dimensions.t && selectedZ.indexOf(t_col.length - $index - 1) > -1 ? 'selected' : ''}"
                 ref="z_index" z-index="${ t_col.length - $index - 1 }"
-                style="background: ${ getColor(zt_value) }"
+                css="background: ${ getColor(zt_value) }"
                 title="${zt_value} Shapes T: ${ toInt(t_index.tIndex) + 1}, Z: ${ t_col.length - $index }"
                 click.delegate="handleGridClick($event, z_index.zIndex, t_index.tIndex)">
             </div>

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -1,5 +1,5 @@
 <!--
-    Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+    Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
     All rights reserved.
 
     This program is free software: you can redistribute it and/or modify

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -18,7 +18,7 @@
 <template>
     <div show.bind="is_pending">Loading data...</div>
 
-    <div class="grid_table">
+    <div show.bind="!is_pending" class="grid_table">
         <div class="col">
             <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">
                 ${plane_shape_counts[0].length - $index}

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -44,7 +44,7 @@
                 class="grid_cell ${t_index.tIndex == regions_info.image_info.dimensions.t && selectedZ.indexOf(t_col.length - $index - 1) > -1 ? 'selected' : ''}"
                 ref="z_index" z-index="${ t_col.length - $index - 1 }"
                 style="background: ${ getColor(zt_value) }"
-                title="${zt_value} Shapes T: ${t_index.tIndex + 1}"
+                title="${zt_value} Shapes T: ${ toInt(t_index.tIndex) + 1}, Z: ${ t_col.length - $index }"
                 click.delegate="handleGridClick($event, z_index.zIndex, t_index.tIndex)">
             </div>
             <div class="grid_cell x_axis">

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -38,10 +38,14 @@
             <div class="grid_cell x_axis">
                 T:
             </div>
-        </div><div repeat.for="z_row of plane_shape_counts" class="col">
-            <div repeat.for="value of reverse(z_row)" class="grid_cell"
-                style="background: ${ getColor(value) }"
-                title="${value} Shapes">
+        </div><div repeat.for="t_col of plane_shape_counts" class="col"
+                ref="t_index" t-index="${ $index }">
+            <div repeat.for="zt_value of reverse(t_col)"
+                class="grid_cell ${t_index.tIndex == regions_info.image_info.dimensions.t && selectedZ.indexOf(t_col.length - $index - 1) > -1 ? 'selected' : ''}"
+                ref="z_index" z-index="${ t_col.length - $index - 1 }"
+                style="background: ${ getColor(zt_value) }"
+                title="${zt_value} Shapes T: ${t_index.tIndex + 1}"
+                click.delegate="handleGridClick($event, z_index.zIndex, t_index.tIndex)">
             </div>
             <div class="grid_cell x_axis">
                 ${$index + 1}

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -1,0 +1,20 @@
+<!--
+    Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+    All rights reserved.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<template>
+    <div>Loading ROI counts...</div>
+</template>

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -16,5 +16,24 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
-    <div>Loading ROI counts...</div>
+    <div show.bind="is_pending">Loading data...</div>
+
+    <div class="grid_table">
+        <div class="col">
+            <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">
+                ${plane_shape_counts[0].length - $index}
+            </div>
+            <div class="grid_cell x_axis">
+                T:
+            </div>
+        </div><div repeat.for="z_row of plane_shape_counts" class="col">
+            <div repeat.for="value of reverse(z_row)" class="grid_cell"
+                style="background: ${ getColor(value) }"
+                title="${value} Shapes">
+            </div>
+            <div class="grid_cell x_axis">
+                ${$index + 1}
+            </div>
+        </div>
+    </div>
 </template>

--- a/src/regions/regions-planes.html
+++ b/src/regions/regions-planes.html
@@ -18,6 +18,18 @@
 <template>
     <div show.bind="is_pending">Loading data...</div>
 
+    <div show.bind="!is_pending" style="margin-bottom: 10px">
+        <span>Shapes per Z/T plane: ${min_shape_count}</span>
+        <div class="grid_table" style="display: inline-block; position: relative; top: 4px">
+            <div repeat.for="i of 5" class="col" style="margin-bottom: 0">
+                <div class="grid_cell" title="${ min_shape_count + (i * (max_shape_count - min_shape_count) /4) }"
+                    style="background: ${ getColor(min_shape_count + (i * (max_shape_count - min_shape_count) /4)) }">
+                </div>
+            </div>
+        </div>
+        <span>${max_shape_count}</span>
+    </div>
+
     <div show.bind="!is_pending" class="grid_table">
         <div class="col">
             <div repeat.for="z of plane_shape_counts[0]" class="grid_cell y_axis">

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -171,7 +171,6 @@ export default class RegionsPlanes {
 
         // Pick one of 5 colors
         let index = Math.round(percent/25);
-        console.log('getColor', count, this.min_shape_count, this.max_shape_count, percent, index);
         let colors = ['rgb(212, 222, 223)', 'rgb(178, 189, 193)', 'rgb(149, 153, 164)',
                     'rgb(90, 89, 109)', 'rgb(20, 18, 30)']
         return colors[index];

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -168,13 +168,10 @@ export default class RegionsPlanes {
             percent = 100;
         }
 
-        // Various color ranges
-        // return `hsl(229, ${ percent }%, 50%)`
-        // return `rgba(2, 141, 255, ${ (percent / 80) + 0.2 })`
-
         // Pick one of 5 colors
         let index = Math.round(percent/25);
-        let colors = ['#dee7cc', '#c6e48b', '#7bc96f', '#239a3b', '#196127'];
+        let colors = ['rgb(212, 222, 223)', 'rgb(178, 189, 193)', 'rgb(149, 153, 164)',
+                    'rgb(90, 89, 109)', 'rgb(20, 18, 30)']
         return colors[index];
     }
 
@@ -186,9 +183,13 @@ export default class RegionsPlanes {
      * @param {Number} tIndex clicked T-index
      */
     handleGridClick(event, zIndex, tIndex) {
+        zIndex = parseInt(zIndex);
+        tIndex = parseInt(tIndex);
+        // T-index doesn't support projection - simply select it
         this.regions_info.image_info.dimensions['t'] = tIndex;
+        // Support Shift-click to select Z-range (projection)
         if (!event.shiftKey) {
-            // select single Z/T plane (no projection)
+            // select single Z plane (no projection)
             this.regions_info.image_info.projection = PROJECTION.NORMAL;
             this.regions_info.image_info.dimensions['z'] = zIndex;
         } else {

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -18,6 +18,7 @@
 
 import {computedFrom} from 'aurelia-framework';
 import Context from '../app/context';
+import Ui from '../utils/ui';
 import { IVIEWER, ROI_TABS,
     PROJECTION} from '../utils/constants';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
@@ -183,6 +184,9 @@ export default class RegionsPlanes {
      * @param {Number} tIndex clicked T-index
      */
     handleGridClick(event, zIndex, tIndex) {
+        if (!this.checkForUnsavedRoiLoss()) {
+            return;
+        }
         zIndex = parseInt(zIndex);
         tIndex = parseInt(tIndex);
         // T-index doesn't support projection - simply select it
@@ -214,6 +218,25 @@ export default class RegionsPlanes {
                     zIndex, this.regions_info.image_info.dimensions.z
                 )
             }
+        }
+    }
+
+    /**
+     * Any change in Z/T or projection will cause ROIs to reload if we are
+     * paginating ROIs by Z/T plane.
+     * Returns true if we are paginating ROIs by plane AND we have unsaved
+     * changes to ROIs.
+     */
+    checkForUnsavedRoiLoss() {
+        if (this.regions_info.isRoiLoadingPaginatedByPlane() &&
+                this.regions_info.hasBeenModified()) {
+            Ui.showModalMessage(
+                "You have unsaved ROI changes. Please Save or Undo " +
+                "before moving to a new plane.",
+                "OK");
+            return false;
+        } else {
+            return true;
         }
     }
 

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -1,0 +1,123 @@
+//
+// Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// js
+import Context from '../app/context';
+import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
+
+/**
+ * Represents the regions planes sub-tab in the right hand panel
+ */
+@customElement('regions-planes')
+@inject(Context, BindingEngine)
+export default class RegionsPlanes {
+    /**
+     * a bound reference to regions_info
+     * and its associated change handler
+     * @memberof RegionsPlanes
+     * @type {RegionsInfo}
+     */
+    @bindable regions_info = null;
+
+    @bindable selected_roi_tab = null;
+
+    /**
+     * the list of property observers
+     * @memberof RegionsPlanes
+     * @type {Array.<Object>}
+     */
+    observers = [];
+
+    /**
+     * 2D array of [z][t] shapes counts
+     */
+    plane_shape_counts;
+
+    /**
+     * @constructor
+     * @param {Context} context the application context (injected)
+     * @param {BindingEngine} bindingEngine the BindingEngine (injected)
+     */
+    constructor(context, bindingEngine) {
+        this.context = context;
+        this.bindingEngine = bindingEngine;
+    }
+
+    requestData() {
+        if (typeof refresh !== 'boolean') refresh = false;
+        this.ready = false;
+
+        $.ajax({
+            url :
+                this.context.server + this.context.getPrefixedURI(IVIEWER) +
+                "/plane_shape_counts/" + this.regions_info.image_info.image_id + '/',
+            success : (response) => {
+                console.log('response', response);
+            },
+            error : (error, textStatus) => {
+                if (typeof error.responseText === 'string') {
+                    console.error(error.responseText);
+                }
+            }
+        });
+    }
+
+     /**
+      * Overridden aurelia lifecycle method:
+      * called whenever the view is bound within aurelia
+      * in other words an 'init' hook that happens before 'attached'
+      *
+      * @memberof RegionsDrawing
+      */
+     bind() {
+        this.registerObservers();
+     }
+
+    /**
+     * Registers observers to react to drawing mode & shape_defaults changes
+     *
+     * @memberof RegionsDrawing
+     */
+    registerObservers() {
+        this.observers.push(
+            this.bindingEngine.propertyObserver(this, "selected_roi_tab")
+                .subscribe((newValue, oldValue) => {
+                    console.log('selected_tab', newValue, oldValue)
+                }
+            )
+        );
+    }
+
+    /**
+     * Unregisters the the observers (property and regions info ready)
+     */
+    unregisterObservers() {
+        this.observers.forEach((o) => {if (o) o.dispose();});
+        this.observers = [];
+    }
+
+    /**
+     * Overridden aurelia lifecycle method:
+     * called whenever the view is unbound within aurelia
+     * in other words a 'destruction' hook that happens after 'detached'
+     */
+    unbind() {
+        // this.unsubscribe();
+        this.unregisterObservers();
+    }
+}

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -36,9 +36,32 @@ export default class RegionsPlanes {
     @bindable regions_info = null;
 
     /**
+     * When the regions_info changes, force load/refresh data
+     * @param {RegionsInfo} newVal
+     * @param {RegionsInfo} oldVal
+     */
+    regions_infoChanged(newVal, oldVal) {
+        if (this.selected_roi_tab === ROI_TABS.ROI_PLANE_GRID) {
+            this.requestData(true);
+        }
+    }
+
+    /**
      * The current ROI sub-tab selected by the parent regions component
      */
     @bindable selected_roi_tab = null;
+
+    /**
+     * When the selected_roi_tab changes, load data (if not already loaded)
+     * @param {String} newVal
+     * @param {String} oldVal
+     */
+    selected_roi_tabChanged(newVal, oldVal) {
+        console.log('selected_roi_tabChanged');
+        if (this.selected_roi_tab === ROI_TABS.ROI_PLANE_GRID) {
+            this.requestData();
+        }
+    }
 
     /**
      * the list of property observers
@@ -111,17 +134,6 @@ export default class RegionsPlanes {
         });
     }
 
-     /**
-      * Overridden aurelia lifecycle method:
-      * called whenever the view is bound within aurelia
-      * in other words an 'init' hook that happens before 'attached'
-      *
-      * @memberof RegionsDrawing
-      */
-    bind() {
-        this.registerObservers();
-    }
-
     /**
      * Simple copy and reverse of Array
      * @param {Array} arr
@@ -138,41 +150,9 @@ export default class RegionsPlanes {
      * @param {Number} count
      */
     getColor(count) {
-        return `rgb(0,0,${ (count * 255 / this.max_shape_count) })`;
-    }
-
-    /**
-     * Registers observers to react to drawing mode & shape_defaults changes
-     *
-     * @memberof RegionsDrawing
-     */
-    registerObservers() {
-        this.observers.push(
-            this.bindingEngine.propertyObserver(this, "selected_roi_tab")
-                .subscribe((newValue, oldValue) => {
-                    if (newValue === ROI_TABS.ROI_PLANE_GRID) {
-                        this.requestData();
-                    }
-                }
-            )
-        );
-    }
-
-    /**
-     * Unregisters the the observers (property and regions info ready)
-     */
-    unregisterObservers() {
-        this.observers.forEach((o) => {if (o) o.dispose();});
-        this.observers = [];
-    }
-
-    /**
-     * Overridden aurelia lifecycle method:
-     * called whenever the view is unbound within aurelia
-     * in other words a 'destruction' hook that happens after 'detached'
-     */
-    unbind() {
-        // this.unsubscribe();
-        this.unregisterObservers();
+        if (count === 0) {
+            return '#ddd';
+        }
+        return `hsl(229, ${ (count * 100 / this.max_shape_count) }%, 50%)`
     }
 }

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -166,7 +166,14 @@ export default class RegionsPlanes {
         if (this.min_shape_count === this.max_shape_count) {
             percent = 100;
         }
+
+        // Various color ranges
         // return `hsl(229, ${ percent }%, 50%)`
-        return `rgba(2, 141, 255, ${ (percent / 80) + 0.2 })`
+        // return `rgba(2, 141, 255, ${ (percent / 80) + 0.2 })`
+
+        // Pick one of 5 colors
+        let index = Math.round(percent/25);
+        let colors = ['#dee7cc', '#c6e48b', '#7bc96f', '#239a3b', '#196127'];
+        return colors[index];
     }
 }

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -270,4 +270,22 @@ export default class RegionsPlanes {
     toInt(number) {
         return parseInt(number)
     }
+
+    /**
+     * Allow template to use slice.
+     *
+     * @param {String} number
+     */
+    slice(list, start, end) {
+        return list.slice(start, end);
+    }
+
+    /**
+     * Allow template to use Math.ceil.
+     *
+     * @param {String} number
+     */
+    ceil(x) {
+        return Math.ceil(x);
+    }
 }

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -171,6 +171,7 @@ export default class RegionsPlanes {
 
         // Pick one of 5 colors
         let index = Math.round(percent/25);
+        console.log('getColor', count, this.min_shape_count, this.max_shape_count, percent, index);
         let colors = ['rgb(212, 222, 223)', 'rgb(178, 189, 193)', 'rgb(149, 153, 164)',
                     'rgb(90, 89, 109)', 'rgb(20, 18, 30)']
         return colors[index];

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -193,14 +193,16 @@ export default class RegionsPlanes {
             this.regions_info.image_info.dimensions['z'] = zIndex;
         } else {
             // select range...
-            // If projection enabled, extend the range
+            // If projection enabled, update start/end (whichever is closest to zIndex)
             if (this.regions_info.image_info.projection === PROJECTION.INTMAX) {
-                this.regions_info.image_info.projection_opts.start = Math.min(
-                    zIndex, this.regions_info.image_info.projection_opts.start
-                )
-                this.regions_info.image_info.projection_opts.end = Math.max(
-                    zIndex, this.regions_info.image_info.projection_opts.end
-                )
+                let start = this.regions_info.image_info.projection_opts.start;
+                let end = this.regions_info.image_info.projection_opts.end;
+                let midPoint = (start + end)/2;
+                if (zIndex < midPoint) {
+                    this.regions_info.image_info.projection_opts.start = zIndex;
+                } else {
+                    this.regions_info.image_info.projection_opts.end = zIndex;
+                }
             } else {
                 // If projection not enabled, select range from current Z
                 this.regions_info.image_info.projection = PROJECTION.INTMAX;

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -57,7 +57,6 @@ export default class RegionsPlanes {
      * @param {String} oldVal
      */
     selected_roi_tabChanged(newVal, oldVal) {
-        console.log('selected_roi_tabChanged');
         if (this.selected_roi_tab === ROI_TABS.ROI_PLANE_GRID) {
             this.requestData();
         }
@@ -80,6 +79,12 @@ export default class RegionsPlanes {
      * @type {Number}
      */
     max_shape_count = 0;
+
+    /**
+     * Min number of shapes on a single plane
+     * @type {Number}
+     */
+    min_shape_count = 0;
 
     /**
      * Flag to indicate when we are loading data
@@ -112,11 +117,13 @@ export default class RegionsPlanes {
                 this.is_pending = false;
                 let shape_counts = [];
                 let max_count = 1;
+                let min_count = Infinity;
                 // switch 2D array [z][t] to [t][z] to aid layout
                 for (let t=0; t<response.data[0].length; t++) {
                     let t_counts = [];
                     for (let z=0; z<response.data.length; z++) {
                         let value = response.data[z][t];
+                        min_count = Math.min(min_count, value);
                         max_count = Math.max(max_count, value);
                         t_counts.push(value);
                     }
@@ -124,6 +131,7 @@ export default class RegionsPlanes {
                 }
                 this.plane_shape_counts = shape_counts;
                 this.max_shape_count = max_count;
+                this.min_shape_count = min_count;
             },
             error : (error, textStatus) => {
                 this.is_pending = false;
@@ -153,6 +161,12 @@ export default class RegionsPlanes {
         if (count === 0) {
             return '#ddd';
         }
-        return `hsl(229, ${ (count * 100 / this.max_shape_count) }%, 50%)`
+        let percent = (count - this.min_shape_count) * 100 / 
+            (this.max_shape_count - this.min_shape_count);
+        if (this.min_shape_count === this.max_shape_count) {
+            percent = 100;
+        }
+        // return `hsl(229, ${ percent }%, 50%)`
+        return `rgba(2, 141, 255, ${ (percent / 80) + 0.2 })`
     }
 }

--- a/src/regions/regions-planes.js
+++ b/src/regions/regions-planes.js
@@ -261,4 +261,13 @@ export default class RegionsPlanes {
         }
         return zPlanes;
     }
+
+    /**
+     * Allow template to use parseInt.
+     *
+     * @param {String} number
+     */
+    toInt(number) {
+        return parseInt(number)
+    }
 }

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -19,6 +19,7 @@
     <require from="./regions-list"></require>
     <require from="./regions-drawing"></require>
     <require from="./regions-edit"></require>
+    <require from="./regions-planes"></require>
 
     <div class="regions-container">
         <div class="regions-tools">
@@ -70,7 +71,25 @@
             </regions-drawing>
             <hr />
         </div>
-        <regions-list regions_info.bind="regions_info" class="regions-list">
-        </regions-list>
+        <ul id="regions-tabs" class="nav nav-tabs small-tabs" role="tablist">
+            <li class="${selected_roi_tab === ROI_TABS.ROI_TABLE ? 'active' : ''}">
+                <a href="#${ ROI_TABS.ROI_TABLE }" role="tab">ROIs</a>
+            </li>
+            <li class="${selected_roi_tab === ROI_TABS.ROI_PLANE_GRID ? 'active' : ''}">
+                <a href="#${ ROI_TABS.ROI_PLANE_GRID }" role="tab">Planes</a>
+            </li>
+        </ul>
+        <div id="regions-tabs-content" class="tab-content">
+            <div id="roi-table"
+                class="tab-pane ${selected_roi_tab === ROI_TABS.ROI_TABLE ? 'active' : ''}">
+                <regions-list regions_info.bind="regions_info" class="regions-list">
+                </regions-list>
+            </div>
+            <div id="roi-plane-grid" role="tabpanel"
+                class="tab-pane ${selected_roi_tab === ROI_TABS.ROI_PLANE_GRID ? 'active' : ''}">
+                <regions-planes regions_info.bind="regions_info" selected_roi_tab.bind="selected_roi_tab">
+                </regions-planes>
+            </div>
+        </div>
     </div>
 </template>

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -20,9 +20,8 @@
 import Context from '../app/context';
 import Misc from '../utils/misc';
 import Ui from '../utils/ui';
-import {TABS} from '../utils/constants';
+import {TABS, ROI_TABS} from '../utils/constants';
 import {REGIONS_STORE_SHAPES, REGIONS_SHOW_COMMENTS} from '../events/events';
-import {PROJECTION} from '../utils/constants';
 import {inject, customElement, bindable} from 'aurelia-framework';
 
 /**
@@ -51,19 +50,15 @@ export default class Regions {
     ];
 
     /**
-     * IDs of the tabs within the ROI panel
-     * @type {Object}
+     * Make this available to the template
      */
-    ROI_TABS = {
-        ROI_PLANE_GRID: "ROI_PLANE_GRID",
-        ROI_TABLE: "ROI_TABLE",
-    }
+    ROI_TABS = ROI_TABS;
 
     /**
      * Currently selected tab within the ROI panel. One of the ROI_TABS options.
      * @type {String}
      */
-    selected_roi_tab = this.ROI_TABS.ROI_TABLE;
+    selected_roi_tab = ROI_TABS.ROI_TABLE;
 
     /**
      * @constructor

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -51,6 +51,21 @@ export default class Regions {
     ];
 
     /**
+     * IDs of the tabs within the ROI panel
+     * @type {Object}
+     */
+    ROI_TABS = {
+        ROI_PLANE_GRID: "ROI_PLANE_GRID",
+        ROI_TABLE: "ROI_TABLE",
+    }
+
+    /**
+     * Currently selected tab within the ROI panel. One of the ROI_TABS options.
+     * @type {String}
+     */
+    selected_roi_tab = this.ROI_TABS.ROI_TABLE;
+
+    /**
      * @constructor
      * @param {Context} context the application context (injected)
      */
@@ -66,6 +81,11 @@ export default class Regions {
      */
     attached() {
         Ui.registerKeyHandlers(this.context, this.key_actions, TABS.ROIS, this);
+
+        $("#regions-tabs").find("a").click((e) => {
+            e.preventDefault();
+            this.selected_roi_tab = e.currentTarget.hash.substring(1);
+        });
     }
 
     /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -252,6 +252,15 @@ export const TABS = {
 }
 
 /**
+ * IDs of the tabs within the ROI panel
+ * @type {Object}
+ */
+export const ROI_TABS = {
+    ROI_PLANE_GRID: "ROI_PLANE_GRID",
+    ROI_TABLE: "ROI_TABLE",
+}
+
+/**
  * the possible intial types the viewer was openend with
  * @type {Object}
  */


### PR DESCRIPTION
This allows you to browse ROIs by plane (find which planes have most ROIs on them).
It implements most of what's on https://github.com/openmicroscopy/design/issues/91

To test:
 - Find a multi-plane image and make sure you have various numbers of Shapes on different planes, including some shapes 'unattached' to Z or T.
 - Under the ROIs tab, click on the "Planes" sub-tab.
 - The grid should show numbers of shapes that appear on each Z/T plane.
 - The 'Key' should show the range of Shape counts per plane
 - Tool-tip on each grid 'cell' should give you the count for that plane.
 - Clicking on the plane should take you to that Z/T position (and show the cell selected)
 - Shift-clicking on a Z-stack image should select a Z-projection range.
 - Single-click (no Shift) should turn off the Z-projection again.

Demo at https://twitter.com/will_j_moore/status/1103206476695236609