### PR TITLE
fix draw shape when paginated

### DIFF
--- a/src/viewers/viewer/controls/ShapeEditPopup.js
+++ b/src/viewers/viewer/controls/ShapeEditPopup.js
@@ -187,12 +187,14 @@ class ShapeEditPopup extends Overlay {
 
         let areaText = "";
         let areaLength = this.regions.getLengthAndAreaForShape(geom);
-        let unit = this.regions.viewer_.image_info_['pixel_size']['symbol_x'] || 'px';
-        ['Area', 'Length'].forEach(dim => {
-            if (areaLength.hasOwnProperty(dim)) {
-                areaText += `${ dim }: ${ areaLength[dim] } ${ unit }${ dim == 'Area' ? '²' : ''}`;
-            }
-        })
+        if (this.regions.viewer_ && areaLength) {
+            let unit = this.regions.viewer_.image_info_['pixel_size']['symbol_x'] || 'px';
+            ['Area', 'Length'].forEach(dim => {
+                if (areaLength.hasOwnProperty(dim)) {
+                    areaText += `${ dim }: ${ areaLength[dim] } ${ unit }${ dim == 'Area' ? '²' : ''}`;
+                }
+            })
+        }
         document.getElementById('shape-popup-coords').value = coordsText;
         document.getElementById('shape-popup-area').value = areaText;
 

--- a/src/viewers/viewer/source/Regions.js
+++ b/src/viewers/viewer/source/Regions.js
@@ -893,6 +893,7 @@ class Regions extends Vector {
      */
     getLengthAndAreaForShape(feature, recalculate) {
             if (!(feature instanceof Feature || feature instanceof Geometry)) return null;
+            if (!this.viewer_) return null;
 
             if (typeof recalculate !== 'boolean') recalculate = false;
 


### PR DESCRIPTION
After scrolling Z/T with paginated ROIs, drawing a new shape fails since regions.viewer_ is null.
A similar fix was in 5ff0845e53

To test:
 - Open an image in iviewer with many ROIs e.g. https://merge-ci.openmicroscopy.org/web/webclient/?show=image-39657 (idr)
 - Scroll to new Z/T plane
 - Try to draw a shape e.g. Rectangle, Polyline etc.
 - Should work normally