### PR TITLE
ROI popup dialog fix

### DIFF
--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -208,6 +208,13 @@ class Viewer extends OlObject {
         this.regions_ = null;
 
         /**
+         * this flag determines whether ShapeEditPopup is shown on selected shape
+         * Defauls to true
+         * @type {boolean}
+         */
+        this.enable_shape_popup = true;
+
+        /**
          * the 'viewer state', i.e. the controls and interactions that were added
          * the items in the map have the following layout
          * <pre>
@@ -783,18 +790,15 @@ class Viewer extends OlObject {
      * @param {boolean} flag
      */
     enableShapePopup(flag) {
-        var regions = this.getRegions();
-        if (regions) {
-            regions.enable_shape_popup = flag;
+        this.enable_shape_popup = flag;
 
-            // If enabling, try to show popup
-            if (flag) {
-                this.viewer_.getOverlays().forEach(o => {
-                    if (o.updatePopupVisibility) {
-                        o.updatePopupVisibility();
-                    }
-                });
-            }
+        // If enabling, try to show popup
+        if (flag) {
+            this.viewer_.getOverlays().forEach(o => {
+                if (o.updatePopupVisibility) {
+                    o.updatePopupVisibility();
+                }
+            });
         }
     }
 

--- a/src/viewers/viewer/controls/ShapeEditPopup.js
+++ b/src/viewers/viewer/controls/ShapeEditPopup.js
@@ -196,7 +196,7 @@ class ShapeEditPopup extends Overlay {
         this.coordsInput.value = coordsText;
         this.areaInput.value = areaText;
 
-        if (this.regions.enable_shape_popup) {
+        if (this.regions.viewer_.enable_shape_popup) {
             this.setPosition([x, y]);
         }
     }

--- a/src/viewers/viewer/source/Regions.js
+++ b/src/viewers/viewer/source/Regions.js
@@ -114,13 +114,6 @@ class Regions extends Vector {
         this.show_comments_ = false;
 
         /**
-         * this flag determines whether ShapeEditPopup is shown on selected shape
-         * Defauls to true
-         * @type {boolean}
-         */
-        this.enable_shape_popup = true;
-
-        /**
          * the associated regions information
          * as retrieved from the omero server
          * @type {Object}


### PR DESCRIPTION
Fixes #346 

This stores the `enable_shape_popup` on the viewer, not on regions.
This means that enable_shape_popup flag won't get lost each time we reload Regions.

To test:
 - Load an image with paginated ROIs (over 500)
 - Select an ROI, then disable the Shape popup (`X`)
 - Load a different 'page' of ROIs
 - Select an ROI - popup should remain disabled.