### PR TITLE
fix 11 thumbnails in Dataset

### DIFF
--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -416,7 +416,7 @@ export default class ThumbnailSlider extends EventSubscriber {
         }
         if (unloaded.length > 0) {
             thumb_start_index = unloaded[0];
-            thumb_end_index = unloaded[unloaded.length-1];
+            thumb_end_index = unloaded[unloaded.length-1] + 1;
             this.requestMoreThumbnails(init, refresh, thumb_start_index, thumb_end_index);
         }
     }


### PR DESCRIPTION
To test:
 - Find or create a Dataset with 11 images (or 21, or 31 etc)
 - Open first image in iviewer
 - Scroll thumbnail slider - check that thumbs load correctly and the LAST thumbnail loads.