### PR TITLE
Unset initial_shape_id once selected

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -425,7 +425,6 @@ def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
             params.addId(image_id)
             result = qs.projection(query, params, conn.SERVICE_OPTS)
             for roi in result:
-                print(unwrap(roi[0]))
                 ids.append(unwrap(roi[0]))
     if image_id is None:
         raise Http404(f'Could not find {obj_type}: {obj_id}')

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -219,6 +219,42 @@ def persist_rois(request, conn=None, **kwargs):
     return JsonResponse(ret)
 
 
+def get_query_for_rois_by_plane(the_z=None, the_t=None, z_end=None,
+        t_end=None, load_shapes=False):
+
+    clauses = ['roi.image.id = :id']
+    if the_z is not None:
+        where_z = "(shapes.theZ = %s or shapes.theZ is null)" % the_z
+        if z_end is not None:
+            where_z = """((shapes.theZ >= %s and shapes.theZ <= %s)
+                or shapes.theZ is null)""" % (the_z, z_end)
+        clauses.append(where_z)
+    if the_t is not None:
+        where_t = "(shapes.theT = %s or shapes.theT is null)" % the_t
+        if t_end is not None:
+            where_t = """((shapes.theT >= %s and shapes.theT <= %s)
+                or shapes.theT is null)""" % (the_t, t_end)
+        clauses.append(where_t)
+
+    query = """
+        select distinct(roi.id) from Roi roi
+        join roi.shapes as shapes
+        where %s
+    """ % ' and '.join(clauses)
+
+    if load_shapes:
+        # If we want to load ALL shapes for the ROIs (omero-marshal fails if
+        # any shapes are None) we use the query above to get ROI IDs, then
+        # load all ROIs with Shapes
+        query = """
+            select roi from Roi roi
+            join fetch roi.details.owner join fetch roi.details.creationEvent
+            left outer join fetch roi.shapes
+            where roi.id in (%s) order by roi.id
+        """ % (query)
+
+    return query
+
 @login_required()
 def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
                   conn=None, **kwargs):
@@ -239,32 +275,7 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
     filter.limit = rint(limit)
     params.theFilter = filter
 
-    where_z = "shapes.theZ = %s or shapes.theZ is null" % the_z
-    where_t = "shapes.theT = %s or shapes.theT is null" % the_t
-    if z_end is not None:
-        where_z = """(shapes.theZ >= %s and shapes.theZ <= %s)
-            or shapes.theZ is null""" % (the_z, z_end)
-    if t_end is not None:
-        where_t = """(shapes.theT >= %s and shapes.theT <= %s)
-            or shapes.theT is null""" % (the_t, t_end)
-
-    filter_query = """
-        select distinct(roi) from Roi roi
-        join roi.shapes as shapes
-        where (%s) and (%s)
-        and roi.image.id = :id
-    """ % (where_z, where_t)
-
-    # We want to load ALL shapes for the ROIs (omero-marshal fails if
-    # any shapes are None) but we want to filter by Shape so we use an inner
-    # query to get the ROI IDs filtered by Shape.
-    query = """
-        select roi from Roi roi
-        join fetch roi.details.owner join fetch roi.details.creationEvent
-        left outer join fetch roi.shapes
-        where roi.id in (%s) order by roi.id
-    """ % (filter_query)
-
+    query = get_query_for_rois_by_plane(the_z, the_t, z_end, t_end, load_shapes=True)
     rois = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
     marshalled = []
     for r in rois:
@@ -273,7 +284,8 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
             marshalled.append(encoder.encode(r))
 
     # Modify query to only select count() and NOT paginate
-    query = filter_query.replace("distinct(roi)", "count(distinct roi)")
+    query = get_query_for_rois_by_plane(the_z, the_t, z_end, t_end)
+    query = query.replace("distinct(roi.id)", "count(distinct roi.id)")
     params = omero.sys.ParametersI()
     params.addId(image_id)
     result = query_service.projection(query, params, conn.SERVICE_OPTS)
@@ -348,6 +360,34 @@ def plane_shape_counts(request, image_id, conn=None, **kwargs):
     return JsonResponse({'data': counts})
 
 
+def get_shape_info(conn, shape_id):
+    """Returns dict of roi_id, image_id, theZ, theT from a shape ID."""
+    params = omero.sys.ParametersI()
+    params.addId(shape_id)
+
+    query = """
+        select roi.id,
+               image.id,
+               shape.theZ,
+               shape.theT
+        from Shape shape
+        join shape.roi roi
+        join roi.image image
+        where shape.id=:id"""
+
+    shapes = conn.getQueryService().projection(query, params, conn.SERVICE_OPTS)
+    rsp = None
+    if len(shapes) > 0:
+        s = unwrap(shapes[0])
+        rsp = {
+            'roi_id': s[0],
+            'image_id': s[1],
+            'theZ': s[2],
+            'theT': s[3],
+        }
+    return rsp
+
+
 @login_required()
 def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
     """
@@ -355,21 +395,38 @@ def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
 
     Returns {image: {'id': 1}, roi_index: 123, roi_count: 3456}
     """
+    query_service = conn.getQueryService()
     image_id = None
+    roi_id = None
+    shape_info = None
+    ids = []
     if obj_type == 'roi':
         roi_id = int(obj_id)
-        roi = conn.getQueryService().get('Roi', roi_id)
+        roi = query_service.get('Roi', roi_id)
         image_id = roi.image.id.val
+        params = omero.sys.ParametersI()
+
+        params.addId(image_id)
+        query = "select roi.id from Roi roi where roi.image.id = :id"
+        ids = [i[0].val for i in query_service.projection(query, params, conn.SERVICE_OPTS)]
     elif obj_type == 'shape':
-        image_id, roi_id = get_image_roi_id_for_shape(conn, obj_id)
+        shape_info = get_shape_info(conn, obj_id)
+        if shape_info is not None:
+            image_id = shape_info.get('image_id')
+            roi_id = shape_info.get('roi_id')
+            the_z = shape_info.get('theZ')
+            the_t = shape_info.get('theT')
+            query = get_query_for_rois_by_plane(the_z, the_t)
+            params = omero.sys.ParametersI()
+            params.addId(image_id)
+            result = query_service.projection(query, params, conn.SERVICE_OPTS)
+            # result = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+            for roi in result:
+                print(unwrap(roi[0]))
+                ids.append(unwrap(roi[0]))
     if image_id is None:
         raise Http404(f'Could not find {obj_type}: {obj_id}')
-    qs = conn.getQueryService()
-    params = omero.sys.ParametersI()
 
-    params.addId(image_id)
-    query = "select roi.id from Roi roi where roi.image.id = :id"
-    ids = [i[0].val for i in qs.projection(query, params, conn.SERVICE_OPTS)]
     ids.sort()
     index = ids.index(roi_id)
     rsp = {
@@ -378,6 +435,9 @@ def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
         'roi_index': index,
         'roi_count': len(ids)
     }
+    if shape_info is not None:
+        rsp['theT'] = shape_info.get('theT')
+        rsp['theZ'] = shape_info.get('theZ')
     return JsonResponse(rsp)
 
 

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -220,7 +220,7 @@ def persist_rois(request, conn=None, **kwargs):
 
 
 def get_query_for_rois_by_plane(the_z=None, the_t=None, z_end=None,
-        t_end=None, load_shapes=False):
+                                t_end=None, load_shapes=False):
 
     clauses = ['roi.image.id = :id']
     if the_z is not None:
@@ -255,6 +255,7 @@ def get_query_for_rois_by_plane(the_z=None, the_t=None, z_end=None,
 
     return query
 
+
 @login_required()
 def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
                   conn=None, **kwargs):
@@ -275,7 +276,8 @@ def rois_by_plane(request, image_id, the_z, the_t, z_end=None, t_end=None,
     filter.limit = rint(limit)
     params.theFilter = filter
 
-    query = get_query_for_rois_by_plane(the_z, the_t, z_end, t_end, load_shapes=True)
+    query = get_query_for_rois_by_plane(the_z, the_t, z_end, t_end,
+                                        load_shapes=True)
     rois = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
     marshalled = []
     for r in rois:
@@ -375,7 +377,8 @@ def get_shape_info(conn, shape_id):
         join roi.image image
         where shape.id=:id"""
 
-    shapes = conn.getQueryService().projection(query, params, conn.SERVICE_OPTS)
+    shapes = conn.getQueryService().projection(query, params,
+                                               conn.SERVICE_OPTS)
     rsp = None
     if len(shapes) > 0:
         s = unwrap(shapes[0])
@@ -395,20 +398,21 @@ def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
 
     Returns {image: {'id': 1}, roi_index: 123, roi_count: 3456}
     """
-    query_service = conn.getQueryService()
+    qs = conn.getQueryService()
     image_id = None
     roi_id = None
     shape_info = None
     ids = []
     if obj_type == 'roi':
         roi_id = int(obj_id)
-        roi = query_service.get('Roi', roi_id)
+        roi = qs.get('Roi', roi_id)
         image_id = roi.image.id.val
         params = omero.sys.ParametersI()
 
         params.addId(image_id)
         query = "select roi.id from Roi roi where roi.image.id = :id"
-        ids = [i[0].val for i in query_service.projection(query, params, conn.SERVICE_OPTS)]
+        ids = [i[0].val for i in qs.projection(query, params,
+                                               conn.SERVICE_OPTS)]
     elif obj_type == 'shape':
         shape_info = get_shape_info(conn, obj_id)
         if shape_info is not None:
@@ -419,8 +423,7 @@ def roi_page_data(request, obj_type, obj_id, conn=None, **kwargs):
             query = get_query_for_rois_by_plane(the_z, the_t)
             params = omero.sys.ParametersI()
             params.addId(image_id)
-            result = query_service.projection(query, params, conn.SERVICE_OPTS)
-            # result = query_service.findAllByQuery(query, params, conn.SERVICE_OPTS)
+            result = qs.projection(query, params, conn.SERVICE_OPTS)
             for roi in result:
                 print(unwrap(roi[0]))
                 ids.append(unwrap(roi[0]))

--- a/src/model/regions_info.js
+++ b/src/model/regions_info.js
@@ -366,6 +366,13 @@ export default class RegionsInfo  {
                 success : (response) => {
                     const page = parseInt(response.roi_index / this.roi_page_size);
                     this.roi_page_number = page;
+                    // This will update the viewer (change listeners)
+                    if (response.theZ != undefined) {
+                        this.image_info.dimensions.z = response.theZ;
+                    }
+                    if (response.theT != undefined) {
+                        this.image_info.dimensions.t = response.theT;
+                    }
                     this.requestData(true);
                 }, error : (error) => {
                     this.is_pending = false;

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -851,17 +851,26 @@ export default class Ol3Viewer extends EventSubscriber {
             let viewerT = this.viewer.getDimensionIndex('t');
             let viewerZ = this.viewer.getDimensionIndex('z');
             let viewerC = this.viewer.getDimensionIndex('c');
+            // Update this.image_config.image_info to load a new Z/T plane...
             let shape =
                 this.image_config.regions_info.getShape(shapeSelection);
+            let correctPlane = true;
             let shapeT = typeof shape.TheT === 'number' ? shape.TheT : -1;
             if (shapeT !== -1 && shapeT !== viewerT) {
                 this.image_config.image_info.dimensions.t = shapeT;
+                correctPlane = false;
                 delay += 25;
             }
             let shapeZ = typeof shape.TheZ === 'number' ? shape.TheZ : -1;
             if (shapeZ !== -1 && shapeZ !== viewerZ) {
                 this.image_config.image_info.dimensions.z = shapeZ;
+                correctPlane = false;
                 delay += 25;
+            }
+            if (correctPlane) {
+                // remove initial_shape_id, so we don't get directed to shape again when browsing
+                // a new plane, (when ROIs are loaded and initRegions() is called again)
+                this.image_config.image_info.initial_shape_id = undefined;
             }
             let shapeC = typeof shape.TheC === 'number' ? shape.TheC : -1;
             if (shapeC !== -1 && viewerC.indexOf(shapeC) === -1) {

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -871,6 +871,9 @@ export default class Ol3Viewer extends EventSubscriber {
                 // remove initial_shape_id, so we don't get directed to shape again when browsing
                 // a new plane, (when ROIs are loaded and initRegions() is called again)
                 this.image_config.image_info.initial_shape_id = undefined;
+            } else {
+                // browsing to new plane - this will select Shape when ROIs load
+                this.image_config.image_info.initial_shape_id = shape['@id'];
             }
             let shapeC = typeof shape.TheC === 'number' ? shape.TheC : -1;
             if (shapeC !== -1 && viewerC.indexOf(shapeC) === -1) {


### PR DESCRIPTION
Fixes one of the issues reported at #335 and a related bug:

To test:
 - Find a multi-plane image that has > 500 ROIs (where ROIs are paginated by Z/T plane
 - Browse to a Shape and copy link to it. (workflow from https://github.com/ome/omero-iviewer/pull/311)
 - Paste link into browser - iviewer should browse to that Z/T plane and select the Shape
 - Try browsing to a different Z/T plane, either with Z/T sliders or via clicking on another Shape
 - Viewer should show the newly-selected Z/T plane and NOT be redirected back to the original Z/T with Shape selected.
 - If browsing via clicking on a Shape, the newly-clicked shape should be selected when the ROIs load for new plane.
 - Also, test the above workflow on an image where ROIs aren't paginated

cc @jburel 