### PR TITLE
zoom 1-to-1 don't setCenter

### DIFF
--- a/src/viewers/viewer/controls/Zoom.js
+++ b/src/viewers/viewer/controls/Zoom.js
@@ -178,8 +178,6 @@ class Zoom extends Control {
                 var view = map ? map.getView() : null;
                 if (view === null) return;
                 view.setResolution(1);
-                var ext = view.getProjection().getExtent();
-                view.setCenter([(ext[2]-ext[0])/2, -(ext[3]-ext[1])/2]);
             }, this);
 
         return oneToOneElement;


### PR DESCRIPTION
I have found it annoying when panning around an image that when I want to zoom to 100%, the ``` 1:1 ``` button also re-centres the viewport to the centre of the image, especially on a big image when you are a long way from the centre-point.

To test:
 - Zoom and pan around an image
 - Click the ```1:1``` button to go to 100% zoom
 - The centre of the viewport should not change