### PR TITLE
Build

### DIFF
--- a/plugin/setup.cfg
+++ b/plugin/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = omero_iviewer/README.rst
+description_file = omero_iviewer/README.rst


### PR DESCRIPTION
This PR removes warning in build. ``underscore`` should be used
Turning ``include_package_data`` to ``False`` fixes the build issue noticed on new CI 