### PR TITLE
Allow higher max zoom for Big images

### DIFF
--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -534,6 +534,11 @@ class Viewer extends OlObject {
             }
         }
 
+        let highestRes = possibleResolutions[possibleResolutions.length-1];
+        // For Big images, allow zooming in further (from 160% up to 322%)
+        if (highestRes > 0.5) {
+            possibleResolutions.push(highestRes/2);
+        }
         // we need a View object for the map
         var view = new View({
             projection: proj,

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -535,9 +535,10 @@ class Viewer extends OlObject {
         }
 
         let highestRes = possibleResolutions[possibleResolutions.length-1];
-        // For Big images, allow zooming in further (from 160% up to 322%)
+        // For Big images, allow zooming in further (from 161% to > 600%)
         if (highestRes > 0.5) {
             possibleResolutions.push(highestRes/2);
+            possibleResolutions.push(highestRes/4);
         }
         // we need a View object for the map
         var view = new View({


### PR DESCRIPTION
See https://forum.image.sc/t/omero-iviewer-zoom-limits/39220

This allows higher zoom levels for big images.
To test, try zooming in on a big image. Should now be able to go to 644% (instead of 161%).

Also check that max zoom of non-Big images is unchanged at 4000% (Not sure if we should reduce this?).

