### PR TITLE
Fix X close button for ROI popup.

### DIFF
--- a/css/ol3-viewer.css
+++ b/css/ol3-viewer.css
@@ -490,9 +490,6 @@
 .shape-edit-popup-closer {
     text-decoration: none;
     position: absolute;
-    top: 2px;
+    top: 0;
     right: 8px;
-}
-.shape-edit-popup-closer:after {
-    content: "✖";
 }

--- a/src/viewers/viewer/controls/ShapeEditPopup.js
+++ b/src/viewers/viewer/controls/ShapeEditPopup.js
@@ -51,7 +51,7 @@ class ShapeEditPopup extends Overlay {
                 value=''/>
             <div><input readonly class='shape-popup-coords'/></div>
             <div><input readonly class='shape-popup-area'/></div>
-            <a href="#" class="shape-edit-popup-closer" class="shape-edit-popup-closer"></a>
+            <a href="#" class="shape-edit-popup-closer" class="shape-edit-popup-closer">&times;</a>
         </div>`;
         // add flag to the event so that the Hover interaction can ignore it
         popup.onpointermove = function(e) {


### PR DESCRIPTION
The unicode sometimes renders incorrectly, possible when font loading is slow??

Fix with tip from https://twitter.com/wesbos/status/499245255703949312

Bug: *sometimes* the X looks like this. Doesn't happen very often
<img width="270" alt="Screenshot 2022-03-25 at 11 40 03" src="https://user-images.githubusercontent.com/900055/160115277-6eb9e1a3-d638-4d5f-92bb-9fa737586148.png">
Mostly looks like this:
<img width="198" alt="Screenshot 2022-03-25 at 11 41 23" src="https://user-images.githubusercontent.com/900055/160115392-22dff7f3-5241-4ce4-ad17-24a6912879dc.png">


