### PR TITLE
Add request limit as a known issue with nginx config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Known issues
 For images with many channels (greater than approximately 30 channels), saving
 of rendering settings fails due to the length of the request string. See
 `#321 <https://github.com/ome/omero-iviewer/issues/321>`_. A work-around is to
-configure nginx to allow longer request strings. For example, to double the
+configure gunicorn to allow longer request strings. For example, to double the
 allowed limit::
 
     omero config set omero.web.wsgi_args ' --limit-request-line 8192'

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,18 @@ equal to the default threshold. To double the limit, use::
 NB: Z-projection is not supported for tiled images in OMERO
 (Images larger than 2000 * 2000 pixels per plane are tiled in iviewer).
 
+Known issues
+============
+
+For images with many channels (greater than approximately 30 channels), saving
+of rendering settings fails due to the length of the request string. See
+`#321 <https://github.com/ome/omero-iviewer/issues/321>`_. A work-around is to
+configure nginx to allow longer request strings. For example, to double the
+allowed limit::
+
+    omero config set omero.web.wsgi_args ' --limit-request-line 8192'
+
+
 Supported URLs
 ==============
 


### PR DESCRIPTION
See #321 and https://forum.image.sc/t/omero-iviewer-doesnt-save-rendering-settings-in-image-w-many-channels/37484

This documents this known issue and the workaround provided by @olatarkowska (thanks).
