### PR TITLE
Tiling threshold max projection bytes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,13 +50,19 @@ https://omero-guides.readthedocs.io/en/latest/iviewer/docs/index.html
 Settings
 ========
 
-OMERO.iviewer limits the size of Z-projections to reduce load on the server.
+OMERO limits the size of Z-projections to reduce load on the server.
 The limit is defined as the number of bytes of raw pixel data in a Z-stack and
-is equivalent to 1024 * 1024 * 256 bytes.
-For example, an 8-bit image (1 byte per pixel) of size 1024 * 1024 * 256 is
-equal to the default threshold. To double the limit, use::
+the OMERO.server default is equivalent to 1024 * 1024 * 256 bytes.
+For example, a single-channel 8-bit image (1 byte per pixel) of XYZ size
+1024 * 1024 * 256 is equal to the default threshold.
 
-    $ omero config set omero.web.iviewer.max_projection_bytes 536870912
+To double the limit, use::
+
+    $ omero config set omero.pixeldata.max_projection_bytes 536870912
+
+If you wish to set a threshold for iviewer that is *lower* than for the server:
+
+    $ omero config set omero.web.iviewer.max_projection_bytes 268435456
 
 NB: Z-projection is not supported for tiled images in OMERO
 (Images larger than 2048 * 2048 pixels per plane are tiled in iviewer).

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ equal to the default threshold. To double the limit, use::
     $ omero config set omero.web.iviewer.max_projection_bytes 536870912
 
 NB: Z-projection is not supported for tiled images in OMERO
-(Images larger than 2000 * 2000 pixels per plane are tiled in iviewer).
+(Images larger than 2048 * 2048 pixels per plane are tiled in iviewer).
 
 Supported URLs
 ==============

--- a/plugin/omero_iviewer/iviewer_settings.py
+++ b/plugin/omero_iviewer/iviewer_settings.py
@@ -27,10 +27,13 @@ IVIEWER_SETTINGS_MAPPING = {
 
     "omero.web.iviewer.max_projection_bytes":
         ["MAX_PROJECTION_BYTES",
-         1024 * 1024 * 256,
+         -1,
          int,
          ("Maximum bytes of raw pixel data allowed for Z-projection. "
-          "Above this threshold, Z-projection is disabled")],
+          "Above this threshold, Z-projection is disabled. "
+          "If unset, the server setting of "
+          "omero.pixeldata.max_projection_bytes will be used or "
+          "the lower value if both are set.")],
 
     "omero.web.iviewer.roi_page_size":
         ["ROI_PAGE_SIZE",

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -87,10 +87,14 @@ def index(request, iid=None, conn=None, **kwargs):
         params['URI_PREFIX'] = settings.FORCE_SCRIPT_NAME
     params['ROI_PAGE_SIZE'] = ROI_PAGE_SIZE
 
-    max_bytes = server_settings.get('omero.pixeldata.max_projection_bytes')
-    if max_bytes is None or (
-            MAX_PROJECTION_BYTES > 0 and MAX_PROJECTION_BYTES < max_bytes):
+    c = conn.getConfigService()
+    max_bytes = c.getConfigValue('omero.pixeldata.max_projection_bytes')
+    # check if MAX_PROJECTION_BYTES should override server setting
+    if max_bytes is None or len(max_bytes) == 0 or (
+            MAX_PROJECTION_BYTES > 0 and MAX_PROJECTION_BYTES < int(max_bytes)):
         max_bytes = MAX_PROJECTION_BYTES
+    else:
+        max_bytes = int(max_bytes)
     params['MAX_PROJECTION_BYTES'] = max_bytes
 
     return render(

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -91,7 +91,8 @@ def index(request, iid=None, conn=None, **kwargs):
     max_bytes = c.getConfigValue('omero.pixeldata.max_projection_bytes')
     # check if MAX_PROJECTION_BYTES should override server setting
     if max_bytes is None or len(max_bytes) == 0 or (
-            MAX_PROJECTION_BYTES > 0 and MAX_PROJECTION_BYTES < int(max_bytes)):
+            MAX_PROJECTION_BYTES > 0 and
+            MAX_PROJECTION_BYTES < int(max_bytes)):
         max_bytes = MAX_PROJECTION_BYTES
     else:
         max_bytes = int(max_bytes)

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -86,7 +86,12 @@ def index(request, iid=None, conn=None, **kwargs):
     if settings.FORCE_SCRIPT_NAME is not None:
         params['URI_PREFIX'] = settings.FORCE_SCRIPT_NAME
     params['ROI_PAGE_SIZE'] = ROI_PAGE_SIZE
-    params['MAX_PROJECTION_BYTES'] = MAX_PROJECTION_BYTES
+
+    max_bytes = server_settings.get('omero.pixeldata.max_projection_bytes')
+    if max_bytes is None or (
+            MAX_PROJECTION_BYTES > 0 and MAX_PROJECTION_BYTES < max_bytes):
+        max_bytes = MAX_PROJECTION_BYTES
+    params['MAX_PROJECTION_BYTES'] = max_bytes
 
     return render(
         request, 'omero_iviewer/index.html',

--- a/src/viewers/viewer/globals.js
+++ b/src/viewers/viewer/globals.js
@@ -108,7 +108,7 @@ export const PREFIXED_URIS = [
  * @const
  * @type {number}
  */
-export const UNTILED_RETRIEVAL_LIMIT = 4000000;
+export const UNTILED_RETRIEVAL_LIMIT = 2048 * 2048;
 
 /**
  * the default tile dimensions


### PR DESCRIPTION
Fixes #341. 

This boosts the "Big Image" (use tiles) threshold in iviewer from 2k * 2k to `2048 * 2048`.
Also, it makes iviewer respect the value of the server config: `omero config set omero.pixeldata.max_projection_bytes`.
So, if you boost this value on the server, iviewer will use that value, instead of needing to also update the corresponding config of `omero.web.iviewer.max_projection_bytes` in iviewer.

To test, an image should be enabled for projection in iviewer IF...

With default settings:
- The image must be below `1024 * 1024 * 256` bytes (e.g. 1 channel 8-bit image of X, Y, Z: 2048 * 2048 * 64) AND...
- Image `X * Y` must be below `2048 * 2048`.

 If `omero.pixeldata.max_projection_bytes` setting is doubled to `1073741824` (`1024 * 1024 * 512 * 2`):

- The image bytes must be below this limit (e.g. 2 channel 8-bit image of X, Y, Z: 2048 * 2048 * 64) AND...
- Image `X * Y` must be below `2048 * 2048`.
  

If `omero.web.iviewer.max_projection_bytes` setting is set to LESS than `omero.pixeldata.max_projection_bytes` then this lower threshold will be used:
- The image bytes must be below this limit (e.g. 2 channel 8-bit image of X, Y, Z: 2048 * 2048 * 64) AND...
- Image `X * Y` must be below `2048 * 2048`.
