### PR TITLE
Use size 96 thumbnail for BirdsEye

### DIFF
--- a/src/viewers/viewer/controls/BirdsEye.js
+++ b/src/viewers/viewer/controls/BirdsEye.js
@@ -111,7 +111,7 @@ class BirdsEye extends Control {
         * @type {Array.<number>}
         * @private
         */
-        this.thumbnail_size_ = [96, 96];
+        this.thumbnail_size_ = [150, 100];
         var fullSidesRatio = this.full_image_size_[0] / this.full_image_size_[1];
         var tmp = [
             this.thumbnail_size_[0],

--- a/src/viewers/viewer/controls/BirdsEye.js
+++ b/src/viewers/viewer/controls/BirdsEye.js
@@ -111,7 +111,7 @@ class BirdsEye extends Control {
         * @type {Array.<number>}
         * @private
         */
-        this.thumbnail_size_ = [150, 100];
+        this.thumbnail_size_ = [96, 96];
         var fullSidesRatio = this.full_image_size_[0] / this.full_image_size_[1];
         var tmp = [
             this.thumbnail_size_[0],
@@ -314,9 +314,7 @@ class BirdsEye extends Control {
         var map = this.getMap();
         var rev = new Date().getTime();
         if (map) rev += "-" + getTargetId(map.getTargetElement());
-
-        return this.thumbnail_url_ + "/" + this.thumbnail_size_[0] +
-            "/" + this.thumbnail_size_[1] + "/?rev=" + rev;
+        return this.thumbnail_url_ + "/?rev=" + rev;
     }
 
     /**


### PR DESCRIPTION
See https://trello.com/c/E62b6Qsc/51-bug-birds-eye-view

This uses the default size 96 thumbnail for the Birds Eye view which means we can use the cached thumbnail which is much faster, particularly for big images. This was the behaviour of the old viewer.

To test:
 - Check that the Birds-Eye works for image in the trello card above.