### PR TITLE
Don't use tiles for non-big movies

### DIFF
--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -182,12 +182,13 @@ const OmeroImage = function(options) {
     /**
      * should we use tiled retrieval methods?
      * for now use them only for truly tiled/pyramidal sources
-     * and images that exceed {@link UNTILED_RETRIEVAL_LIMIT}
+     * and single-T images that exceed {@link UNTILED_RETRIEVAL_LIMIT}
+     * (Want to avoid async tile loading while movie is playing)
      * @type {boolean}
      * @private
      */
     this.use_tiled_retrieval_ = this.tiled_ ||
-        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT;
+        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT && this._time == 1;
 
     /**
      * for untiled retrieval the tile size equals the entire image extent


### PR DESCRIPTION
Fixes #453.

If the image is not a Big (tiled) image, then don't use tile-based loading if the image is a Movie.
