### PR TITLE
Link image ID back to webclient

### DIFF
--- a/src/info/info.html
+++ b/src/info/info.html
@@ -40,7 +40,12 @@
     <table show.bind="image_info.ready" class="table table-condensed">
         <tr>
             <td class="col-sm-6 text-weight-bold">Image ID:</td>
-            <td class="col-sm-6">${image_info.image_id}</td>
+            <td class="col-sm-6">
+                <a href="${image_info.web_url}"
+                   title="Show ${image_info.short_image_name} in webclient"
+                   target="_blank">${image_info.image_id}
+                </a>
+            </td>
         </tr>
         <tr show.bind="parent_info !== null">
             <td class="col-sm-6 text-weight-bold">${parent_info.title}:</td>

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -21,7 +21,7 @@ import Misc from '../utils/misc';
 import Ui from '../utils/ui';
 import {
     APP_TITLE, CHANNEL_SETTINGS_MODE, INITIAL_TYPES, IVIEWER,
-    PROJECTION, REQUEST_PARAMS, WEBGATEWAY
+    PROJECTION, REQUEST_PARAMS, WEBCLIENT, WEBGATEWAY
 } from '../utils/constants';
 import { IMAGE_SETTINGS_REFRESH } from '../events/events';
 
@@ -237,6 +237,13 @@ export default class ImageInfo {
     model = "color";
 
     /**
+     * URL to open the image in the main client
+     * @memberof ImageInfo
+     * @type {string}
+     */
+    web_url = null;
+
+    /**
      * @constructor
      * @param {Context} context the application context
      * @param {number} config_id the config id we belong to
@@ -255,6 +262,9 @@ export default class ImageInfo {
                 parent_type <= INITIAL_TYPES.WELL)
                     this.parent_type = parent_type;
         }
+        this.web_url = this.context.server +
+        this.context.getPrefixedURI(WEBCLIENT) +
+        '/?show=image-' + this.image_id;
     }
 
     /**


### PR DESCRIPTION
Previously there was no way to go back to the image in the webclient, you could only go to the dataset. This makes the Image ID a link.

Testing: Click on the Image ID, you should be taken to the image in the webclient