### PR TITLE
Tile load error warning

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -551,6 +551,28 @@ span.sp-thumb-el {
     height: 100%;
 }
 
+@keyframes spinner {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.map_spinner:after {
+    content: "";
+    box-sizing: border-box;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 40px;
+    height: 40px;
+    margin-top: -20px;
+    margin-left: -20px;
+    border-radius: 50%;
+    border: 5px solid rgba(180, 180, 180, 0.6);
+    border-top-color: rgba(0, 0, 0, 0.6);
+    animation: spinner 0.6s linear infinite;
+}
+
 .thumbnail-panel {
     padding-top: 30px;
     width: 100px;

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -80,6 +80,8 @@ export const HISTOGRAM_RANGE_UPDATE = "HISTOGRAM_RANGE_UPDATE";
 export const THUMBNAILS_UPDATE = "THUMBNAILS_UPDATE";
 /** whenever the presently active image settings should be saved */
 export const SAVE_ACTIVE_IMAGE_SETTINGS = "SAVE_ACTIVE_IMAGE_SETTINGS";
+/** used to notify of a tileloaderror from openlayers viewer */
+export const TILE_LOAD_ERROR = "TILE_LOAD_ERROR";
 
 /**
  * Facilitates recurring event subscription

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -35,12 +35,12 @@
                 'WEB_API_BASE': 'api/v0/',
                 'ROI_PAGE_SIZE': '500',
                 'MAX_PROJECTION_BYTES': "268435456", // 1024 * 1024 * 256
-                // 'IMAGES': "1"   // "4420" // "73537",
+                'IMAGES': "1929",      // "4420" // "73537",
                 //'ROI_COLOR_PALETTE': '["rgb(0,255,0)","blue","blue","pink","blue"],["rgb(255,255,255)"]',
                 'ENABLE_MIRROR': 'True',
-                'FY': 'true',
+                // 'FY': 'true',
                 //'SHOW_PALETTE_ONLY': true,
-                'DATASET': "1",
+                // 'DATASET': "1",
                 //'WELL': "1"
         };
         // check if we need to log in

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -39,7 +39,7 @@
         </dimension-slider>
 
         <div class="viewer">
-              <div id.bind="container" class="viewer-container"></div>
+              <div id.bind="container" class="viewer-container map_spinner"></div>
         </div>
     </div>
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -42,7 +42,7 @@ import {
     REGIONS_MODIFY_SHAPES, REGIONS_PROPERTY_CHANGED, REGIONS_SET_PROPERTY,
     REGIONS_SHOW_COMMENTS, REGIONS_STORED_SHAPES, REGIONS_STORE_SHAPES,
     VIEWER_IMAGE_SETTINGS, VIEWER_PROJECTIONS_SYNC, VIEWER_SET_SYNC_GROUP,
-    ENABLE_SHAPE_POPUP,
+    ENABLE_SHAPE_POPUP, TILE_LOAD_ERROR,
     EventSubscriber
 } from '../events/events';
 import Mirror from './viewer/controls/Mirror';
@@ -153,6 +153,8 @@ export default class Ol3Viewer extends EventSubscriber {
             (params={}) => this.saveCanvasData(params)],
         [VIEWER_SET_SYNC_GROUP,
             (params={}) => this.setSyncGroup(params)],
+        [TILE_LOAD_ERROR,
+            (params={}) => Ui.showModalMessage("Failed to load tiles.<br>Please try refreshing the page.", "OK")],
         [IMAGE_SETTINGS_REFRESH,
             (params={}) => this.refreshImageSettings(params)]];
 

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -652,7 +652,7 @@ class Viewer extends OlObject {
         }
 
         // listen for any tile loading errors...
-        listen(
+        this.tileLoadErrorListener = listen(
             this.getImageLayer().getSource(), "tileloaderror",
             function(event) {
                 if (this.eventbus_) {
@@ -1806,6 +1806,9 @@ class Viewer extends OlObject {
             if (typeof(this.onViewRotationListener) !== 'undefined' &&
                 this.onViewRotationListener)
                     unlistenByKey(this.onViewRotationListener);
+            if (typeof(this.tileLoadErrorListener) !== 'undefined' &&
+                this.tileLoadErrorListener)
+                    unlistenByKey(this.tileLoadErrorListener);
 
             this.viewer_.dispose();
         }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -2322,7 +2322,6 @@ class Viewer extends OlObject {
     getViewParameters() {
         if (this.viewer_ === null || this.getImage() === null) return null;
         var viewProps = this.viewer_.getView().getProperties()
-        console.log(viewProps)
         return {
             "z": this.getDimensionIndex('z'),
             "t": this.getDimensionIndex('t'),

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,13 +651,11 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
-        // listen (once) for rendercomplete to remove the map_spinner
-        const renderCompleteListener = listen(
+        // listen for rendercomplete to remove the map_spinner
+        this.renderCompleteListener = listen(
             this.viewer_, "rendercomplete",
             function(event) {
-                this.viewer_.getTargetElement().classList.remove('map_spinner');
-                // stop listening
-                unlistenByKey(renderCompleteListener);
+                this.hideSpinner();
             }, this);
 
         // listen for any tile loading errors...
@@ -1818,7 +1816,9 @@ class Viewer extends OlObject {
             if (typeof(this.tileLoadErrorListener) !== 'undefined' &&
                 this.tileLoadErrorListener)
                     unlistenByKey(this.tileLoadErrorListener);
-
+            if (this.renderCompleteListener) {
+                unlistenByKey(this.renderCompleteListener);
+            }
             this.viewer_.dispose();
         }
 
@@ -2278,6 +2278,20 @@ class Viewer extends OlObject {
     }
 
     /**
+     * Shows a spinner indicating the map is loading data
+     */
+    showSpinner() {
+        this.viewer_.getTargetElement().classList.add('map_spinner');
+    }
+
+    /**
+     * Hides the spinner
+     */
+    hideSpinner() {
+        this.viewer_.getTargetElement().classList.remove('map_spinner');
+    }
+
+    /**
      * Triggers an explicit rerendering of the image (tile) layer
      *
      * @param {boolean} clearCache empties the tile cache if true
@@ -2301,6 +2315,7 @@ class Viewer extends OlObject {
             } else {
                 imageSource.cache_version_++;
             }
+            this.showSpinner();
             imageSource.changed();
         } catch(canHappen) {}
     }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,6 +651,15 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
+        // listen (once) for rendercomplete to remove the map_spinner
+        const renderCompleteListener = listen(
+            this.viewer_, "rendercomplete",
+            function(event) {
+                this.viewer_.getTargetElement().classList.remove('map_spinner');
+                // stop listening
+                unlistenByKey(renderCompleteListener);
+            }, this);
+
         // listen for any tile loading errors...
         this.tileLoadErrorListener = listen(
             this.getImageLayer().getSource(), "tileloaderror",

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,6 +651,15 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
+        // listen for any tile loading errors...
+        listen(
+            this.getImageLayer().getSource(), "tileloaderror",
+            function(event) {
+                if (this.eventbus_) {
+                    sendEventNotification(this, "TILE_LOAD_ERROR");
+                }
+            }, this);
+
         // listens to resolution changes
         this.onViewResolutionListener =
         listen( // register a resolution handler for zoom display


### PR DESCRIPTION
As discussed at IDR meeting, instead of failing silently and showing white background when tiles fail to load, we should warn the user and encourage them to refresh the viewer since tiles may load on 2nd attempt.

![Screenshot 2024-02-22 at 15 00 22](https://github.com/ome/omero-iviewer/assets/900055/c3f5ff21-30fc-4961-a940-db00aaf50d93)

EDIT: also added a spinner when the map loads, based on example at https://openlayers.org/en/latest/examples/load-events.html

To test,
 - Open an Image in ivewer - should see a spinner on the map until the last tile has loaded.
 - Go back to webclient and logout
 - Zoom / pan or adjust Z/T or rendering settings to try and load more tiles - should see error above.