### PR TITLE
test: print to console

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,4 +53,7 @@ module.exports = function(config) {
     autoWatch: false,
     concurrency: Infinity,
   })
+  process.on('infrastructure_error', (error) => {
+      console.error('infrastructure_error', error);
+  })
 }


### PR DESCRIPTION
print error output to the console when running the tests.
This was useful when investigating https://github.com/ome/omero-plugins/pull/42

cc @sbesson 