### PR TITLE
Load delta_t after image_data

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -280,30 +280,31 @@ a.ui-button:active,
 }
 
 .time-slider {
-    left: 90px;
-    right: 55px;
+    left: 0;
     z-index: 3;
+    display: flex;
+    right: 0;
 }
 .show-zSlider .time-slider {
-    left: 125px;
+    left: 35px;
 }
 
 .plane-slider span, .time-slider span {
-    position: absolute;
     font-size: 18px;
 }
 
-.plane-slider.glyphicon, .time-slider .glyphicon {
+.plane-slider.glyphicon {
     position: absolute;
 }
 
 .plane-slider span {
+    position: absolute;
     left: 0;
     width: 35px;
     text-align: center;
 }
 .time-slider span {
-    top: 6px;
+    margin: 6px;
 }
 
 .plane-slider .glyphicon {
@@ -311,6 +312,7 @@ a.ui-button:active,
 }
 .time-slider .glyphicon {
     top: 11px;
+    margin: 0 6px;
 }
 
 .plane-slider .dim-label {
@@ -328,13 +330,11 @@ a.ui-button:active,
     left: -55px;
     color: #999;
     text-align: right;
-    width: 30px;
 }
 
 .time-slider .dim-size {
     right: -55px;
     color: #999;
-    width: 30px;
 }
 .plane-slider .dim-size {
     top: -45px;
@@ -380,7 +380,7 @@ a.ui-button:active,
     margin-left: 12px;
 }
 .time-slider .ui-slider {
-    width: 100%;
+    flex-grow: 1;
     height: 9px;
     margin-top: 14px;
 }
@@ -390,7 +390,7 @@ a.ui-button:active,
     width: 19px;
 }
 .time-slider .ui-slider-handle {
-    top: -0.45em;
+    top: -14px;
     height: 19px;
 }
 
@@ -399,19 +399,16 @@ a.ui-button:active,
     top: auto;
 }
 .time-slider .glyphicon-chevron-left {
-    left: -20px;
+    /* left: -20px; */
 }
 
 .plane-slider .glyphicon-chevron-up {
     top: -20px;
 }
 .time-slider .glyphicon-chevron-right {
-    right: -20px;
+    /* right: -20px; */
 }
 
-.time-slider .glyphicon-play, .time-slider .glyphicon-stop {
-    left: -70px;
-}
 .plane-slider .glyphicon-play, .plane-slider .glyphicon-stop {
     bottom: -85px;
     top: auto;
@@ -427,10 +424,11 @@ a.ui-button:active,
     top: -50px;
 }
 
-
+.plane-slider .dim-arrows {
+    position: absolute;
+}
 .dim-arrows {
     cursor: pointer;
-    position: absolute;
 }
 .dim-arrow-up {
     background-image: url('images/arrow-up.png');

--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
         name='omero_iviewer_persist_rois'),
     url(r'^image_data/(?P<image_id>[0-9]+)/$', views.image_data,
         name='omero_iviewer_image_data'),
+    url(r'^image_data/(?P<image_id>[0-9]+)/delta_t/$', views.delta_t_data,
+        name='omero_iviewer_image_data_deltat'),
     # load image_data for image linked to an ROI or Shape
     url(r'^(?P<obj_type>(roi|shape))/(?P<obj_id>[0-9]+)/image_data/$',
         views.roi_image_data, name='omero_iviewer_roi_image_data'),

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -528,9 +528,6 @@ def delta_t_data(request, image_id, conn=None, **kwargs):
 
     rv = {}
 
-    import time
-    time.sleep(10)
-
     size_t = image.getSizeT()
     time_list = []
     delta_t_unit_symbol = None

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -395,7 +395,6 @@ export default class ImageInfo {
         this.import_date = response.import_date;
         if (typeof response.acquisition_date === 'string')
             this.acquisition_date = response.acquisition_date;
-        this.setFormattedDeltaT(response);
         this.roi_count = response.roi_count;
         if (typeof response.meta.datasetName === 'string')
             this.dataset_name = response.meta.datasetName;
@@ -417,6 +416,8 @@ export default class ImageInfo {
             this.context.publish(
                 IMAGE_SETTINGS_REFRESH, { config_id : this.config_id});
         }
+        // Finally, load delta_t data
+        this.requestDeltaT();
     }
 
     /**
@@ -621,6 +622,22 @@ export default class ImageInfo {
             default: m = 'color';
         }
         return m;
+    }
+
+    /**
+     * Loads and the Image delta_t timestamp data
+     */
+    requestDeltaT() {
+        if (this.dimensions.max_t <= 1) return;
+        let url = this.context.server + this.context.getPrefixedURI(IVIEWER);
+        url += "/image_data/" + this.image_id + '/delta_t/';
+        $.ajax({
+            url,
+            success: (response) => {
+                console.log('response this.image_id', this.image_id, response.image_id);
+                this.setFormattedDeltaT(response)
+            }
+        });
     }
 
     /**

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -53,8 +53,7 @@
                 dim="t"
                 player_info.bind="player_info"
                 class="time-slider"
-                css="${image_config.image_info.image_delta_t.length > 0 ?
-                       'right: 175px': ''}">
+            >
             </dimension-slider>
     </div>
     <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>


### PR DESCRIPTION
Investigating solutions for slow loading of delta_t info.
Fixes #371.

This allows for loading of `delta_t` info to happen *after* the initial load of `image_data` and the update of the UI to show the image.

NB: `time.sleep(10)` used to simulate slow loading of delta_t, (reported as over 10 secs in issue above).
This slow loading should not cause any issues with the loading of other image data, or update of the UI.

To test (with fake delay temporarily added as above):

 - Open Time-lapse images in iviewer 
 - Should see that timestamp info isn't initially loaded (but this doesn't otherwise delay image opening, and being able to interact with the image)
 - Timestamp info should eventually be loaded and displayed after about 10 seconds
 - Switching between images faster than this shouldn't cause any issues (e.g. late loading of `delta_t` info doesn't get displayed on wrong image.)

If this all works fine, then I'll remove the `time.sleep(10)` and we can try testing on a real image which has slow loading of timestamp info.

cc @sbesson 