### PR TITLE
Roi query support

### DIFF
--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -26,6 +26,9 @@ urlpatterns = [
         name='omero_iviewer_persist_rois'),
     url(r'^image_data/(?P<image_id>[0-9]+)/$', views.image_data,
         name='omero_iviewer_image_data'),
+    # load image_data for image linked to an ROI
+    url(r'^roi/(?P<roi_id>[0-9]+)/image_data/$', views.roi_image_data,
+        name='omero_iviewer_roi_image_data'),
     url(r'^save_projection/?$', views.save_projection,
         name='omero_iviewer_save_projection'),
     url(r'^well_images/?$', views.well_images,

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -44,4 +44,7 @@ urlpatterns = [
         views.rois_by_plane, name='omero_iviewer_rois_by_plane'),
     url(r'^plane_shape_counts/(?P<image_id>[0-9]+)/$',
         views.plane_shape_counts, name='omero_iviewer_plane_shape_counts'),
+    # Find the index of an ROI within all ROIs for the Image (for pagination)
+    url(r'^roi/(?P<roi_id>[0-9]+)/page_data/$',
+        views.roi_page_data, name='omero_iviewer_roi_page_data'),
 ]

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -26,9 +26,9 @@ urlpatterns = [
         name='omero_iviewer_persist_rois'),
     url(r'^image_data/(?P<image_id>[0-9]+)/$', views.image_data,
         name='omero_iviewer_image_data'),
-    # load image_data for image linked to an ROI
-    url(r'^roi/(?P<roi_id>[0-9]+)/image_data/$', views.roi_image_data,
-        name='omero_iviewer_roi_image_data'),
+    # load image_data for image linked to an ROI or Shape
+    url(r'^(?P<obj_type>(roi|shape))/(?P<obj_id>[0-9]+)/image_data/$',
+        views.roi_image_data, name='omero_iviewer_roi_image_data'),
     url(r'^save_projection/?$', views.save_projection,
         name='omero_iviewer_save_projection'),
     url(r'^well_images/?$', views.well_images,
@@ -45,6 +45,6 @@ urlpatterns = [
     url(r'^plane_shape_counts/(?P<image_id>[0-9]+)/$',
         views.plane_shape_counts, name='omero_iviewer_plane_shape_counts'),
     # Find the index of an ROI within all ROIs for the Image (for pagination)
-    url(r'^roi/(?P<roi_id>[0-9]+)/page_data/$',
+    url(r'^(?P<obj_type>(roi|shape))/(?P<obj_id>[0-9]+)/page_data/$',
         views.roi_page_data, name='omero_iviewer_roi_page_data'),
 ]

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -346,6 +346,7 @@ def plane_shape_counts(request, image_id, conn=None, **kwargs):
 
     return JsonResponse({'data': counts})
 
+
 @login_required()
 def roi_page_data(request, roi_id, conn=None, **kwargs):
     """
@@ -378,6 +379,7 @@ def roi_image_data(request, roi_id, conn=None, **kwargs):
     roi = conn.getQueryService().get('Roi', int(roi_id))
     image_id = roi.image.id.val
     return image_data(request, image_id, conn=None, **kwargs)
+
 
 @login_required()
 def image_data(request, image_id, conn=None, **kwargs):

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -346,6 +346,12 @@ def plane_shape_counts(request, image_id, conn=None, **kwargs):
 
     return JsonResponse({'data': counts})
 
+@login_required()
+def roi_image_data(request, roi_id, conn=None, **kwargs):
+    """ Get image_data for image linked to ROI """
+    roi = conn.getQueryService().get('Roi', int(roi_id))
+    image_id = roi.image.id.val
+    return image_data(request, image_id, conn=None, **kwargs)
 
 @login_required()
 def image_data(request, image_id, conn=None, **kwargs):

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -347,6 +347,32 @@ def plane_shape_counts(request, image_id, conn=None, **kwargs):
     return JsonResponse({'data': counts})
 
 @login_required()
+def roi_page_data(request, roi_id, conn=None, **kwargs):
+    """
+    Get info for loading the correct 'page' of ROIs
+
+    Returns {image: {'id': 1}, roi_index: 123, roi_count: 3456}
+    """
+    roi = conn.getQueryService().get('Roi', int(roi_id))
+    image_id = roi.image.id.val
+
+    qs = conn.getQueryService()
+    params = omero.sys.ParametersI()
+
+    params.addId(image_id)
+    query = "select roi.id from Roi roi where roi.image.id = :id"
+    ids = [i[0].val for i in qs.projection(query, params, conn.SERVICE_OPTS)]
+    ids.sort()
+    index = ids.index(int(roi_id))
+    rsp = {
+        'image': {'id': image_id},
+        'roi_index': index,
+        'roi_count': len(ids)
+    }
+    return JsonResponse(rsp)
+
+
+@login_required()
 def roi_image_data(request, roi_id, conn=None, **kwargs):
     """ Get image_data for image linked to ROI """
     roi = conn.getQueryService().get('Roi', int(roi_id))

--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -118,7 +118,7 @@ setup(name="omero-iviewer",
       url="https://github.com/ome/omero-iviewer/",
       download_url='https://github.com/ome/omero-iviewer/archive/v%s.tar.gz' % version,  # NOQA
       keywords=['OMERO.web', 'plugin'],
-      install_requires=['omero-web>=5.6.0'],
+      install_requires=['omero-web>=5.7.0'],
       python_requires='>=3',
       include_package_data=True,
       zip_safe=False,

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -363,6 +363,9 @@ export default class Context {
             // also support ?roi=1
             initial_ids = this.initParams[REQUEST_PARAMS.ROI];
             initial_type = INITIAL_TYPES.ROIS;
+        } else if (this.initParams[REQUEST_PARAMS.SHAPE]) {
+            initial_ids = this.initParams[REQUEST_PARAMS.ROI];
+            initial_type = INITIAL_TYPES.SHAPES;
         }
         if (initial_ids) {
             this.initial_ids = initial_ids.split(',')
@@ -384,8 +387,8 @@ export default class Context {
         if (typeof initial_well_id !== 'number' || isNaN(initial_well_id))
             initial_well_id = null;
 
-        // add image config if we have image ids OR roi ids
-        if ([INITIAL_TYPES.IMAGES, INITIAL_TYPES.ROIS].indexOf(this.initial_type) > -1) {
+        // add image config if we have image ids OR roi id OR shape id
+        if ([INITIAL_TYPES.IMAGES, INITIAL_TYPES.ROIS, INITIAL_TYPES.SHAPES].indexOf(this.initial_type) > -1) {
             let parent_id = initial_dataset_id || initial_well_id;
             let parent_type;
             if (parent_id) {

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -356,8 +356,12 @@ export default class Context {
             initial_ids = this.initParams[REQUEST_PARAMS.IMAGES];
             initial_type = INITIAL_TYPES.IMAGES;
         } else if (this.initParams[REQUEST_PARAMS.ROIS]) {
-            // Only support ONE ROI ID.
+            // Only support ONE ROI ID. e.g. ?rois=1
             initial_ids = this.initParams[REQUEST_PARAMS.ROIS].split(',')[0];
+            initial_type = INITIAL_TYPES.ROIS;
+        } else if (this.initParams[REQUEST_PARAMS.ROI]) {
+            // also support ?roi=1
+            initial_ids = this.initParams[REQUEST_PARAMS.ROI];
             initial_type = INITIAL_TYPES.ROIS;
         }
         if (initial_ids) {

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -364,7 +364,7 @@ export default class Context {
             initial_ids = this.initParams[REQUEST_PARAMS.ROI];
             initial_type = INITIAL_TYPES.ROIS;
         } else if (this.initParams[REQUEST_PARAMS.SHAPE]) {
-            initial_ids = this.initParams[REQUEST_PARAMS.ROI];
+            initial_ids = this.initParams[REQUEST_PARAMS.SHAPE];
             initial_type = INITIAL_TYPES.SHAPES;
         }
         if (initial_ids) {
@@ -630,15 +630,19 @@ export default class Context {
             }
         } else {
             // 'standard' url
-            if (this.initial_type === INITIAL_TYPES.IMAGES || this.initial_type === INITIAL_TYPES.ROIS) {
+            if (this.initial_type === INITIAL_TYPES.IMAGES || this.initial_type === INITIAL_TYPES.ROIS
+                    || this.initial_type === INITIAL_TYPES.SHAPES) {
                 if (this.initial_ids.length > 1)
+                    // e.g. ?images=1,2 - Don't update URL
                     newPath += window.location.search;
                 else {
+                    // e.g. ?images=1 - update to ?images=2&dataset=1
                     parent_id = selConf.image_info.parent_id;
                     newPath +=
                         '?images=' + image_id + '&' + parentTypeString + "=" + parent_id;
                 }
             } else {
+                // e.g. ?dataset=1 - Don't update URL
                 parent_id = this.initial_ids[0];
                 newPath += "?" + parentTypeString + "=" + parent_id;
             }

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -356,7 +356,8 @@ export default class Context {
             initial_ids = this.initParams[REQUEST_PARAMS.IMAGES];
             initial_type = INITIAL_TYPES.IMAGES;
         } else if (this.initParams[REQUEST_PARAMS.ROIS]) {
-            initial_ids = this.initParams[REQUEST_PARAMS.ROIS];
+            // Only support ONE ROI ID.
+            initial_ids = this.initParams[REQUEST_PARAMS.ROIS].split(',')[0];
             initial_type = INITIAL_TYPES.ROIS;
         }
         if (initial_ids) {
@@ -716,7 +717,7 @@ export default class Context {
      * @param {number} obj_id the image or roi id for the clicked thumbnail
      * @param {boolean} is_double_click true if triggered by a double click
      */
-    onClicks(obj_id, thumb_type, is_double_click = false, replace_image_config) {
+    onClicks(obj_id, is_double_click = false, replace_image_config) {
         let image_config = this.getSelectedImageConfig();
         let navigateToNewImage = () => {
             this.rememberImageConfigChange(obj_id);
@@ -728,7 +729,7 @@ export default class Context {
             if (this.useMDI && !is_double_click && !replace_image_config) {
                 replace_image_config = image_config;
             }
-            let initial_type = thumb_type == 'image' ? INITIAL_TYPES.IMAGES : INITIAL_TYPES.ROIS;
+            let initial_type = INITIAL_TYPES.IMAGES;
             if (replace_image_config) {
                 let oldPosition = Object.assign({}, replace_image_config.position);
                 let oldSize = Object.assign({}, replace_image_config.size);
@@ -750,8 +751,7 @@ export default class Context {
                 obj_id) : [];
         let selImgConf = this.getSelectedImageConfig();
         let hasSameImageSelected =
-            selImgConf && (thumb_type == 'image' && selImgConf.image_info.image_id === obj_id ||
-                thumb_type == 'roi' && selImgConf.image_info.initial_roi_id === obj_id);
+            selImgConf && selImgConf.image_info.image_id === image_id;
         // show dialogs for modified rois
         if (image_config &&
             image_config.regions_info &&

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -751,7 +751,7 @@ export default class Context {
                 obj_id) : [];
         let selImgConf = this.getSelectedImageConfig();
         let hasSameImageSelected =
-            selImgConf && selImgConf.image_info.image_id === image_id;
+            selImgConf && selImgConf.image_info.image_id === obj_id;
         // show dialogs for modified rois
         if (image_config &&
             image_config.regions_info &&

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -355,10 +355,6 @@ export default class Context {
         if (this.initParams[REQUEST_PARAMS.IMAGES]) {
             initial_ids = this.initParams[REQUEST_PARAMS.IMAGES];
             initial_type = INITIAL_TYPES.IMAGES;
-        } else if (this.initParams[REQUEST_PARAMS.ROIS]) {
-            // Only support ONE ROI ID. e.g. ?rois=1
-            initial_ids = this.initParams[REQUEST_PARAMS.ROIS].split(',')[0];
-            initial_type = INITIAL_TYPES.ROIS;
         } else if (this.initParams[REQUEST_PARAMS.ROI]) {
             // also support ?roi=1
             initial_ids = this.initParams[REQUEST_PARAMS.ROI];

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -622,7 +622,7 @@ export default class Context {
             }
         } else {
             // 'standard' url
-            if (this.initial_type === INITIAL_TYPES.IMAGES) {
+            if (this.initial_type === INITIAL_TYPES.IMAGES || this.initial_type === INITIAL_TYPES.ROIS) {
                 if (this.initial_ids.length > 1)
                     newPath += window.location.search;
                 else {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -258,9 +258,10 @@ export class Index  {
      */
     handleDrop(event) {
         var image_id = parseInt(event.dataTransfer.getData("id"), 10);
+        var thumb_type = event.dataTransfer.getData("thumb_type");
         this.context.useMDI = true;
         // similar behaviour to double-clicking
-        this.context.onClicks(image_id, true);
+        this.context.onClicks(image_id, thumb_type, true);
     }
 
     /**

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -258,10 +258,9 @@ export class Index  {
      */
     handleDrop(event) {
         var image_id = parseInt(event.dataTransfer.getData("id"), 10);
-        var thumb_type = event.dataTransfer.getData("thumb_type");
         this.context.useMDI = true;
         // similar behaviour to double-clicking
-        this.context.onClicks(image_id, thumb_type, true);
+        this.context.onClicks(image_id, true);
     }
 
     /**

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -112,7 +112,7 @@ export class RightHandPanel {
         });
 
         // If ROI ID is set, show ROIs tab:
-        if (this.image_config.image_info && this.image_config.image_info.initial_roi_id) {
+        if (this.image_config && this.image_config.image_info && this.image_config.image_info.initial_roi_id) {
             // This will trigger image_info to load ROIs once image data is loaded
             this.context.selected_tab = TABS.ROIS;
         }

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -110,6 +110,12 @@ export class RightHandPanel {
             this.makeInitialRoisRequestIfRoisTabIsActive();
             $(e.currentTarget).tab('show');
         });
+
+        // If ROI ID is set, show ROIs tab:
+        if (this.image_config.image_info && this.image_config.image_info.initial_roi_id) {
+            // This will trigger image_info to load ROIs once image data is loaded
+            this.context.selected_tab = TABS.ROIS;
+        }
     }
 
     /**

--- a/src/app/right-hand-panel.js
+++ b/src/app/right-hand-panel.js
@@ -112,7 +112,8 @@ export class RightHandPanel {
         });
 
         // If ROI ID is set, show ROIs tab:
-        if (this.image_config && this.image_config.image_info && this.image_config.image_info.initial_roi_id) {
+        if (this.image_config && this.image_config.image_info &&
+                (this.image_config.image_info.initial_roi_id || this.image_config.image_info.initial_shape_id)) {
             // This will trigger image_info to load ROIs once image data is loaded
             this.context.selected_tab = TABS.ROIS;
         }

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -42,8 +42,8 @@
                 src.bind="thumb.url ? thumb.url + '?version=' + thumb.revision : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII='"
                 title="${thumb.title}"
                 alt=""
-                click.delegate="onClick(thumb.id, thumb.type)"
-                dblclick.delegate="onDoubleClick(thumb.id, thumb.type, $event)"/>
+                click.delegate="onClick(thumb.id)"
+                dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
             </div>
         </div>
 

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -42,8 +42,8 @@
                 src.bind="thumb.url ? thumb.url + '?version=' + thumb.revision : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII='"
                 title="${thumb.title}"
                 alt=""
-                click.delegate="onClick(thumb.id)"
-                dblclick.delegate="onDoubleClick(thumb.id, $event)"/>
+                click.delegate="onClick(thumb.id, thumb.type)"
+                dblclick.delegate="onDoubleClick(thumb.id, thumb.type, $event)"/>
             </div>
         </div>
 

--- a/src/app/thumbnail-slider.html
+++ b/src/app/thumbnail-slider.html
@@ -34,7 +34,7 @@
             <!-- Both the div and the img have data-id for drag-n-drop -->
             <div repeat.for="thumb of thumbnails" class="thumbnail-wrapper"
                 data-id="${thumb.id}"
-                draggable="true" dragstart.delegate="handleDragStart($event)">
+                draggable="true" dragstart.delegate="handleDragStart($event, thumb.type)">
               <!-- show placeholder 1 x 1 px png if no thumb.url -->
               <img id="${'img-thumb-' + thumb.id}" data-id="${thumb.id}"
                 class="${image_config.image_info.image_id === thumb.id ? 'selected' : ''}

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -236,7 +236,7 @@ export default class ThumbnailSlider extends EventSubscriber {
         };
 
         // we don't have a dataset id
-        if (this.context.initial_type === INITIAL_TYPES.IMAGES &&
+        if ((this.context.initial_type === INITIAL_TYPES.IMAGES || this.context.initial_type === INITIAL_TYPES.ROIS) &&
             this.context.initial_ids.length === 1 &&
             this.image_config.image_info.parent_id !== 'number') {
             // have we had all the data already
@@ -703,8 +703,9 @@ export default class ThumbnailSlider extends EventSubscriber {
      *
      * @param {Object} event Drag start event
      */
-    handleDragStart(event) {
+    handleDragStart(event, thumb_type) {
         event.dataTransfer.setData("id", event.target.dataset.id);
+        event.dataTransfer.setData("thumb_type", thumb_type);
         return true;
     }
 

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -297,8 +297,8 @@ export default class ThumbnailSlider extends EventSubscriber {
             this.context.initial_type === INITIAL_TYPES.ROIS) {
                 let thumbType = this.context.initial_type === INITIAL_TYPES.IMAGES ? 'image' : 'roi';
             if (this.context.initial_ids.length > 1) {
-                // we are a list of images or rois
-                this.setThumbnailsFromIds(this.context.initial_ids, thumbType);
+                // we are a list of images
+                this.setThumbnailsFromIds(this.context.initial_ids);
             } else {
                 this.gatherThumbnailMetaInfo();
             }
@@ -388,13 +388,13 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {list} imageIds List of IDs
      * @memberof ThumbnailSlider
      */
-    setThumbnailsFromIds(obj_ids, thumb_type) {
+    setThumbnailsFromIds(obj_ids) {
         this.setThumbnailsCount(obj_ids.length);
         let to_add = obj_ids.map(id => ({
             '@id': id,
-            Name: thumb_type + ': ' + id,
+            Name: 'Image: ' + id
         }));
-        this.addThumbnails(to_add, 0, thumb_type);
+        this.addThumbnails(to_add, 0);
     }
 
     /**
@@ -530,16 +530,11 @@ export default class ThumbnailSlider extends EventSubscriber {
      * @param {number} start_index Index to start replacing
      * @memberof ThumbnailSlider
      */
-    addThumbnails(thumbnails, start_index, thumb_type='image') {
+    addThumbnails(thumbnails, start_index) {
         // if we are remote we include the server
         let thumbPrefix =
-            (this.context.server !== "" ? this.context.server + "/" : "");
-
-        if (thumb_type === 'image') {
-            thumbPrefix += this.webclient_prefix + "/render_thumbnail/";
-        } else if (thumb_type === 'roi') {
-            thumbPrefix += this.webgateway_prefix + "/render_roi_thumbnail/";
-        }
+            (this.context.server !== "" ? this.context.server + "/" : "") +
+            this.webclient_prefix + "/render_thumbnail/";
 
         let new_index = 0;
         this.thumbnails = this.thumbnails.map((thumb, idx) => {
@@ -548,7 +543,6 @@ export default class ThumbnailSlider extends EventSubscriber {
                 new_index++;
                 return {
                     id: t['@id'],
-                    type: thumb_type,
                     url: thumbPrefix + t['@id'] + "/",
                     title: typeof t.Name === 'string' ? t.Name : t['@id'],
                     revision : 0
@@ -600,15 +594,14 @@ export default class ThumbnailSlider extends EventSubscriber {
      * hacky solution to allow double - single click distinction
      *
      * @memberof ThumbnailSlider
-     * @param {number} obj_id the id for the clicked image or roi thumbnail
-     * @param {string} thumb_type e.g. 'image' or 'roi'
+     * @param {number} image_id the id for the clicked image thumbnail
      */
-    onClick(obj_id, thumb_type) {
+    onClick(image_id) {
         if (this.click_handle) {
             clearTimeout(this.click_handle);
             this.click_handle = null;
         }
-        this.click_handle = setTimeout(() => this.context.onClicks(obj_id, thumb_type), 250);
+        this.click_handle = setTimeout(() => this.context.onClicks(image_id), 250);
     }
 
     /**
@@ -616,10 +609,9 @@ export default class ThumbnailSlider extends EventSubscriber {
      *
      * @memberof ThumbnailSlider
      * @param {number} image_id the image id for the clicked thumbnail
-     * @param {string} thumb_type e.g. 'image' or 'roi'
      * @param {Object} event the mouse click event
      */
-    onDoubleClick(obj_id, thumb_type, event) {
+    onDoubleClick(image_id, event) {
         event.stopPropagation();
 
         if (this.click_handle) {
@@ -627,7 +619,7 @@ export default class ThumbnailSlider extends EventSubscriber {
             this.click_handle = null;
         }
         this.context.useMDI = true;
-        this.context.onClicks(obj_id, thumb_type, true);
+        this.context.onClicks(image_id, true);
 
         return false;
     }
@@ -703,9 +695,8 @@ export default class ThumbnailSlider extends EventSubscriber {
      *
      * @param {Object} event Drag start event
      */
-    handleDragStart(event, thumb_type) {
+    handleDragStart(event) {
         event.dataTransfer.setData("id", event.target.dataset.id);
-        event.dataTransfer.setData("thumb_type", thumb_type);
         return true;
     }
 

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -300,8 +300,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                 // we are a list of images or rois
                 this.setThumbnailsFromIds(this.context.initial_ids, thumbType);
             } else {
-                this.gatherThumbnailMetaInfo(
-                        this.image_config.image_info.image_id);
+                this.gatherThumbnailMetaInfo();
             }
         } else if (this.context.initial_type === INITIAL_TYPES.DATASET ||
                     this.context.initial_type === INITIAL_TYPES.WELL) {
@@ -316,13 +315,18 @@ export default class ThumbnailSlider extends EventSubscriber {
      * (e.g. open with) or for images whose parent is a well this method finds
      * the parent id
      *
-     * @param {number} image_id the id of the image in the dataset
      * @memberof ThumbnailSlider
      */
-    gatherThumbnailMetaInfo(image_id) {
-        let url =
-            this.context.server + this.webclient_prefix + "/api/paths_to_object/?" +
-            "image=" + image_id + "&page_size=" + this.thumbnails_request_size;
+    gatherThumbnailMetaInfo() {
+
+        let url = this.context.server + this.webclient_prefix + "/api/paths_to_object/";
+
+        if (this.context.initial_type === INITIAL_TYPES.IMAGES) {
+            url += "?image=" + this.context.initial_ids[0];
+        } else if (this.context.initial_type === INITIAL_TYPES.ROIS) {
+            url += "?roi=" + this.context.initial_ids[0];
+        }
+        url += "&page_size=" + this.thumbnails_request_size;
 
         $.ajax(
             {url : url,
@@ -348,7 +352,6 @@ export default class ThumbnailSlider extends EventSubscriber {
                     let parents = containers.filter(c => c.type === 'well' || (c.type === 'dataset' && c.id === pid));
                     return parents.length > 0 ? parents[0] : null;
                 }).filter(parent => parent);
-
                 let parent = matching_parents.length ? matching_parents[0] : null
                 let imgInf = this.image_config.image_info;
 

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -358,6 +358,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                 if (parent) {
                     if (parent.type === 'dataset') {
                         imgInf.parent_type = INITIAL_TYPES.DATASET
+                        imgInf.parent_id = parent.id;
                     } else if (parent.type === 'well') {
                         imgInf.parent_type = INITIAL_TYPES.WELL;
                         imgInf.parent_id = parent.id;
@@ -438,15 +439,15 @@ export default class ThumbnailSlider extends EventSubscriber {
      */
     requestMoreThumbnails(init = false, refresh = false,
                           thumb_start_index = 0, thumb_end_index) {
+        let init_type = this.context.initial_type;
         let parent_id =
-            this.context.initial_type === INITIAL_TYPES.DATASET ||
-            this.context.initial_type === INITIAL_TYPES.WELL ?
+            init_type === INITIAL_TYPES.DATASET ||
+            init_type === INITIAL_TYPES.WELL ?
                 this.context.initial_ids[0] :
                 this.image_config.image_info.parent_id;
         let parent_type =
-            this.context.initial_type === INITIAL_TYPES.IMAGES ?
-                this.image_config.image_info.parent_type :
-                this.context.initial_type;
+            (init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS) ?
+                this.image_config.image_info.parent_type : init_type;
 
         let offset = parseInt(thumb_start_index / this.thumbnails_request_size) * this.thumbnails_request_size;
         let limit = this.thumbnails_request_size;
@@ -458,8 +459,8 @@ export default class ThumbnailSlider extends EventSubscriber {
 
 
         let url = this.context.server;
-        if (this.context.initial_type === INITIAL_TYPES.DATASET ||
-            (this.context.initial_type === INITIAL_TYPES.IMAGES &&
+        if (init_type === INITIAL_TYPES.DATASET ||
+            ((init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS) &&
             parent_type === INITIAL_TYPES.DATASET)) {
                 url += this.web_api_base + DATASETS_REQUEST_URL +
                     '/' + parent_id + '/images/?';

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -236,7 +236,9 @@ export default class ThumbnailSlider extends EventSubscriber {
         };
 
         // we don't have a dataset id
-        if ((this.context.initial_type === INITIAL_TYPES.IMAGES || this.context.initial_type === INITIAL_TYPES.ROIS) &&
+        if ((this.context.initial_type === INITIAL_TYPES.IMAGES ||
+                this.context.initial_type === INITIAL_TYPES.ROIS ||
+                this.context.initial_type === INITIAL_TYPES.SHAPES) &&
             this.context.initial_ids.length === 1 &&
             this.image_config.image_info.parent_id !== 'number') {
             // have we had all the data already
@@ -294,8 +296,8 @@ export default class ThumbnailSlider extends EventSubscriber {
     initializeThumbnails(refresh = false) {
         // standard case: we are an image
         if (this.context.initial_type === INITIAL_TYPES.IMAGES ||
-            this.context.initial_type === INITIAL_TYPES.ROIS) {
-                let thumbType = this.context.initial_type === INITIAL_TYPES.IMAGES ? 'image' : 'roi';
+            this.context.initial_type === INITIAL_TYPES.ROIS ||
+            this.context.initial_type === INITIAL_TYPES.SHAPES) {
             if (this.context.initial_ids.length > 1) {
                 // we are a list of images
                 this.setThumbnailsFromIds(this.context.initial_ids);
@@ -325,6 +327,8 @@ export default class ThumbnailSlider extends EventSubscriber {
             url += "?image=" + this.context.initial_ids[0];
         } else if (this.context.initial_type === INITIAL_TYPES.ROIS) {
             url += "?roi=" + this.context.initial_ids[0];
+        } else if (this.context.initial_type === INITIAL_TYPES.SHAPES) {
+            url += "?shape=" + this.context.initial_ids[0];
         }
         url += "&page_size=" + this.thumbnails_request_size;
 
@@ -446,7 +450,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                 this.context.initial_ids[0] :
                 this.image_config.image_info.parent_id;
         let parent_type =
-            (init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS) ?
+            (init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS || init_type === INITIAL_TYPES.SHAPES) ?
                 this.image_config.image_info.parent_type : init_type;
 
         let offset = parseInt(thumb_start_index / this.thumbnails_request_size) * this.thumbnails_request_size;
@@ -460,7 +464,7 @@ export default class ThumbnailSlider extends EventSubscriber {
 
         let url = this.context.server;
         if (init_type === INITIAL_TYPES.DATASET ||
-            ((init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS) &&
+            ((init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS || init_type === INITIAL_TYPES.SHAPES) &&
             parent_type === INITIAL_TYPES.DATASET)) {
                 url += this.web_api_base + DATASETS_REQUEST_URL +
                     '/' + parent_id + '/images/?';

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -463,16 +463,16 @@ export default class ThumbnailSlider extends EventSubscriber {
 
 
         let url = this.context.server;
+        let child_is_image = (init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS ||
+                init_type === INITIAL_TYPES.SHAPES);
         if (init_type === INITIAL_TYPES.DATASET ||
-            ((init_type === INITIAL_TYPES.IMAGES || init_type === INITIAL_TYPES.ROIS || init_type === INITIAL_TYPES.SHAPES) &&
-            parent_type === INITIAL_TYPES.DATASET)) {
+            (child_is_image && parent_type === INITIAL_TYPES.DATASET)) {
                 url += this.web_api_base + DATASETS_REQUEST_URL +
                     '/' + parent_id + '/images/?';
         } else if (this.context.initial_type === INITIAL_TYPES.WELL ||
-                    (this.context.initial_type === INITIAL_TYPES.IMAGES &&
-                    parent_type === INITIAL_TYPES.WELL)) {
-                        url += this.context.getPrefixedURI(IVIEWER) +
-                            "/well_images/?id=" + parent_id + "&";
+            (child_is_image && parent_type === INITIAL_TYPES.WELL)) {
+                url += (this.context.getPrefixedURI(IVIEWER) +
+                        "/well_images/?id=" + parent_id + "&");
         }
         url += 'offset=' + offset + '&limit=' + limit;
 

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -120,7 +120,8 @@ export default class ImageConfig extends History {
         this.image_info =
             new ImageInfo(
                 this.context, this.id, obj_id, obj_type, parent_id, parent_type);
-        this.regions_info = new RegionsInfo(this.image_info);
+        let roi_id = (obj_type == INITIAL_TYPES.ROIS) ? obj_id : undefined;
+        this.regions_info = new RegionsInfo(this.image_info, roi_id);
     }
 
     /**

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -120,8 +120,7 @@ export default class ImageConfig extends History {
         this.image_info =
             new ImageInfo(
                 this.context, this.id, obj_id, obj_type, parent_id, parent_type);
-        let roi_id = (obj_type == INITIAL_TYPES.ROIS) ? obj_id : undefined;
-        this.regions_info = new RegionsInfo(this.image_info, roi_id);
+        this.regions_info = new RegionsInfo(this.image_info);
     }
 
     /**

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -23,7 +23,7 @@ import Misc from '../utils/misc';
 import History from './history';
 import {WEBGATEWAY} from '../utils/constants';
 import {VIEWER_SET_SYNC_GROUP} from '../events/events';
-import {CHANNEL_SETTINGS_MODE} from '../utils/constants';
+import {CHANNEL_SETTINGS_MODE, INITIAL_TYPES} from '../utils/constants';
 
 /**
  * Holds the combined data/model that is relevant to working with an image:
@@ -106,11 +106,12 @@ export default class ImageConfig extends History {
     /**
      * @constructor
      * @param {Context} context the application context
-     * @param {number} image_id the image id to be queried
+     * @param {number} obj_id the id of the obj (image, roi)
+     * @param {number} obj_type the type of obj. e.g. INITIAL_TYPES.IMAGES or ROIS
      * @param {number} parent_id an optional parent id
-     * @param {number} parent_type an optional parent type  (e.g. dataset or well)
+     * @param {number} parent_type an optional parent type  (e.g. INITIAL_TYPES.DATASET or WELL)
      */
-    constructor(context, image_id, parent_id, parent_type) {
+    constructor(context, obj_id, obj_type, parent_id, parent_type) {
         super(); // for history
         this.context = context;
         // for now this should suffice, especially given js 1 threaded nature
@@ -118,8 +119,8 @@ export default class ImageConfig extends History {
         // go create the data objects for an image and its associated region
         this.image_info =
             new ImageInfo(
-                this.context, this.id, image_id, parent_id, parent_type);
-        this.regions_info = new RegionsInfo(this.image_info)
+                this.context, this.id, obj_id, obj_type, parent_id, parent_type);
+        this.regions_info = new RegionsInfo(this.image_info);
     }
 
     /**

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -307,14 +307,12 @@ export default class ImageInfo {
 
                 // read initial request params
                 this.initializeImageInfo(response, refresh);
-                console.log('response.meta.datasetId;', response.meta.datasetId);
                 // check for a parent id (if not well)
                 if (this.context.initial_type !== INITIAL_TYPES.WELL &&
                     typeof this.parent_id !== 'number') {
                     if (typeof response.meta === 'object' &&
                             typeof response.meta.datasetId === 'number')
                         this.parent_id = response.meta.datasetId;
-                    console.log('image_info this.parent_id', this.parent_id);
                 }
 
                 // fetch copied img RDef

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -249,7 +249,7 @@ export default class ImageInfo {
         this.context = context;
         this.config_id = config_id;
         this.image_id = obj_type == INITIAL_TYPES.IMAGES ? obj_id : undefined;
-        this.roi_id = obj_type == INITIAL_TYPES.ROIS ? obj_id : undefined;
+        this.initial_roi_id = obj_type == INITIAL_TYPES.ROIS ? obj_id : undefined;
         if (typeof parent_id === 'number') {
             this.parent_id = parent_id;
             if (typeof parent_type === 'number' &&
@@ -293,8 +293,8 @@ export default class ImageInfo {
 
         // if we have ROI id instead of Image id, use diff
         let url = this.context.server + this.context.getPrefixedURI(IVIEWER);
-        if (!this.image_id && this.roi_id) {
-            url += "/roi/" + this.roi_id + '/image_data/';
+        if (!this.image_id && this.initial_roi_id) {
+            url += "/roi/" + this.initial_roi_id + '/image_data/';
         } else {
             url += "/image_data/" + this.image_id + '/';
         }

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -307,13 +307,14 @@ export default class ImageInfo {
 
                 // read initial request params
                 this.initializeImageInfo(response, refresh);
-
+                console.log('response.meta.datasetId;', response.meta.datasetId);
                 // check for a parent id (if not well)
                 if (this.context.initial_type !== INITIAL_TYPES.WELL &&
                     typeof this.parent_id !== 'number') {
                     if (typeof response.meta === 'object' &&
                             typeof response.meta.datasetId === 'number')
                         this.parent_id = response.meta.datasetId;
+                    console.log('image_info this.parent_id', this.parent_id);
                 }
 
                 // fetch copied img RDef

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -291,7 +291,7 @@ export default class ImageInfo {
         if (typeof refresh !== 'boolean') refresh = false;
         this.ready = false;
 
-        // if we have ROI id instead of Image id, use diff
+        // if we have ROI id instead of Image id, use that to load image_data
         let url = this.context.server + this.context.getPrefixedURI(IVIEWER);
         if (!this.image_id && this.initial_roi_id) {
             url += "/roi/" + this.initial_roi_id + '/image_data/';
@@ -320,8 +320,13 @@ export default class ImageInfo {
                 this.requestImgRDef();
                 // request regions data if rois tab showing
                 let conf = this.context.getImageConfig(this.config_id);
-                if (this.context.isRoisTabActive())
-                    conf.regions_info.requestData();
+                if (this.context.isRoisTabActive()) {
+                    if (this.initial_roi_id) {
+                        conf.regions_info.setPageByRoiAndReload(this.initial_roi_id);
+                    } else {
+                        conf.regions_info.requestData();
+                    }
+                }
             },
             error : (error, textStatus) => {
                 this.ready = false;

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -250,6 +250,7 @@ export default class ImageInfo {
         this.config_id = config_id;
         this.image_id = obj_type == INITIAL_TYPES.IMAGES ? obj_id : undefined;
         this.initial_roi_id = obj_type == INITIAL_TYPES.ROIS ? obj_id : undefined;
+        this.initial_shape_id = obj_type == INITIAL_TYPES.SHAPES ? obj_id : undefined;
         if (typeof parent_id === 'number') {
             this.parent_id = parent_id;
             if (typeof parent_type === 'number' &&
@@ -295,6 +296,8 @@ export default class ImageInfo {
         let url = this.context.server + this.context.getPrefixedURI(IVIEWER);
         if (!this.image_id && this.initial_roi_id) {
             url += "/roi/" + this.initial_roi_id + '/image_data/';
+        } else if (!this.image_id && this.initial_shape_id) {
+            url += "/shape/" + this.initial_shape_id + '/image_data/';
         } else {
             url += "/image_data/" + this.image_id + '/';
         }
@@ -322,6 +325,8 @@ export default class ImageInfo {
                 if (this.context.isRoisTabActive()) {
                     if (this.initial_roi_id) {
                         conf.regions_info.setPageByRoiAndReload(this.initial_roi_id);
+                    } else if (this.initial_shape_id) {
+                        conf.regions_info.setPageByRoiAndReload(null, this.initial_shape_id);
                     } else {
                         conf.regions_info.requestData();
                     }

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -197,9 +197,8 @@ export default class RegionsInfo  {
      * @constructor
      * @param {ImageInfo} image_info the associated image
      */
-    constructor(image_info, roi_id) {
+    constructor(image_info) {
         this.image_info = image_info;
-        this.initial_roi_id = roi_id;
         // we want history
         this.history = new RegionsHistory(this);
         // sync copied shapes with localStorage

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -197,8 +197,9 @@ export default class RegionsInfo  {
      * @constructor
      * @param {ImageInfo} image_info the associated image
      */
-    constructor(image_info) {
+    constructor(image_info, roi_id) {
         this.image_info = image_info;
+        this.initial_roi_id = roi_id;
         // we want history
         this.history = new RegionsHistory(this);
         // sync copied shapes with localStorage

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -345,6 +345,33 @@ export default class RegionsInfo  {
     }
 
     /**
+     * Load ROIs, setting page based on ROI ID
+     *
+     * @memberof RegionsInfo
+     * @param {number} roiId   ROI id
+     */
+    setPageByRoiAndReload(roiId) {
+        // If ROI count is less than page size, simply load...
+        if (!this.isRoiLoadingPaginatedByPlane()) {
+            this.requestData();
+        } else {
+            // Otherwise, need to find page number...
+            let url = this.image_info.context.getPrefixedURI(IVIEWER)
+                        + `/roi/${ roiId }/page_data/`;
+            $.ajax({url,
+                success : (response) => {
+                    const page = parseInt(response.roi_index / this.roi_page_size);
+                    this.roi_page_number = page;
+                    this.requestData(true);
+                }, error : (error) => {
+                    this.is_pending = false;
+                    console.error("Failed to load Rois: " + error)
+                }
+            });
+        }
+    }
+
+    /**
      * Get the number of pages needed to show all paginated ROIs
      * on current plane.
      */

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -344,19 +344,24 @@ export default class RegionsInfo  {
     }
 
     /**
-     * Load ROIs, setting page based on ROI ID
+     * Load ROIs, setting page based on ROI ID OR Shape ID
      *
      * @memberof RegionsInfo
      * @param {number} roiId   ROI id
+     * @param {number} shapeId   OR use Shape id
      */
-    setPageByRoiAndReload(roiId) {
+    setPageByRoiAndReload(roiId, shapeId) {
         // If ROI count is less than page size, simply load...
         if (!this.isRoiLoadingPaginatedByPlane()) {
             this.requestData();
         } else {
             // Otherwise, need to find page number...
-            let url = this.image_info.context.getPrefixedURI(IVIEWER)
-                        + `/roi/${ roiId }/page_data/`;
+            let url = this.image_info.context.getPrefixedURI(IVIEWER);
+            if (shapeId) {
+                url += `/shape/${ shapeId }/page_data/`;
+            } else {
+                url += `/roi/${ roiId }/page_data/`;
+            }
             $.ajax({url,
                 success : (response) => {
                     const page = parseInt(response.roi_index / this.roi_page_size);
@@ -650,6 +655,29 @@ export default class RegionsInfo  {
         let shape = roi.shapes.get(ids.shape_id);
         return (typeof shape !== 'undefined') ? shape : null;
     }
+
+
+    /**
+     * Looks up shape by ID e.g. 1
+     *
+     * @memberof RegionsInfo
+     * @param {number} id the shape.id
+     * @return {Object|null} the shape object or null if none was found
+     */
+    getRoiFromShapeId(id) {
+        if (this.data === null) return null;
+
+        let roi_id;
+        this.data.forEach((roi, roiId) => {
+            roi.shapes.forEach((s, sh_id) => {
+                if (s['@id'] == id) {
+                    roi_id = roiId;
+                };
+            });
+        });
+        return roi_id;
+    }
+
 
     /**
      * Any shape modification, addition or deletion results in a history entry.

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -64,7 +64,7 @@
                     disabled.bind="!(regions_info.selected_shapes &&
                         regions_info.selected_shapes.length > 0)"
                     class="btn btn-link btn-sm"
-                    style="margin-left: 5px"
+                    style="margin-left: 5px; outline: none;"
                     title="Link to selected ROI${ regions_info.selected_shapes.length === 1 ? '' : 's'}"
                     click.delegate="toggleShowRoiLink()">
                     <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
@@ -72,14 +72,11 @@
             </div>
 
             <div show.bind="show_roi_link"
+                mouseout.delegate="toggleShowRoiLink()"
                 style="position: absolute; border: solid #ddd 1px; border-radius: 3px; padding: 5px; top: 35px;
                     right: 5px; z-index: 10; background: #f8f8f8; width: 300px; box-shadow: 2px 2px 5px #ccc;">
-                <input />
-                ${ regions_info.selected_shapes.length }
-                ${ getShapesLink(regions_info.selected_shapes) }
-                <div>
-                    <span repeat.for="shape of regions_info.selected_shapes">${shape.split(':')[0]},</span>
-                </div>
+                <!-- NB: we pass shapes.length to function to ensure update https://discourse.aurelia.io/t/array-map-and-join-in-template/3550/4 -->
+                <input id="roi_link_input" style="width:100%" value="${ getRoisLink(regions_info.selected_shapes, regions_info.selected_shapes.length) }"/>
             </div>
 
             <regions-edit regions_info.bind="regions_info"></regions-edit>

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -62,7 +62,7 @@
                 <button type="button"
                     show.bind="regions_info.ready"
                     disabled.bind="!(regions_info.selected_shapes &&
-                        regions_info.selected_shapes.length > 0)"
+                        regions_info.selected_shapes.length === 1)"
                     class="btn btn-link btn-sm"
                     style="margin-left: 5px; outline: none;"
                     title="Link to selected ROI${ regions_info.selected_shapes.length === 1 ? '' : 's'}"

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -59,6 +59,27 @@
                     </label>
                 </div>
 
+                <button type="button"
+                    show.bind="regions_info.ready"
+                    disabled.bind="!(regions_info.selected_shapes &&
+                        regions_info.selected_shapes.length > 0)"
+                    class="btn btn-link btn-sm"
+                    style="margin-left: 5px"
+                    title="Link to selected ROI${ regions_info.selected_shapes.length === 1 ? '' : 's'}"
+                    click.delegate="toggleShowRoiLink()">
+                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+                </button>
+            </div>
+
+            <div show.bind="show_roi_link"
+                style="position: absolute; border: solid #ddd 1px; border-radius: 3px; padding: 5px; top: 35px;
+                    right: 5px; z-index: 10; background: #f8f8f8; width: 300px; box-shadow: 2px 2px 5px #ccc;">
+                <input />
+                ${ regions_info.selected_shapes.length }
+                ${ getShapesLink(regions_info.selected_shapes) }
+                <div>
+                    <span repeat.for="shape of regions_info.selected_shapes">${shape.split(':')[0]},</span>
+                </div>
             </div>
 
             <regions-edit regions_info.bind="regions_info"></regions-edit>

--- a/src/regions/regions.html
+++ b/src/regions/regions.html
@@ -65,7 +65,7 @@
                         regions_info.selected_shapes.length === 1)"
                     class="btn btn-link btn-sm"
                     style="margin-left: 5px; outline: none;"
-                    title="Link to selected ROI${ regions_info.selected_shapes.length === 1 ? '' : 's'}"
+                    title="Link to selected ROI${ regions_info.selected_shapes.length === 1 ? '' : ' (need to select 1)'}"
                     click.delegate="toggleShowRoiLink()">
                     <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
                 </button>

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -175,8 +175,12 @@ export default class Regions {
      * @memberof Regions
      */
     getRoisLink(shapes) {
-        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?rois=' + shapes
-            .map(s => s.split(':')[0])
-            .join(',');
+        // Only take first ROI:shape
+        let roiId = shapes[0].split(':')[0];
+        // If unsaved, will have negative IDs. Return message instead
+        if (roiId < 0) {
+            return "Can't link to unsaved ROIs";
+        }
+        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?rois=' + roiId;
     }
 }

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -163,10 +163,20 @@ export default class Regions {
      */
     toggleShowRoiLink() {
         this.show_roi_link = !this.show_roi_link;
+        if (this.show_roi_link) {
+            setTimeout(() => {document.getElementById('roi_link_input').select()}, 0);
+        }
     }
 
-    getShapesLink(shapes) {
-        console.log('getShapesLink', shapes.length);
-        return 'url?shapes=' + shapes.map(s => s.split(':')[0]).join(',');
+    /**
+     * Used by template to provide link to currently selected ROIs
+     *
+     * @param {Array} shapes from regions_info.selected_shapes 'roi:shape' IDs
+     * @memberof Regions
+     */
+    getRoisLink(shapes) {
+        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?rois=' + shapes
+            .map(s => s.split(':')[0])
+            .join(',');
     }
 }

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -175,6 +175,9 @@ export default class Regions {
      * @memberof Regions
      */
     getRoisLink(shapes) {
+        if (shapes.length === 0) {
+            return "No shapes selected";
+        }
         // Only take first ROI:shape
         let roiId = shapes[0].split(':')[0];
         // If unsaved, will have negative IDs. Return message instead

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -175,7 +175,7 @@ export default class Regions {
      * @memberof Regions
      */
     getRoisLink(shapes) {
-        if (shapes.length === 0) {
+        if (!shapes || shapes.length === 0) {
             return "No shapes selected";
         }
         // Only take first ROI:shape
@@ -184,6 +184,6 @@ export default class Regions {
         if (roiId < 0) {
             return "Can't link to unsaved ROIs";
         }
-        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?rois=' + roiId;
+        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?roi=' + roiId;
     }
 }

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -179,11 +179,11 @@ export default class Regions {
             return "No shapes selected";
         }
         // Only take first ROI:shape
-        let roiId = shapes[0].split(':')[0];
+        let shapeId = shapes[0].split(':')[1];
         // If unsaved, will have negative IDs. Return message instead
-        if (roiId < 0) {
+        if (shapeId < 0) {
             return "Can't link to unsaved ROIs";
         }
-        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?roi=' + roiId;
+        return window.location.origin + this.context.getPrefixedURI(IVIEWER) + '?shape=' + shapeId;
     }
 }

--- a/src/regions/regions.js
+++ b/src/regions/regions.js
@@ -20,7 +20,7 @@
 import Context from '../app/context';
 import Misc from '../utils/misc';
 import Ui from '../utils/ui';
-import {TABS, ROI_TABS} from '../utils/constants';
+import {TABS, ROI_TABS, IVIEWER} from '../utils/constants';
 import {REGIONS_STORE_SHAPES, REGIONS_SHOW_COMMENTS} from '../events/events';
 import {inject, customElement, bindable} from 'aurelia-framework';
 
@@ -59,6 +59,8 @@ export default class Regions {
      * @type {String}
      */
     selected_roi_tab = ROI_TABS.ROI_TABLE;
+
+    show_roi_link = false;
 
     /**
      * @constructor
@@ -152,5 +154,19 @@ export default class Regions {
         if (!this.regions_info.ready) return;
 
         this.regions_info.history.redoHistory();
+    }
+
+    /**
+     * Handles Click on ROI link button
+     *
+     * @memberof Regions
+     */
+    toggleShowRoiLink() {
+        this.show_roi_link = !this.show_roi_link;
+    }
+
+    getShapesLink(shapes) {
+        console.log('getShapesLink', shapes.length);
+        return 'url?shapes=' + shapes.map(s => s.split(':')[0]).join(',');
     }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -121,6 +121,7 @@ export const REQUEST_PARAMS = {
     IMAGES: 'IMAGES',
     ROIS: 'ROIS',
     ROI: 'ROI',
+    SHAPE: 'SHAPE',
     MAPS: 'MAPS',
     MODEL: 'M',
     OMERO_VERSION: 'OMERO_VERSION',
@@ -273,6 +274,7 @@ export const INITIAL_TYPES = {
     DATASET: 2,
     WELL: 3,
     ROIS: 4,
+    SHAPES: 5,
 }
 
 /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -119,6 +119,7 @@ export const REQUEST_PARAMS = {
     DATASET_ID: 'DATASET',
     INTERPOLATE: 'INTERPOLATE',
     IMAGES: 'IMAGES',
+    ROIS: 'ROIS',
     MAPS: 'MAPS',
     MODEL: 'M',
     OMERO_VERSION: 'OMERO_VERSION',
@@ -269,7 +270,8 @@ export const INITIAL_TYPES = {
     NONE: 0,
     IMAGES: 1,
     DATASET: 2,
-    WELL: 3
+    WELL: 3,
+    ROIS: 4,
 }
 
 /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -120,6 +120,7 @@ export const REQUEST_PARAMS = {
     INTERPOLATE: 'INTERPOLATE',
     IMAGES: 'IMAGES',
     ROIS: 'ROIS',
+    ROI: 'ROI',
     MAPS: 'MAPS',
     MODEL: 'M',
     OMERO_VERSION: 'OMERO_VERSION',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -119,7 +119,6 @@ export const REQUEST_PARAMS = {
     DATASET_ID: 'DATASET',
     INTERPOLATE: 'INTERPOLATE',
     IMAGES: 'IMAGES',
-    ROIS: 'ROIS',
     ROI: 'ROI',
     SHAPE: 'SHAPE',
     MAPS: 'MAPS',

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -823,8 +823,8 @@ export default class Ol3Viewer extends EventSubscriber {
 
 
         // switch to plane/time/channel that shape to be selected is on
-        // for deselect the last selected shape is chosen (if exists)
         let shapeSelection = params.shapes[params.shapes.length-1];
+        // for de-selecting (value is false) the last selected shape is chosen (if exists)
         if (!params.value) {
             let numberOfSelectedShapes =
                 this.image_config.regions_info.selected_shapes.length;
@@ -832,13 +832,18 @@ export default class Ol3Viewer extends EventSubscriber {
                 let lastSelected =
                     this.image_config.regions_info.selected_shapes[
                         numberOfSelectedShapes-1];
+                // if last-selected is not being de-selected, select it 
                 if (lastSelected !== shapeSelection) {
                     shapeSelection = lastSelected;
                 } else if (numberOfSelectedShapes > 1) {
+                    // or previous shape...
                     shapeSelection =
                         this.image_config.regions_info.selected_shapes[
                             numberOfSelectedShapes-2];
-                } else shapeSelection = null;
+                } else {
+                    // or nothing
+                    shapeSelection = null;
+                }
             } else shapeSelection = null;
         }
         let delay = 0;
@@ -869,7 +874,7 @@ export default class Ol3Viewer extends EventSubscriber {
             this.abortDrawing();
             this.viewer.selectShapes(
                 params.shapes, params.value, params.clear,
-                params.center ? shapeSelection : null);
+                params.center ? shapeSelection : null, params.zoomToShape);
             // If we've just selected a bunch of shapes, hide the ShapeEditPopup
             if (params.shapes.length > 1) {
                 this.viewer.viewer_.getOverlays().forEach(o => {
@@ -978,6 +983,7 @@ export default class Ol3Viewer extends EventSubscriber {
                 clear: true,
                 value: true,
                 center: true,
+                zoomToShape: true,
             });
         }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -953,8 +953,8 @@ export default class Ol3Viewer extends EventSubscriber {
             }
         };
         // If we have initial_roi_id for this viewer, select it...
-        if (this.image_config.regions_info.initial_roi_id) {
-            let roi_id = this.image_config.regions_info.initial_roi_id;
+        if (this.image_config.image_info.initial_roi_id) {
+            let roi_id = this.image_config.image_info.initial_roi_id;
             let roi = this.image_config.regions_info.data.get(roi_id);
             // select all shapes in ROI
             this.changeShapeSelection({

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -967,8 +967,8 @@ export default class Ol3Viewer extends EventSubscriber {
             if (shape_id) {
                 shape_ids = [`${roi_id}:${shape_id}`];
             } else {
-                // select all shapes in ROI
-                shape_ids = [...roi.shapes.keys()].map(s_id => `${roi.id}:${s_id}`)
+                // select first shape in ROI
+                shape_ids = [`${roi.id}:${roi.shapes.keys().next().value}`];
             }
             // select shapes...
             this.changeShapeSelection({

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1627,17 +1627,19 @@ export default class Ol3Viewer extends EventSubscriber {
         // prevent event bubbling up to parent .frame
         event.stopPropagation();
 
+        // need to know if we dropped an ROI thumbnail or Image thumbnail
         var image_id = parseInt(event.dataTransfer.getData("id"), 10);
+        var thumb_type = event.dataTransfer.getData("thumb_type");
 
         // If we are not in multi-viewer mode, enter multi-viewer mode
         if (!this.context.useMDI) {
             // similar behaviour to double-clicking
             this.context.useMDI = true;
-            this.context.onClicks(image_id, true);
+            this.context.onClicks(image_id, thumb_type, true);
         } else {
             // similar behaviour to single-click:
             // replace this image_config with new one
-            this.context.onClicks(image_id, false, this.image_config);
+            this.context.onClicks(image_id, thumb_type, false, this.image_config);
         }
     }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1627,19 +1627,17 @@ export default class Ol3Viewer extends EventSubscriber {
         // prevent event bubbling up to parent .frame
         event.stopPropagation();
 
-        // need to know if we dropped an ROI thumbnail or Image thumbnail
         var image_id = parseInt(event.dataTransfer.getData("id"), 10);
-        var thumb_type = event.dataTransfer.getData("thumb_type");
 
         // If we are not in multi-viewer mode, enter multi-viewer mode
         if (!this.context.useMDI) {
             // similar behaviour to double-clicking
             this.context.useMDI = true;
-            this.context.onClicks(image_id, thumb_type, true);
+            this.context.onClicks(image_id, true);
         } else {
             // similar behaviour to single-click:
             // replace this image_config with new one
-            this.context.onClicks(image_id, thumb_type, false, this.image_config);
+            this.context.onClicks(image_id, false, this.image_config);
         }
     }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -952,6 +952,21 @@ export default class Ol3Viewer extends EventSubscriber {
                 }
             }
         };
+        // If we have initial_roi_id for this viewer, select it...
+        if (this.image_config.regions_info.initial_roi_id) {
+            let roi_id = this.image_config.regions_info.initial_roi_id;
+            let roi = this.image_config.regions_info.data.get(roi_id);
+            // select all shapes in ROI
+            this.changeShapeSelection({
+                config_id: this.image_config.id,
+                property: "selected",
+                shapes: [...roi.shapes.keys()].map(s_id => `${roi.id}:${s_id}`),
+                clear: true,
+                value: true,
+                center: true,
+            });
+        }
+
         setTimeout(updateMeasurements, 50);
     }
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -953,14 +953,28 @@ export default class Ol3Viewer extends EventSubscriber {
             }
         };
         // If we have initial_roi_id for this viewer, select it...
-        if (this.image_config.image_info.initial_roi_id) {
-            let roi_id = this.image_config.image_info.initial_roi_id;
+        let roi_id;
+        let shape_id;
+        if (this.image_config.image_info.initial_shape_id) {
+            shape_id = this.image_config.image_info.initial_shape_id;
+            roi_id = this.image_config.regions_info.getRoiFromShapeId(shape_id);
+        } else if (this.image_config.image_info.initial_roi_id) {
+            roi_id = this.image_config.image_info.initial_roi_id;
+        }
+        if (roi_id) {
             let roi = this.image_config.regions_info.data.get(roi_id);
-            // select all shapes in ROI
+            let shape_ids;
+            if (shape_id) {
+                shape_ids = [`${roi_id}:${shape_id}`];
+            } else {
+                // select all shapes in ROI
+                shape_ids = [...roi.shapes.keys()].map(s_id => `${roi.id}:${s_id}`)
+            }
+            // select shapes...
             this.changeShapeSelection({
                 config_id: this.image_config.id,
                 property: "selected",
-                shapes: [...roi.shapes.keys()].map(s_id => `${roi.id}:${s_id}`),
+                shapes: shape_ids,
                 clear: true,
                 value: true,
                 center: true,

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -805,6 +805,7 @@ class Viewer extends OlObject {
         if (typeof regions.idIndex_[panToShape] === 'object') {
             let geom = regions.idIndex_[panToShape].getGeometry();
             let target_res;
+            let forceCentre = false;
             if (zoomToShape) {
                 let extent = geom.getExtent();
                 // extent is [x, -y, x2, -y2]
@@ -815,9 +816,12 @@ class Viewer extends OlObject {
                 target_res = Math.max(length / 300, 1);
                 // Don't zoom out from current resolution
                 var res = this.viewer_.getView().getResolution();
+                // If we zoom in, make sure we centre on shape
+                if (target_res > res) {
+                    forceCentre = true;
+                }
                 target_res = Math.min(target_res, res);
             }
-            let forceCentre = zoomToShape;
             this.centerOnGeometry(geom, target_res, forceCentre);
         }
     }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -817,7 +817,7 @@ class Viewer extends OlObject {
                 // Don't zoom out from current resolution
                 var res = this.viewer_.getView().getResolution();
                 // If we zoom in, make sure we centre on shape
-                if (target_res > res) {
+                if (target_res < res) {
                     forceCentre = true;
                 }
                 target_res = Math.min(target_res, res);


### PR DESCRIPTION
Support ```/iviewer/?rois=1,2``` to open ROIs in iviewer.
Shows a thumbnail view of multiple ROIs.

To test:
 - Open iviewer and select some saved Shapes
 - Check the Link icon in top-right of the ROIs tab - (Button should only be enabled if 1 shape is selected)
 - Click the button. Link to `?shape=ID` should be shown and selected (if unsaved Shapes are selected, should see a suitable message).
 - Copy the link and paste into browser...
 - Page should open iviewer to show the shape
    - Test with shape on non-default Z/T and not on first 'page' (>500 ROIs) e.g. https://merge-ci.openmicroscopy.org/web/iviewer?shape=223406
 - Thumbnails on left should load as expected for single Image:
    - If shape is on Orphaned Image, or multiple parents - No thumbnails
    - If shape is on Dataset Image, show Dataset thumbnails
    - If shape is on SPW image, show Well thumbnails
 - Browser link/history should behave as for single Image:
    - Clicking the thumnail will update the URL to point to that image
 - Also test linking by ROI ID: `/iviewer/?roi=1`. The *first* shape will be selected.
 - Probably a good idea to test other URLs still work as expected (thumbnails & URL updates):
    - Test `/iviewer/?dataset=1`
    - Test `/iviewer/?images=1` and `?images=1,2`
    - Test default viewer URL `/webclient/img_detail/2/?dataset=2`

Fixes #308 

This requires a new release of `omero-web` with https://github.com/ome/omero-web/pull/157 and https://github.com/ome/omero-web/pull/159 and https://github.com/ome/omero-web/pull/178
 y