### PR TITLE
Don't scale labels by default

### DIFF
--- a/plugin/omero_iviewer/iviewer_settings.py
+++ b/plugin/omero_iviewer/iviewer_settings.py
@@ -25,6 +25,14 @@ from omeroweb.settings import process_custom_settings, report_settings
 # load settings
 IVIEWER_SETTINGS_MAPPING = {
 
+    "omero.web.iviewer.scale_text":
+        ["SCALE_TEXT",
+         True,
+         str,
+         # NB: use str() here because bool("False") is True!
+         # whereas str() allows setting this to "False"
+         ("Scale ROI text labels when zooming")],
+
     "omero.web.iviewer.max_projection_bytes":
         ["MAX_PROJECTION_BYTES",
          -1,

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -46,6 +46,7 @@ from . import iviewer_settings
 WEB_API_VERSION = 0
 MAX_LIMIT = max(1, API_MAX_LIMIT)
 
+SCALE_TEXT = getattr(iviewer_settings, 'SCALE_TEXT')
 ROI_PAGE_SIZE = getattr(iviewer_settings, 'ROI_PAGE_SIZE')
 ROI_PAGE_SIZE = min(MAX_LIMIT, ROI_PAGE_SIZE)
 MAX_PROJECTION_BYTES = getattr(iviewer_settings, 'MAX_PROJECTION_BYTES')
@@ -105,6 +106,7 @@ def index(request, iid=None, conn=None, **kwargs):
         if MAX_PROJECTION_BYTES > 0:
             max_bytes = MAX_PROJECTION_BYTES
 
+    params['SCALE_TEXT'] = SCALE_TEXT
     params['MAX_PROJECTION_BYTES'] = max_bytes
     params['ROI_COLOR_PALETTE'] = ROI_COLOR_PALETTE
     params['SHOW_PALETTE_ONLY'] = SHOW_PALETTE_ONLY

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -468,6 +468,7 @@ export default class Ol3Viewer extends EventSubscriber {
         // tweak initParams for ol3viewer to reflect iviewer app name
         let ol3initParams = Object.assign({}, this.context.initParams);
         ol3initParams[PLUGIN_PREFIX] = this.context.getPrefixedURI(IVIEWER);
+        let scaleText = this.context.getInitialRequestParam("SCALE_TEXT") === "True";
 
         // create viewer instance
         this.viewer =
@@ -477,7 +478,8 @@ export default class Ol3Viewer extends EventSubscriber {
                      server : this.context.server,
                      data: this.image_config.image_info.tmp_data,
                      initParams :  ol3initParams,
-                     container: this.container
+                     container: this.container,
+                     scaleText,
                  });
         delete this.image_config.image_info.tmp_data;
 

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -118,6 +118,8 @@ class Viewer extends OlObject {
 
         var opts = options || {};
 
+        this.scaleText = opts.scaleText;
+
         /**
          * the image id
          *
@@ -729,6 +731,9 @@ class Viewer extends OlObject {
 
         var options = {};
         if (data) options['data'] = data;
+        if (this.scaleText) {
+            options['scaleText'] = true;
+        }
         // Regions constructor creates ol.Features from JSON data
         this.regions_ = new Regions(this, options);
 

--- a/src/viewers/viewer/source/Regions.js
+++ b/src/viewers/viewer/source/Regions.js
@@ -87,11 +87,11 @@ class Regions extends Vector {
 
         /**
          * a flag that tells us if we'd like for the text to be scaled with resolution
-         * changes of the view. Defaults to true
+         * changes of the view. Defaults to false
          * @type {boolean}
          * @private
          */
-        this.scale_text_ = true;
+        this.scale_text_ = false;
         if (typeof(opts['scaleText']) === 'boolean')
             this.scale_text_ = opts['scaleText'];
 


### PR DESCRIPTION
Fixes #442.

This adds a config option to disable the scaling of labels and shape-text when you zoom:

```
omero config set omero.web.iviewer.scale_text false
```

Often the behaviour of NOT scaling labels as you zoom (typical behaviour on maps etc) is preferable.

But that would be a breaking change - E.g. in this case, all the labels are 200px high, and if shown that large at lower zoom levels then they would obscure the image (and each other): https://chamber.mrc.ox.ac.uk/iviewer/?images=124

For testing, the above config has been set-up on merge-ci:
 - Add text to shapes and a Text label
 - Zooming in and out shouldn't change the size of the label - always shown on screen at 100%