### PR TITLE
Fix multi-viewer save rois

### DIFF
--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -2302,7 +2302,7 @@ class Viewer extends OlObject {
             }
         };
 
-        ret = [];
+        var ret = [];
         for (var r in rois)
             if (rois[r]['shapes'].length > 0) ret.push(rois[r]);
         return ret;


### PR DESCRIPTION
To test:

 - Open the same image in 2 viewers at the same time
 - Draw some ROIs in one, don't save.
 - Select the other viewer.
 - Dialog says "Save?"  -> Yes
 - Other viewer should load the newly saved ROIs
 - Also, in multi-viewer mode, editing and saving ROIs should work normally (ROIs updated from unsaved to saved state in the table)