### PR TITLE
Bump jQuery to 3.6.2 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "clean-css-cli": "^4.3.0",
         "d3": "7.6.1",
         "file-saver": "1.3.3",
-        "jquery": "3.5.0",
+        "jquery": "3.6.2",
         "jquery-ui": "1.13.2",
         "jszip": "3.7.0",
         "karma": "^6.3.16",
@@ -7194,9 +7194,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
+      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A=="
     },
     "node_modules/jquery-ui": {
       "version": "1.13.2",
@@ -18913,9 +18913,9 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
+      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A=="
     },
     "jquery-ui": {
       "version": "1.13.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean-css-cli": "^4.3.0",
     "d3": "7.6.1",
     "file-saver": "1.3.3",
-    "jquery": "3.5.0",
+    "jquery": "3.6.2",
     "jquery-ui": "1.13.2",
     "jszip": "3.7.0",
     "karma": "^6.3.16",


### PR DESCRIPTION
Fixes #440.

JQuery is only used for `$.ajax()` loading data, so testing should include testing of loading images, ROIs and saving rdefs, ROIs etc.