### PR TITLE
Ignore rendering settings

### DIFF
--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -271,6 +271,7 @@ const OmeroImage = function(options) {
             // maps parameter (incl. inverted)
             var maps = [];
             // add channel param
+            return url;
             url += 'c=';
             var channelsLength = this.channels_info_.length;
             for (var c=0; c<channelsLength;c++) {


### PR DESCRIPTION
This is a potential emergency patch to disable rendering settings.
We don't disable the controls, but the settings are ignored (not added to the tile URL).
cc @joshmoore 