### PR TITLE
Show roi.Name in list if set

### DIFF
--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -408,6 +408,7 @@ export default class RegionsInfo  {
             for (let r in data) {
                 let shapes = new Map();
                 let roi = data[r];
+                let name = data[r]['Name'] || '';
                 // add shapes
                 if (Misc.isArray(roi.shapes) && roi.shapes.length > 0) {
                     let roiId = roi['@id'];
@@ -437,6 +438,7 @@ export default class RegionsInfo  {
                         count++;
                     }
                     this.data.set(roiId, {
+                        name: name,
                         shapes: shapes,
                         show: false,
                         deleted: 0

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -123,8 +123,8 @@
                         <div class="regions-table-col shape-z"></div>
                         <div class="regions-table-col shape-t"></div>
                         <div class="regions-table-col shape-c"></div>
-                        <div class="regions-table-col shape-comment"
-                             style="display: none">
+                        <div class="regions-table-col shape-comment">
+                            ${roi.name}
                         </div>
                         <div class="regions-table-col shape-area"></div>
                         <div class="regions-table-col shape-length"></div>


### PR DESCRIPTION
`omero.model.RoiI` has a name field. This is currently ignored by iviewer, here it is displayed in the `Comment` column. In this example the ROIs are named `"1"`, `"2"`, `"3"`, ...

![Screen Shot 2019-06-04 at 15 35 24-fullpage](https://user-images.githubusercontent.com/1644105/58887903-6365fa00-86de-11e9-829f-d53369fa212a.png)
