### PR TITLE
Include current z-plane in getViewportLink()

### DIFF
--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1500,6 +1500,7 @@ export default class Ol3Viewer extends EventSubscriber {
         let image_info = this.image_config.image_info;
         let args = [];
         let center = view.getCenter();
+        args.push([REQUEST_PARAMS.PLANE, image_info.dimensions.z]);
         args.push([REQUEST_PARAMS.CENTER_X, parseInt(center[0])]);
         args.push([REQUEST_PARAMS.CENTER_Y, (-parseInt(center[1]))]);
         args.push([REQUEST_PARAMS.ZOOM, parseInt(100 / view.getResolution())]);


### PR DESCRIPTION
Fixes #355 

To test:
 - Open a multi-z image in iviewer
 - Scroll to a particular Z-plane (zoom in to feature of interest)
 - Right-click on Image -> `Get Link to Viewport`. Copy the link (notice it includes `z=...`
 - Paste the URL in new browser tab - this should take you to the specified Z plane (and location)