### PR TITLE
ellipse area

### DIFF
--- a/src/viewers/viewer/geom/Ellipse.js
+++ b/src/viewers/viewer/geom/Ellipse.js
@@ -217,6 +217,16 @@ class Ellipse extends Polygon {
     }
 
     /**
+     * Returns the Area as Pi * rx * ry instead of relying on Polygon superclass
+     * method which is less accurate.
+     *
+     * @return {number} the area of the ellipse
+     */
+    getArea() {
+        return Math.PI * this.rx_ * this.ry_;
+    }
+
+    /**
      * Make a complete copy of the geometry.
      * @return {Ellipse} Clone.
      */


### PR DESCRIPTION
This improves the accuracy of the Area reported for an Ellipse, using ```PI * rx * ry``` instead of relying on OpenLayers which treats the Ellipse like a Polygon.
It should fix the discrepancy between the Polygon area seen in iviewer vv exported in Batch_ROI_Export.py script, as reported https://github.com/ome/scripts/pull/147#issuecomment-483335252
