### PR TITLE
roi outside image csv fix

### DIFF
--- a/src/app/header.js
+++ b/src/app/header.js
@@ -382,7 +382,7 @@ export class Header {
                         let stat = shape.stats[s];
                         if (active.indexOf(stat.index) !== -1) {
                             if (stat.points === 0) {
-                                csv += csvCommonInfo + "," + emptyRow;
+                                csv += csvCommonInfo + "," + emptyRow + CSV_LINE_BREAK;
                                 break;
                             }
                             csv += csvCommonInfo +


### PR DESCRIPTION
This fixes a bug in CSV export of ROIs when an ROI is outside the limits of the image.

To test:
 - create a bunch of ROIs, 1 or more should be outside the limits of the image
 - Export to CSV.
 - Check that the ROI that comes after the outside ROI is on a new line and the CSV is all formatted correctly.