### PR TITLE
Scalebar border-radius 0

### DIFF
--- a/css/ol3-viewer.css
+++ b/css/ol3-viewer.css
@@ -36,6 +36,9 @@
     cursor: pointer;
     z-index: 2;
 }
+.ol-control.ol-scale-line {
+    border-radius: 0;
+}
 .ol-scale-line-inner {
     border-bottom: 6px solid #000;
     color: #333;


### PR DESCRIPTION
See https://github.com/ome/omero-iviewer/issues/259

To test, check that scalebar doesn't have rounded corners.

Thanks to @kouichi-c-nakamura for the fix.