### PR TITLE
ROI export menu rename

### DIFF
--- a/src/app/header.html
+++ b/src/app/header.html
@@ -91,7 +91,7 @@
                     <li class="${image_config.regions_info.ready &&
                                  image_config.regions_info.selected_shapes.length > 0 ?
                                     '' : 'disabled-color'}"
-                        title="Export selected ROIs to a spreadsheet (csv file), suitable for opening in Excel">
+                        title="Export selected ROIs to a spreadsheet (CSV file), suitable for opening in Excel">
                         <a click.delegate="saveRoiMeasurements(true)"
                            href="#">Export as Table (CSV)</a>
                     </li>

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -90,15 +90,10 @@
                     </li>
                     <li class="${image_config.regions_info.ready &&
                                  image_config.regions_info.selected_shapes.length > 0 ?
-                                    '' : 'disabled-color'}">
-                        <a click.delegate="saveRoiMeasurements(false)"
-                           href="#">Export (Excel)</a>
-                    </li>
-                    <li class="${image_config.regions_info.ready &&
-                                 image_config.regions_info.selected_shapes.length > 0 ?
-                                    '' : 'disabled-color'}">
+                                    '' : 'disabled-color'}"
+                        title="Export selected ROIs to a spreadsheet (csv file), suitable for opening in Excel">
                         <a click.delegate="saveRoiMeasurements(true)"
-                           href="#">Export (CSV)</a>
+                           href="#">Export as Table</a>
                     </li>
                 </ul>
             </div>

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -93,7 +93,7 @@
                                     '' : 'disabled-color'}"
                         title="Export selected ROIs to a spreadsheet (csv file), suitable for opening in Excel">
                         <a click.delegate="saveRoiMeasurements(true)"
-                           href="#">Export as Table</a>
+                           href="#">Export as Table (CSV)</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
See https://trello.com/c/UySyfhIZ/7-export-to-excel-options

This removes the confusing "Export (Excel)" option from ROI menu.
Also renames the existing one and adds tooltip to give more info.


![Screen Shot 2019-04-01 at 12 38 34](https://user-images.githubusercontent.com/900055/55324870-3fd2c900-547b-11e9-9ab1-02c7a094ab74.png)
