### PR TITLE
Resize viewer when thumbnail panel hidden

### DIFF
--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -592,6 +592,7 @@ export default class ThumbnailSlider extends EventSubscriber {
         $('.frame').addClass('left-hand-panel-hidden');
         $('.frame').css('margin-left', '');
         $('.frame').css('padding-left', '');
+        this.context.eventbus.publish(IMAGE_VIEWER_RESIZE, { config_id: -1 });
     }
 
     /**


### PR DESCRIPTION
Fixes #367

To test, open an orphaned image in iviewer (Thumbnails panel will be hidden).
The image shouldn't appear *stretched* length-ways.

Then make a tiny drag to resize the right-panel divider or a tiny resize of the browser window and you *shouldn't* notice a change in the aspect ratio of the image (as in the video attached to the image.sc post above).

