### PR TITLE
Use conn.SERVICE_OPTS in well_images()

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -482,7 +482,8 @@ def well_images(request, conn=None, **kwargs):
         # get total count first
         count = query_service.projection(
             "select count(distinct ws.id) from WellSample ws " +
-            "where ws.well.id = :well_id", params, )
+            "where ws.well.id = :well_id", params,
+            conn.SERVICE_OPTS)
         results = {"data": [], "meta": {"totalCount": count[0][0].val}}
 
         # set offset and limit
@@ -494,7 +495,8 @@ def well_images(request, conn=None, **kwargs):
         # fire off query
         images = query_service.findAllByQuery(
             "select ws.image from WellSample ws " +
-            "where ws.well.id = :well_id order by well_index", params)
+            "where ws.well.id = :well_id order by well_index", params,
+            conn.SERVICE_OPTS)
 
         # we need only image id and name for our purposes
         for img in images:


### PR DESCRIPTION
See https://github.com/ome/omero-iviewer/issues/270

To test:
 - Browse to a Well in your non-default group
 - Open-with iviewer. URL is e.g. ```iviewer/?well=101```
 - Should see images in the well etc instead of "No image data"
 - Also can confirm directly that ```/iviewer/well_images/?id=101``` shows the correct response.