### PR TITLE
Channel min spinner fix

### DIFF
--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -896,10 +896,11 @@ export default class ImageInfo {
                     precision <= 0) precision = 3;
         } else precision = 0;
 
+        if (precision != 0 && this.image_pixels_type === 'float') {
+            start_min = Misc.roundAtDecimal(start_min, precision)
+        }
         return {
-            start_min:
-                precision === 0 ?
-                    start_min : Misc.roundAtDecimal(start_min, precision),
+            start_min: start_min,
             start_max:
                 (precision === 0 ?
                     start_max :

--- a/src/settings/channel-range.js
+++ b/src/settings/channel-range.js
@@ -161,8 +161,10 @@ export default class ChannelRange  {
 
         // channel start
         let channelStart = $(this.element).find(".channel-start");
+        // spinner widget doesn't work properly with VERY negative numbers.
+        let spinnerMin = Math.max(-1000000000000000, this.full_range_min_max.start_min)
         channelStart.spinner({
-            min: this.full_range_min_max.start_min, max: this.full_range_min_max.start_max,
+            min: spinnerMin, max: this.full_range_min_max.start_max,
             step: this.min_max_range.step_size
         });
         let channelStartArrows =


### PR DESCRIPTION
Fixes issues for 'start' channel slider input as reported at https://github.com/ome/ZarrReader/issues/67#issuecomment-1794622742.

 - With a very large negative number, the formatting of the number as required for floats was resulting in Nan.
 - Also, the spinner behaviour (jQuery plugin) doesn't work with very large negative numbers. Reducing the minimum number fixes this issue.