### PR TITLE
Clear cached image settings on save all

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -945,6 +945,15 @@ export default class Context {
     }
 
     /**
+     * Clears cache of image settings for all images
+     *
+     * @memberof Context
+     */
+    clearCachedImageSettings() {
+        this.cached_image_settings = {};
+    }
+
+    /**
      * Convenience or short hand way of publishing via the internal eventbus.
      * It will just delegate whatever you hand it as arguments
      *

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -945,12 +945,22 @@ export default class Context {
     }
 
     /**
-     * Clears cache of image settings for all images
+     * Clears cache of image settings, specified by ID.
+     * If imageIds is not defined, this clears ALL cached images settings.
      *
+     * @param {Array.<number>} imageIds the IDs of Images to clear from cache
      * @memberof Context
      */
-    clearCachedImageSettings() {
-        this.cached_image_settings = {};
+    clearCachedImageSettings(imageIds) {
+        if (Misc.isArray(imageIds)) {
+            imageIds.forEach(image_id => {
+                if (this.cached_image_settings[image_id]) {
+                    delete this.cached_image_settings[image_id];
+                }
+            });
+        } else {
+            this.cached_image_settings = {};
+        }
     }
 
     /**

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -409,12 +409,15 @@ export default class Settings extends EventSubscriber {
             };
             params.success =
                 (response) => {
-                    // Clear any cached settings; Newly saved settings are used
-                    this.context.clearCachedImageSettings();
                     let thumbIds = [imgInf.image_id];
                     if (typeof response === 'object' && response !== null &&
-                        Misc.isArray(response.True))
+                        Misc.isArray(response.True)) {
                         thumbIds = thumbIds.concat(response.True);
+                        // Clear any cached settings; Newly saved settings are used
+                        this.context.clearCachedImageSettings(response.True);
+                    } else {
+                        this.context.clearCachedImageSettings();
+                    }
                     // reissue get rendering requests, then
                     // force thumbnail update
                     let action =

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -409,6 +409,8 @@ export default class Settings extends EventSubscriber {
             };
             params.success =
                 (response) => {
+                    // Clear any cached settings; Newly saved settings are used
+                    this.context.clearCachedImageSettings();
                     let thumbIds = [imgInf.image_id];
                     if (typeof response === 'object' && response !== null &&
                         Misc.isArray(response.True))


### PR DESCRIPTION
See https://trello.com/c/zdbn7Fhh/72-cached-rnd-and-save-to-all

To test:
 - Find a Dataset that has some "compatible" images where Save-to-all works, but also some that are not compatible.
 - Browse through the images in iviewer, so that we cache settings for them.
 - Save to All so that multiple images are updated
 - The cache should be cleared for all "compatible" images where the Save to All was applied. The newly saved rendering settings should be shown for these images
 - For the non-compatible images, the cache should not be cleared. They should still display the last-viewed settings.

cc @pwalczysko 