### PR TITLE
projection slider range clearer

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -366,7 +366,12 @@ a.ui-button:active,
 
 .time-slider .ui-slider-range,
 .plane-slider .ui-slider-range {
-    background: #144773;
+    background: #333333;
+}
+
+.time-slider .ui-slider-handle,
+.plane-slider .ui-slider-handle {
+    border: 1px solid #333333;
 }
 
 .plane-slider .ui-slider {

--- a/css/app.css
+++ b/css/app.css
@@ -364,6 +364,11 @@ a.ui-button:active,
     background: #c5c5c5;
 }
 
+.time-slider .ui-slider-range,
+.plane-slider .ui-slider-range {
+    background: #144773;
+}
+
 .plane-slider .ui-slider {
     height: 100%;
     width: 9px;

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -340,6 +340,7 @@ export default class DimensionSlider {
         };
 
         if (this.dim === 'z' && imgInf.projection === PROJECTION.INTMAX) {
+            options.range = true;
             options.change =
                 (event, ui) => {
                     if (event.originalEvent) {


### PR DESCRIPTION
Fixes #337 

To test:
 - Z slider should highlight the range between handles more clearly:

![Screenshot 2020-08-27 at 16 06 41](https://user-images.githubusercontent.com/900055/91460218-78005600-e87f-11ea-9423-69e16e922fae.png)

Could possibly make the whole slider darker too? cc @pwalczysko ?