### PR TITLE
fix image viewer sync buttons

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -845,11 +845,14 @@ export default class Context {
      * @param {number} id the ImageConfig id
      */
     selectConfig(id=null) {
-        if (typeof id !== 'number' || id < 0 ||
-            !(this.image_configs.get(id) instanceof ImageConfig) ||
-            this.selected_config === id) return;
-
-        this.selected_config = id;
+        if (typeof id === 'number' && id > 0 &&
+            (this.image_configs.get(id) instanceof ImageConfig) &&
+            this.selected_config !== id) {
+          this.selected_config = id;
+        }
+        // NB: return true so that the event bubbles.
+        // see https://github.com/ome/omero-iviewer/issues/274
+        return true;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/ome/omero-iviewer/issues/274, reported at https://forum.image.sc/t/channels-checkbox-in-omero-iviewer/28793

To test:
 - Open multiple viewers
 - Check that sync of View, Channels & Z/T  working (checkboxes behave normally)
 - Confirm that you can still select viewers by clicking on the frame or the image as in https://github.com/ome/omero-iviewer/pull/239