### PR TITLE
Disable autoPan for shape popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8359,6 +8359,12 @@
         }
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",

--- a/src/viewers/viewer/controls/ShapeEditPopup.js
+++ b/src/viewers/viewer/controls/ShapeEditPopup.js
@@ -65,10 +65,7 @@ class ShapeEditPopup extends Overlay {
         super({
             element: popup,
             insertFirst: false,
-            autoPan: true,
-            autoPanAnimation: {
-                duration: 250
-            }
+            autoPan: false,
         });
 
         // TODO: Don't need to store all of these!

--- a/src/viewers/viewer/controls/ShapeEditPopup.js
+++ b/src/viewers/viewer/controls/ShapeEditPopup.js
@@ -42,25 +42,21 @@ class ShapeEditPopup extends Overlay {
     constructor(regions_reference) {
 
         var els = document.querySelectorAll('.shape-edit-popup');
-        let popup = els && els.length > 0 ? els[0] : null;
-        if (!popup) {
-            popup = document.createElement('div');
-            popup.className = 'shape-edit-popup';
-            popup.innerHTML = `
-            <div>
-                <input id='shape-popup-edit-text'
-                    placeholder='Edit shape comment'
-                    value=''/>
-                <div><input readonly id='shape-popup-coords'/></div>
-                <div><input readonly id='shape-popup-area'/></div>
-                <a href="#" id="shape-edit-popup-closer" class="shape-edit-popup-closer"></a>
-            </div>`;
-            // add flag to the event so that the Hover interaction can ignore it
-            popup.onpointermove = function(e) {
-                e.isOverShapeEditPopup = true;
-            };
-
-        }
+        let popup = document.createElement('div');
+        popup.className = 'shape-edit-popup';
+        popup.innerHTML = `
+        <div>
+            <input class='shape-popup-edit-text'
+                placeholder='Edit shape comment'
+                value=''/>
+            <div><input readonly class='shape-popup-coords'/></div>
+            <div><input readonly class='shape-popup-area'/></div>
+            <a href="#" class="shape-edit-popup-closer" class="shape-edit-popup-closer"></a>
+        </div>`;
+        // add flag to the event so that the Hover interaction can ignore it
+        popup.onpointermove = function(e) {
+            e.isOverShapeEditPopup = true;
+        };
 
         super({
             element: popup,
@@ -75,6 +71,11 @@ class ShapeEditPopup extends Overlay {
         this.map = regions_reference.viewer_.viewer_;
         // Need to add to map before we can bindListeners() to DOM elements
         this.map.addOverlay(this);
+
+        this.textInput = this.popup.querySelectorAll('.shape-popup-edit-text')[0];
+        this.coordsInput = this.popup.querySelectorAll('.shape-popup-coords')[0];
+        this.areaInput = this.popup.querySelectorAll('.shape-popup-area')[0];
+        this.popupCloser = this.popup.querySelectorAll('.shape-edit-popup-closer')[0];
         this.bindListeners();
     };
 
@@ -106,7 +107,7 @@ class ShapeEditPopup extends Overlay {
         // so we know which shape we're editing...
         this.shapeId = feature.getId();
 
-        document.getElementById('shape-popup-edit-text').value = text;
+        this.textInput.value = text;
 
         // show if feature is visible
         if (this.regions.renderFeature(feature)) {
@@ -123,7 +124,7 @@ class ShapeEditPopup extends Overlay {
      */
     updatePopupText(shape_ids, text) {
         if (this.shapeId && shape_ids.indexOf(this.shapeId) > -1) {
-            document.getElementById('shape-popup-edit-text').value = text;
+            this.textInput.value = text;
         }
     }
 
@@ -192,8 +193,8 @@ class ShapeEditPopup extends Overlay {
                 }
             })
         }
-        document.getElementById('shape-popup-coords').value = coordsText;
-        document.getElementById('shape-popup-area').value = areaText;
+        this.coordsInput.value = coordsText;
+        this.areaInput.value = areaText;
 
         if (this.regions.enable_shape_popup) {
             this.setPosition([x, y]);
@@ -204,9 +205,8 @@ class ShapeEditPopup extends Overlay {
      * Add Listeners for events.
      */
     bindListeners() {
-        let textInput = document.getElementById('shape-popup-edit-text');
         let inputTimeout;
-        textInput.onkeyup = (event) => {
+        this.textInput.onkeyup = (event) => {
 
             // Use a de-bounce to automatically save when user stops typing
             if (inputTimeout) {
@@ -227,7 +227,7 @@ class ShapeEditPopup extends Overlay {
             }, 500);
         }
 
-        document.getElementById('shape-edit-popup-closer').onclick = (event) => {
+        this.popupCloser.onclick = (event) => {
             this.setPosition(undefined);
             event.target.blur();
 
@@ -247,8 +247,8 @@ class ShapeEditPopup extends Overlay {
      * Removes listeners added above
      */
     unbindListeners() {
-        document.getElementById('shape-popup-edit-text').onkeyup = null;
-        document.getElementById('shape-edit-popup-closer').onclick = null;
+        this.textInput.onkeyup = null;
+        this.popupCloser.onclick = null;
     }
 
     /**

--- a/src/viewers/viewer/interaction/Hover.js
+++ b/src/viewers/viewer/interaction/Hover.js
@@ -41,11 +41,8 @@ class Hover extends Pointer {
 
         var els = document.querySelectorAll(
             '.hover-popup');
-        this.tooltip = els && els.length > 0 ? els[0] : null;
-        if (!this.tooltip) {
-            this.tooltip = document.createElement('div');
-            this.tooltip.className = 'hover-popup';
-        }
+        this.tooltip = document.createElement('div');
+        this.tooltip.className = 'hover-popup';
 
         this.regions_ = regions_reference;
         this.map = regions_reference.viewer_.viewer_;


### PR DESCRIPTION
This fixes a minor bug where the image pans when drawing shapes because of the popup appearing for a new shape. The shape popup should never cause the image to Pan.
To test:
 - Select to draw a Shape E.g. Polygon
 - Click on the image near the top of the viewport to start drawing
 - The shape popup will appear and track the Polygon as you draw it, but it should not cause the image to pan. NB: this was noticeably worse when using Shift-draw to draw freehand.
 - Also, clicking to select existing shapes when they are close to the edge of the viewport should also not cause the image to pan.
  - In multi-viewer mode, popups and tooltip should work properly on both viewers.