### PR TITLE
Scale bar lengths

### DIFF
--- a/src/viewers/viewer/controls/ScaleBar.js
+++ b/src/viewers/viewer/controls/ScaleBar.js
@@ -36,11 +36,11 @@ class ScaleBar extends ScaleLine {
         super(opt_options);
 
         /**
-         * default scale bar width in pixels
+         * minimum scale bar width in pixels
          * @type {number}
          * @private
          */
-        this.bar_width_ = 100;
+        this.bar_min_width_ = 100;
 
         /**
          * the scalebar 'drag' listener
@@ -102,7 +102,9 @@ class ScaleBar extends ScaleLine {
 
         var micronsPerPixel = viewState.projection.getMetersPerUnit();
         var resolution = viewState.resolution;
-        var scaleBarLengthInUnits = micronsPerPixel * this.bar_width_ * resolution;
+
+        // first find the Units and Length for min-length scalebar
+        var scaleBarLengthInUnits = micronsPerPixel * this.bar_min_width_ * resolution;
         var symbol = '\u00B5m';
         for (var u=0;u<UNITS_LENGTH.length;u++) {
             var unit = UNITS_LENGTH[u];
@@ -113,16 +115,21 @@ class ScaleBar extends ScaleLine {
             }
         }
 
-        var html = scaleBarLengthInUnits.toFixed(2) + ' ' + symbol;
-        if (this.renderedHTML_ !== html) {
-            this.innerElement_.innerHTML = html;
-            this.renderedHTML_ = html;
+        // Find a length value BIGGER than our min target length
+        let snapToLengths = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
+        var value = 0;
+        let pixels = 0;
+        for (let snap=0; snap<snapToLengths.length; snap++) {
+            value = snapToLengths[snap];
+            if (value >= scaleBarLengthInUnits) {
+                pixels = this.bar_min_width_ * value / scaleBarLengthInUnits;
+                break;
+            }
         }
 
-        if (this.renderedWidth_ != this.bar_width_) {
-            this.innerElement_.style.width = this.bar_width_ + 'px';
-            this.renderedWidth_ = this.bar_width_;
-        }
+        var html = value + ' ' + symbol;
+        this.innerElement_.innerHTML = html;
+        this.innerElement_.style.width = pixels + 'px';
 
         if (!this.renderedVisible_) {
             this.element.style.display = '';

--- a/src/viewers/viewer/controls/ScaleBar.js
+++ b/src/viewers/viewer/controls/ScaleBar.js
@@ -22,6 +22,13 @@ import {listen, unlistenByKey} from 'ol/events';
 import {UNITS_LENGTH} from '../globals';
 
 /**
+ * For a given pixel unit, e.g. microns, we want the scalebar to be one of
+ * these lengths.
+ */
+const SNAP_TO_LENGTHS = [1, 2, 5, 10, 20, 50,
+                         100, 200, 500, 1000, 2000, 5000, 10000];
+
+/**
  * @classdesc
  * Extends the built ScaleLine
  */
@@ -116,11 +123,10 @@ class ScaleBar extends ScaleLine {
         }
 
         // Find a length value BIGGER than our min target length
-        let snapToLengths = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
         var value = 0;
         let pixels = 0;
-        for (let snap=0; snap<snapToLengths.length; snap++) {
-            value = snapToLengths[snap];
+        for (let snap=0; snap<SNAP_TO_LENGTHS.length; snap++) {
+            value = SNAP_TO_LENGTHS[snap];
             if (value >= scaleBarLengthInUnits) {
                 pixels = this.bar_min_width_ * value / scaleBarLengthInUnits;
                 break;

--- a/src/viewers/viewer/globals.js
+++ b/src/viewers/viewer/globals.js
@@ -222,7 +222,7 @@ export const PROJECTION = {
  */
 export const UNITS_LENGTH = [
     { unit: 'angstrom',
-      threshold: 0.1, multiplier: 10000, symbol: '\u212B'},
+      threshold: 0.01, multiplier: 10000, symbol: '\u212B'},
     { unit: 'nanometer',
       threshold: 1, multiplier: 1000, symbol: 'nm'},
     { unit: 'micron',
@@ -232,7 +232,9 @@ export const UNITS_LENGTH = [
     { unit: 'centimeter',
       threshold: 1000000, multiplier: 0.0001, symbol: 'cm'},
     { unit: 'meter',
-      threshold: 100000000, multiplier: 0.000001, symbol: 'm'}
+      threshold: 1000000000, multiplier: 0.000001, symbol: 'm'},
+    { unit: 'kilometer',
+      threshold: Infinity, multiplier: 0.000000001, symbol: 'km'},
  ];
 
 /**


### PR DESCRIPTION
See https://github.com/ome/omero-iviewer/issues/252

Now we calculate the length of the scalebar to show a nice rounded number.

To test:
 - find / create images with various pixel sizes (see first 4 images in Dataset http://web-dev-merge.openmicroscopy.org/webclient/?show=dataset-27801 user-3)
 - zoom in & out and check that scalebar is accurate and shows a nice round number.

E.g, zooming in looks something like this:

<img width="175" alt="Screen Shot 2019-03-19 at 04 08 15" src="https://user-images.githubusercontent.com/900055/54579791-1470c880-49fd-11e9-9477-ce53cf3031a3.png">

<img width="173" alt="Screen Shot 2019-03-19 at 04 08 31" src="https://user-images.githubusercontent.com/900055/54579799-1d619a00-49fd-11e9-9948-78e889bdd51b.png">

<img width="227" alt="Screen Shot 2019-03-19 at 04 08 50" src="https://user-images.githubusercontent.com/900055/54579805-2488a800-49fd-11e9-8837-9173c0ed4bbd.png">

<img width="193" alt="Screen Shot 2019-03-19 at 04 08 57" src="https://user-images.githubusercontent.com/900055/54579810-2ce0e300-49fd-11e9-8153-dde5e0884b94.png">

<img width="234" alt="Screen Shot 2019-03-19 at 04 09 08" src="https://user-images.githubusercontent.com/900055/54579859-57cb3700-49fd-11e9-8b07-e1c9c9205aa8.png">

<img width="227" alt="Screen Shot 2019-03-19 at 04 09 15" src="https://user-images.githubusercontent.com/900055/54579866-5dc11800-49fd-11e9-8fb1-f55292224e81.png">
