### PR TITLE
Time unit fixes

### DIFF
--- a/src/controls/dimension-slider.html
+++ b/src/controls/dimension-slider.html
@@ -80,11 +80,9 @@
             ${image_config.image_info.dimensions['max_' + dim]}
         </span>
         <span show.bind="image_config.image_info.image_delta_t.length > 0"
-              class="timestamp">
-            ${image_config.image_info.dimensions[dim] &lt;
-                image_config.image_info.image_delta_t.length ?
-                    image_config.image_info.image_delta_t[
-                        image_config.image_info.dimensions[dim]] : '&nbsp;'}
+            title="${image_config.image_info.formatDeltaT(image_config.image_info.image_delta_t[image_config.image_info.dimensions[dim]], true)}"
+            class="timestamp">
+            ${image_config.image_info.formatDeltaT(image_config.image_info.image_delta_t[image_config.image_info.dimensions[dim]])}
         </span>
     </template>
 </template>

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -322,7 +322,7 @@ export default class DimensionSlider {
                     this.dim.toUpperCase() + ":" + (newDimVal+1);
                 if (this.dim === 't' && imgInf.image_delta_t.length > 0 &&
                     newDimVal < imgInf.image_delta_t.length)
-                        sliderTip += " [" + imgInf.image_delta_t[newDimVal] + "]";
+                    sliderTip += " [" + imgInf.formatDeltaT(imgInf.image_delta_t[newDimVal]) + "]";
                 sliderValueSpan.text(sliderTip);
                 let percent = (ui.value / (imgInf.dimensions['max_' + this.dim] - 1)) * 100;
                 if (this.dim === 'z') {

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -665,19 +665,26 @@ export default class ImageInfo {
                 t = -t;
             }
             if (t !== 0) deltaTisAllZeros = false;
+            // days
+            let days = parseInt(t / (24 * 3600 * precision));
+            t -= (days * 24 * 3600 * precision);
             // hrs
             let hours = parseInt(t / (3600 * precision));
-            deltaTformatted += ("00" + hours).slice(-2) + ":";
             t -= (hours * 3600 * precision);
             // minutes
             let mins =  parseInt(t / (60 * precision));
-            deltaTformatted += ("00" + mins).slice(-2) + ":";
             t -= (mins * (60 * precision));
             // seconds
             let secs = parseInt(t / precision);
-            deltaTformatted += ("00" + secs).slice(-2) + ".";
             // milliseconds
             let millis = t - (secs * precision);
+
+            if (days != 0) {
+                deltaTformatted += days + " days "
+            }
+            deltaTformatted += ("00" + hours).slice(-2) + ":";
+            deltaTformatted += ("00" + mins).slice(-2) + ":";
+            deltaTformatted += ("00" + secs).slice(-2) + ".";
             deltaTformatted += ("000" + millis).slice(-3);
             this.image_delta_t.push(deltaTformatted);
         });

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -642,58 +642,67 @@ export default class ImageInfo {
 
     /**
      * Sets image_delta_t member from response
-     * after formatting it to hours:minutes:seconds:milliseconds
      *
      * @private
      * @param {Object} response the response object
      * @memberof ImageInfo
      */
     setFormattedDeltaT(response) {
+
+        this.image_delta_t = response.delta_t
+
+        // original units
+        this.image_delta_t_unit = response.delta_t_unit_symbol;
+    }
+
+    /**
+     * Formats delta-T to 'dd hh:mm:ss:milliseconds'
+     *
+     * @param {Number} t            time in seconds
+     * @param {Boolean} verbose     if true, use e.g. '10 days 01 hours minutes seconds'
+     * @memberof ImageInfo
+     */
+    formatDeltaT(t, verbose=false) {
         // avoid further IEEE inaccuracies for remainders
         // by using multiplier and rounding to integer (at ms effectively)
         const precision = 1000;
 
-        let deltaTisAllZeros = true;
-        response.delta_t.map((t) => {
-            t = Math.round(t * precision);
-            let deltaTformatted = "";
+        t = Math.round(t * precision);
+        let deltaTformatted = "";
 
-            // put minus in front
-            let isNegative = t < 0;
-            if (isNegative) {
-                deltaTformatted += "-";
-                t = -t;
-            }
-            if (t !== 0) deltaTisAllZeros = false;
-            // days
-            let days = parseInt(t / (24 * 3600 * precision));
-            t -= (days * 24 * 3600 * precision);
-            // hrs
-            let hours = parseInt(t / (3600 * precision));
-            t -= (hours * 3600 * precision);
-            // minutes
-            let mins =  parseInt(t / (60 * precision));
-            t -= (mins * (60 * precision));
-            // seconds
-            let secs = parseInt(t / precision);
-            // milliseconds
-            let millis = t - (secs * precision);
+        // put minus in front
+        let isNegative = t < 0;
+        if (isNegative) {
+            deltaTformatted += "-";
+            t = -t;
+        }
+        // days
+        let days = parseInt(t / (24 * 3600 * precision));
+        t -= (days * 24 * 3600 * precision);
+        // hrs
+        let hours = parseInt(t / (3600 * precision));
+        t -= (hours * 3600 * precision);
+        // minutes
+        let mins =  parseInt(t / (60 * precision));
+        t -= (mins * (60 * precision));
+        // seconds
+        let secs = parseInt(t / precision);
+        // milliseconds
+        let millis = t - (secs * precision);
 
-            if (days != 0) {
-                deltaTformatted += days + " days "
-            }
-            deltaTformatted += ("00" + hours).slice(-2) + ":";
-            deltaTformatted += ("00" + mins).slice(-2) + ":";
-            deltaTformatted += ("00" + secs).slice(-2) + ".";
-            deltaTformatted += ("000" + millis).slice(-3);
-            this.image_delta_t.push(deltaTformatted);
-        });
-
-        // we reset to deltaT to [] if all zeros
-        if (deltaTisAllZeros) this.image_delta_t = [];
-        // original units
-        this.image_delta_t_unit = response.delta_t_unit_symbol;
-    }
+        function pad(value, length=2) {
+            return ("000" + value).slice(-length);
+        }
+        if (days != 0) {
+            deltaTformatted += (verbose ? (days + " days ") : (pad(days) + " "));
+        }
+        if (verbose) {
+            deltaTformatted += `${hours} hours ${mins} minutes ${secs}.${pad(millis, 3)} seconds`
+        } else {
+            deltaTformatted += `${pad(hours)}:${pad(mins)}:${pad(secs)}.${pad(millis, 3)}`
+        }
+        return deltaTformatted;
+    };
 
     /**
      * Retrieves the copied rendering settings

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -693,11 +693,15 @@ export default class ImageInfo {
         function pad(value, length=2) {
             return ("000" + value).slice(-length);
         }
+
+        function s(value) {
+            return value == 1 ? "" : "s";
+        }
         if (days != 0) {
-            deltaTformatted += (verbose ? (days + " days ") : (pad(days) + " "));
+            deltaTformatted += (verbose ? (days + ` day${s(days)} `) : (pad(days) + " "));
         }
         if (verbose) {
-            deltaTformatted += `${hours} hours ${mins} minutes ${secs}.${pad(millis, 3)} seconds`
+            deltaTformatted += `${hours} hour${s(hours)} ${mins} minute${s(mins)} ${secs}.${pad(millis, 3)} seconds`
         } else {
             deltaTformatted += `${pad(hours)}:${pad(mins)}:${pad(secs)}.${pad(millis, 3)}`
         }


### PR DESCRIPTION
Fixes #385

This PR handles time values up to Days (previously, anything over 99 hours was not displayed correctly).
It also handles any time units.

Tested using script at https://github.com/ome/omero-iviewer/issues/385#issuecomment-874824752 to set units for existing image.

When doing this for a sample (FRAP) image, timestamps that are less than a day, no 'days' are shown:

![Screenshot 2021-07-06 at 16 02 33](https://user-images.githubusercontent.com/900055/124624362-b8a00700-de74-11eb-912f-0d0bce1d6ec7.png)

But when the time is longer than a day it is show like this (NB: open to suggestions for best way to format days)?

![Screenshot 2021-07-06 at 16 01 58](https://user-images.githubusercontent.com/900055/124624503-d5d4d580-de74-11eb-91e9-90b54c466b01.png)

If the time is an exact number of days, e.g. `3 days`, we still show `hh:mm:ss.sss`. Is it worth eliminating that if all those values are zero?

cc @jburel 