### PR TITLE
show hide shapes in ROI

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -966,6 +966,10 @@ thumbnail-slider img {
     -webkit-user-select: none;
 }
 
+.regions-table-row input[type='checkbox'] {
+    margin: 0;
+}
+
 .regions-table-col {
     float: left;
     min-width: 10px;

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -124,7 +124,7 @@
                          </div>
                          <div class="regions-table-col shape-show">
                              <input type="checkbox"
-                                 title="Show/Hide shapes" checked.one-way="regions_info.roi_visibility_toggles[roi_id] === 0"
+                                 title="Show/Hide shapes" checked.one-way="regions_info.roi_visibility_toggles[roi_id] === undefined || regions_info.roi_visibility_toggles[roi_id] === 0"
                                  change.delegate="toggleRoiVisibility(roi_id, $event)"/>
                          </div>
                          <div class="regions-table-col shape-type">

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -122,7 +122,11 @@
                                  ${roi.show ? '&#9660;' : '&#9658;'}
                              </div>
                          </div>
-                         <div class="regions-table-col shape-show"></div>
+                         <div class="regions-table-col shape-show">
+                             <input type="checkbox"
+                                 title="Show/Hide shapes" checked.one-way="roi.visible"
+                                 change.delegate="toggleRoiVisibility(roi_id, $event)"/>
+                         </div>
                          <div class="regions-table-col shape-type">
                              (${(roi.shapes.size - roi.deleted)})
                          </div>

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -124,7 +124,7 @@
                          </div>
                          <div class="regions-table-col shape-show">
                              <input type="checkbox"
-                                 title="Show/Hide shapes" checked.one-way="roi.visible"
+                                 title="Show/Hide shapes" checked.one-way="regions_info.roi_visibility_toggles[roi_id] === 0"
                                  change.delegate="toggleRoiVisibility(roi_id, $event)"/>
                          </div>
                          <div class="regions-table-col shape-type">

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -491,6 +491,29 @@ export default class RegionsList extends EventSubscriber {
     }
 
     /**
+     * ROI visibility toggler
+     * Toggles the visibility of ALL shapes in the ROI
+     *
+     * @param {number} roi_id the roi id
+     * @param {Object} event the mouse event object
+     * @memberof RegionsList
+     */
+    toggleRoiVisibility(roi_id, event) {
+        event.stopPropagation();
+        event.preventDefault();
+        let roi = this.regions_info.data.get(roi_id);
+        let shape_ids = [];
+        roi.shapes.forEach((s) => shape_ids.push(s.shape_id));
+        this.context.publish(
+            REGIONS_SET_PROPERTY, {
+                config_id: this.regions_info.image_info.config_id,
+                property : "visible",
+                shapes : shape_ids,
+                value : event.target.checked});
+        return false;
+    }
+
+    /**
      * shape visibility toggler
      *
      * @param {number} id the shape id

--- a/src/regions/regions-list.js
+++ b/src/regions/regions-list.js
@@ -501,15 +501,21 @@ export default class RegionsList extends EventSubscriber {
     toggleRoiVisibility(roi_id, event) {
         event.stopPropagation();
         event.preventDefault();
+        let visible = event.target.checked;
         let roi = this.regions_info.data.get(roi_id);
         let shape_ids = [];
-        roi.shapes.forEach((s) => shape_ids.push(s.shape_id));
+        roi.shapes.forEach((s) => {
+            if (s.visible !== visible) {
+                shape_ids.push(s.shape_id);
+            }
+        });
+        if (shape_ids.length == 0) return;
         this.context.publish(
             REGIONS_SET_PROPERTY, {
                 config_id: this.regions_info.image_info.config_id,
                 property : "visible",
                 shapes : shape_ids,
-                value : event.target.checked});
+                value : visible});
         return false;
     }
 


### PR DESCRIPTION
See https://trello.com/c/DtbhtoAA/81-show-hide-all-shapes-in-an-roi
from https://forum.image.sc/t/large-mask-roi-on-large-image/29200/7

To test:
 - Find an image with multiple Shapes per ROI (or create in Insight)
 - Check ROI checkbox to show/hide all shapes in the ROI
 - Toggling individual Shape visibility should 'check' the ROI checkbox if All shapes in the ROI are checked (same behaviour as the "Show" checkbox at the top of the table).
 - The "Show" checkbox at the top of the table should also continue to work as expected.
