### PR TITLE
Update link to how-to guide

### DIFF
--- a/src/app/header.html
+++ b/src/app/header.html
@@ -108,7 +108,7 @@
                 <ul class="dropdown-menu">
                     <li>
                         <a target="_blank"
-                            href="https://omero-guides.readthedocs.io/projects/iviewer/">
+                            href="https://omero-guides.readthedocs.io/en/latest/iviewer/docs/index.html">
                             How to use OMERO.iviewer
                         </a>
                     </li>

--- a/src/app/header.html
+++ b/src/app/header.html
@@ -108,7 +108,7 @@
                 <ul class="dropdown-menu">
                     <li>
                         <a target="_blank"
-                            href="https://omero-guides.readthedocs.io/en/latest/iviewer/docs/index.html">
+                            href="https://omero-guides.readthedocs.io/en/latest/iviewer/docs/">
                             How to use OMERO.iviewer
                         </a>
                     </li>


### PR DESCRIPTION
Introduced in #336, this unifies the target link with what is in the README and points at the guide published as part of the omero-guides project.