### PR TITLE
Rename ?server query parameter to ?host

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -428,7 +428,7 @@ export default class Context {
      * @memberof Context
      */
     processInitialParameters() {
-        let server = this.initParams[REQUEST_PARAMS.SERVER];
+        let server = this.initParams[REQUEST_PARAMS.HOST];
         if (typeof server !== 'string' || server.length === 0) server = "";
         else {
             // check for localhost and if we need to prefix for requests
@@ -443,7 +443,7 @@ export default class Context {
                 server = "http://" + server;
         }
         this.server = server;
-        delete this.initParams[REQUEST_PARAMS.SERVER];
+        delete this.initParams[REQUEST_PARAMS.HOST];
 
         let interpolate =
             typeof this.initParams[REQUEST_PARAMS.INTERPOLATE] === 'string' ?

--- a/src/viewers/viewer/globals.js
+++ b/src/viewers/viewer/globals.js
@@ -132,7 +132,7 @@ export const REQUEST_PARAMS = {
     OMERO_VERSION: 'OMERO_VERSION',
     PLANE: 'Z',
     PROJECTION: 'P',
-    SERVER: 'SERVER',
+    HOST: 'HOST',
     TIME: 'T',
     ZOOM: 'ZM'
 };


### PR DESCRIPTION
This prevents collision with ?server=2 used by webclient @login_required decorator

This testing is the same `omero-web` functionality as recently tested in https://github.com/ome/omero-web/pull/386, that was previously broken because `iviewer` uses the `?server=2` parameter from the URL which causes errors (this parameter was originally added for dev functionality but not used now). This has been re-named to `host` to prevent the collision, allowing the `omero-web` workflow to function as normal...

See https://github.com/ome/omero-web/issues/379

To test, get a session ID, e.g via cli to e.g. nightshade

```
$ omero login
$ omero sessions list
```

Try to login to a server that is not the first on the list. E.g. for merge-ci, try to login to nightshade, listed 3rd (`server=3`)
First you need to look up an Image ID on target server (nightshade) that you can access with the session created above.

Then go to:

https://merge-ci.openmicroscopy.org/web/webclient/img_detail/IMAGE_ID/?bsession=SESSION_ID&server=3

You should be able to see the image.