### PR TITLE
Fix ROI loading on play movie

### DIFF
--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -263,7 +263,8 @@ export default class RegionsList extends EventSubscriber {
             let last_plane = image_info.dimensions['max_' + params.dim] - 1;
             let dim_value = image_info.dimensions[params.dim];
             // If movie is playing and we're not on the last plane - ignore
-            if (image_config.is_movie_playing && dim_value < last_plane) {
+            if (image_config.is_movie_playing && dim_value < last_plane &&
+                    this.regions_info.isRoiLoadingPaginatedByPlane()) {
                 this.regions_info.resetRegionsInfo();
                 return;
             }


### PR DESCRIPTION
Added a missing check here to only clear the ROIs if we are loading the ROIs by plane (for images with > 500 ROIs).
I already had this check for re-loading ROIs when the movie stopped, which is why they never re-load.

To test:
 - Find a multi-T image with < 500 ROIs on various planes (and/or 'unattached' to T) e.g. http://web-dev-merge.openmicroscopy.org/webclient/img_detail/9469/ (user-3)
 - Play the movie
 - ROIs should remain loaded and update on each change of T (as before)