### PR TITLE
Movie playing waits for planes

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -290,7 +290,7 @@ span.sp-thumb-el {
     position: absolute;
 }
 
-.cursor_spinner {
+.cursor_spinner * {
     cursor: wait;
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -551,6 +551,28 @@ span.sp-thumb-el {
     height: 100%;
 }
 
+@keyframes spinner {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.map_spinner:after {
+    content: "";
+    box-sizing: border-box;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 40px;
+    height: 40px;
+    margin-top: -20px;
+    margin-left: -20px;
+    border-radius: 50%;
+    border: 5px solid rgba(180, 180, 180, 0.6);
+    border-top-color: rgba(0, 0, 0, 0.6);
+    animation: spinner 0.6s linear infinite;
+}
+
 .thumbnail-panel {
     padding-top: 30px;
     width: 100px;

--- a/css/app.css
+++ b/css/app.css
@@ -290,6 +290,14 @@ span.sp-thumb-el {
     position: absolute;
 }
 
+.cursor_spinner {
+    cursor: wait;
+}
+
+.cursor_spinner .dim-arrows {
+    cursor: wait;
+}
+
 .plane-slider {
     bottom: 115px;
     top: 45px;

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -120,14 +120,16 @@ export default class DimensionSlider {
             this.player_info.forwards === forwards;
 
         // make history entry for stop
-        if (stop)
+        if (stop) {
             conf.addHistory({
                 prop: ['image_info', 'dimensions', this.dim],
                 old_val : this.last_player_start,
                 new_val:  conf.image_info.dimensions[this.dim],
                 type : "number"
             });
-        else this.last_player_start = conf.image_info.dimensions[this.dim];
+        } else {
+            this.last_player_start = conf.image_info.dimensions[this.dim];
+        }
 
         // send out a dimension change notification
         this.context.publish(

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -74,6 +74,8 @@ export const REGIONS_HISTORY_ENTRY = "REGIONS_HISTORY_ENTRY";
 export const REGIONS_HISTORY_ACTION = "REGIONS_HISTORY_ACTION";
 /** whenever we want to copy selected shape definitions */
 export const REGIONS_COPY_SHAPES = "REGIONS_COPY_SHAPES";
+/** Viewer notification that rendering is complete */
+export const RENDER_COMPLETE = "RENDER_COMPLETE";
 /** whenever the histogram range was updated */
 export const HISTOGRAM_RANGE_UPDATE = "HISTOGRAM_RANGE_UPDATE";
 /** whenever thumbnails are supposed to be updated */

--- a/src/events/events.js
+++ b/src/events/events.js
@@ -80,6 +80,8 @@ export const HISTOGRAM_RANGE_UPDATE = "HISTOGRAM_RANGE_UPDATE";
 export const THUMBNAILS_UPDATE = "THUMBNAILS_UPDATE";
 /** whenever the presently active image settings should be saved */
 export const SAVE_ACTIVE_IMAGE_SETTINGS = "SAVE_ACTIVE_IMAGE_SETTINGS";
+/** used to notify of a tileloaderror from openlayers viewer */
+export const TILE_LOAD_ERROR = "TILE_LOAD_ERROR";
 
 /**
  * Facilitates recurring event subscription

--- a/src/index-dev.html
+++ b/src/index-dev.html
@@ -35,12 +35,12 @@
                 'WEB_API_BASE': 'api/v0/',
                 'ROI_PAGE_SIZE': '500',
                 'MAX_PROJECTION_BYTES': "268435456", // 1024 * 1024 * 256
-                // 'IMAGES': "1"   // "4420" // "73537",
+                'IMAGES': "1929",      // "4420" // "73537",
                 //'ROI_COLOR_PALETTE': '["rgb(0,255,0)","blue","blue","pink","blue"],["rgb(255,255,255)"]',
                 'ENABLE_MIRROR': 'True',
-                'FY': 'true',
+                // 'FY': 'true',
                 //'SHOW_PALETTE_ONLY': true,
-                'DATASET': "1",
+                // 'DATASET': "1",
                 //'WELL': "1"
         };
         // check if we need to log in

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -22,6 +22,7 @@
 
     <div class="${context.useMDI && context.image_configs.size > 1 ?
                     'center-row1-mdi' : 'center-row1'}
+                ${image_config.is_movie_playing ? 'cursor_spinner' : ''}
                 ${image_config.image_info.dimensions.max_t > 1 ? 'show-tSlider' : ''}
                 ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}"
             drop.delegate="handleDrop($event)"
@@ -45,6 +46,7 @@
 
     <div class="${image_config.image_info.dimensions.max_t > 1 ?
                     'center-row2' : 'center-row2-hidden'}
+                ${image_config.is_movie_playing ? 'cursor_spinner' : ''}
                 ${image_config.image_info.dimensions.max_z > 1 ?
                     'show-zSlider' : ''}">
             <dimension-slider

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -39,7 +39,7 @@
         </dimension-slider>
 
         <div class="viewer">
-              <div id.bind="container" class="viewer-container"></div>
+              <div id.bind="container" class="viewer-container map_spinner"></div>
         </div>
     </div>
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -42,7 +42,7 @@ import {
     REGIONS_MODIFY_SHAPES, REGIONS_PROPERTY_CHANGED, REGIONS_SET_PROPERTY,
     REGIONS_SHOW_COMMENTS, REGIONS_STORED_SHAPES, REGIONS_STORE_SHAPES,
     VIEWER_IMAGE_SETTINGS, VIEWER_PROJECTIONS_SYNC, VIEWER_SET_SYNC_GROUP,
-    ENABLE_SHAPE_POPUP,
+    ENABLE_SHAPE_POPUP, TILE_LOAD_ERROR,
     EventSubscriber
 } from '../events/events';
 import Mirror from './viewer/controls/Mirror';
@@ -153,6 +153,8 @@ export default class Ol3Viewer extends EventSubscriber {
             (params={}) => this.saveCanvasData(params)],
         [VIEWER_SET_SYNC_GROUP,
             (params={}) => this.setSyncGroup(params)],
+        [TILE_LOAD_ERROR,
+            (params={}) => Ui.showModalMessage("Failed to load tiles.<br>Please try refreshing the page.", "OK")],
         [IMAGE_SETTINGS_REFRESH,
             (params={}) => this.refreshImageSettings(params)]];
 

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -34,7 +34,7 @@ import {
 } from '../utils/constants';
 import {
     IMAGE_CANVAS_DATA, IMAGE_DIMENSION_CHANGE, IMAGE_DIMENSION_PLAY,
-    IMAGE_INTENSITY_QUERYING, IMAGE_SETTINGS_CHANGE, IMAGE_SETTINGS_REFRESH,
+    IMAGE_SETTINGS_CHANGE, IMAGE_SETTINGS_REFRESH,
     IMAGE_VIEWER_CONTROLS_VISIBILITY, IMAGE_VIEWER_INTERACTION,
     IMAGE_VIEWER_RESIZE, IMAGE_VIEWPORT_CAPTURE, IMAGE_VIEWPORT_LINK,
     REGIONS_CHANGE_MODES, REGIONS_COPY_SHAPES, REGIONS_DRAW_SHAPE,
@@ -42,7 +42,7 @@ import {
     REGIONS_MODIFY_SHAPES, REGIONS_PROPERTY_CHANGED, REGIONS_SET_PROPERTY,
     REGIONS_SHOW_COMMENTS, REGIONS_STORED_SHAPES, REGIONS_STORE_SHAPES,
     VIEWER_IMAGE_SETTINGS, VIEWER_PROJECTIONS_SYNC, VIEWER_SET_SYNC_GROUP,
-    ENABLE_SHAPE_POPUP, TILE_LOAD_ERROR,
+    ENABLE_SHAPE_POPUP, TILE_LOAD_ERROR, RENDER_COMPLETE,
     EventSubscriber
 } from '../events/events';
 
@@ -115,7 +115,7 @@ export default class Ol3Viewer extends EventSubscriber {
             (params={}) => this.changeDimension(params)],
         [IMAGE_DIMENSION_PLAY,
             (params={}) => this.playDimension(params)],
-        ["RENDER_COMPLETE",
+        [RENDER_COMPLETE,
             (params={}) => this.handleRenderComplete(params)],
         [IMAGE_SETTINGS_CHANGE,
             (params={}) => this.changeImageSettings(params)],
@@ -1384,8 +1384,6 @@ export default class Ol3Viewer extends EventSubscriber {
             typeof params.dim !== 'string' ||
             (params.dim !== 'z' && params.dim !== 't')) return;
 
-        console.log("ol3-viewer playDimension()", params);
-
         // check explicit stop flag (we default to true if not there)
         if (typeof params.stop !== 'boolean') params.stop = true;
         let forwards = params.forwards;
@@ -1409,88 +1407,109 @@ export default class Ol3Viewer extends EventSubscriber {
         // bounds and present dimension index
         let dims = this.image_config.image_info.dimensions;
         let dim = params.dim;
-        let min_dim = 0;
         var max_dim = dims['max_' + dim]-1;
-        var pres_dim = dims[dim];
 
         if (max_dim === 0) return
-
-        // if already at end, play from start
-        if (forwards && pres_dim >= max_dim) {
-            dims[dim] = 0;
-        }
-        if (!forwards && pres_dim <= min_dim) {
-            dims[dim] = max_dim;
-        }
 
         this.player_info.dim = dim;
         this.player_info.forwards = forwards;
         this.player_info.delay = delay;
         this.image_config.is_movie_playing = true;
-        this.player_info.handle =
-            setTimeout(
-                () => {
-                    this.incrementDimension();
-                }, delay);
+        // start immediately
+        this.player_info.handle = setTimeout(() => {
+            this.player_info.waiting_on_delay = false;
+            this.incrementDimension(true);
+        }, 0);
     }
 
-    // the stop function
+    /**
+     * Stops dimension play
+     *
+     * @memberof Ol3Viewer
+     */
     stopPlay() {
-        console.log("ol3-viewer stopPlay()")
         if (this.player_info.handle !== null)
             clearTimeout(this.player_info.handle);
         this.player_info.dim = null;
         this.player_info.forwards = null;
         this.player_info.handle = null;
         this.image_config.is_movie_playing = false;
-        this.viewer.getRenderStatus(true);
     }
 
-    incrementDimension() {
+    /**
+     * Increment Z/T when playing movie
+     *
+     * @memberof Ol3Viewer
+     */
+    incrementDimension(starting) {
+        // If we're still waiting for planes to render or movie delay, abort...
+        if (this.player_info.waiting_on_render || this.player_info.waiting_on_delay) {
+            return;
+        }
+
         let dim = this.player_info.dim;
         let dims = this.image_config.image_info.dimensions;
         let forwards = this.player_info.forwards;
         var max_dim = dims['max_' + dim]-1;
         let min_dim = 0;
-        console.log("ol3-viewer incrementDimension()", {dim, dims, forwards, max_dim});
-        // try {
+
+        try {
             // keep handle backup in window in case of error
             window.interval_handle = this.player_info.handle;
 
-            // if we get an in progress status the dimension has not yet
-            // rendered and we return to wait for the next iteration
             let renderStatus = this.viewer.getRenderStatus();
-            if (renderStatus === RENDER_STATUS.IN_PROGRESS) return;
 
             // get present dim index and check if we have hit a bound
             // if so => abort play
             var pres_dim = dims[dim];
+            let next_dim = pres_dim + (forwards ? 1 : -1);
+            if (starting) {
+                // if already at end, play from start
+                if (forwards && pres_dim >= max_dim) {
+                    next_dim = 0;
+                }
+                if (!forwards && pres_dim <= min_dim) {
+                    next_dim = max_dim;
+                }
+            }
+
             if (renderStatus === RENDER_STATUS.ERROR ||
-                    (forwards && pres_dim >= max_dim) ||
-                    (!forwards && pres_dim <= min_dim)) {
+                    (forwards && next_dim > max_dim) ||
+                    (!forwards && next_dim < min_dim)) {
                         this.stopPlay(); return;}
 
-            // arrange for the render status to be watched
-            if (!this.viewer.watchRenderStatus(true))
-                this.viewer.getRenderStatus(true);
             // set the new dimension index
-            dims[dim] = pres_dim + (forwards ? 1 : -1);
+            dims[dim] = next_dim;
 
-            console.log("incrementDimension this.image_config.is_movie_playing", this.image_config.is_movie_playing);
+            // don't increment again while waiting on render or delay
+            this.player_info.waiting_on_render = true;
+            this.player_info.waiting_on_delay = true;
+
             if (this.image_config.is_movie_playing) {
                 let delay = this.player_info.delay || MOVIE_DELAY;
-                setTimeout(() => {
+                this.player_info.handle = setTimeout(() => {
+                    this.player_info.waiting_on_delay = false;
+
                     this.incrementDimension();
                 }, delay);
             }
-        // } catch(ignored) {
-        //     clearInterval(window.interval_handle);
-        // }
+        } catch(ignored) {
+            clearInterval(window.interval_handle);
+        }
     }
 
+    /**
+     * When rendering image plane is complete, and we're playing a movie, increment...
+     *
+     * @memberof Ol3Viewer
+     */
     handleRenderComplete(params={}) {
-        console.log("ol3viewer handleRenderComplete()")
+        // set status
+        this.player_info.waiting_on_render = false;
 
+        if (this.image_config.is_movie_playing) {
+            this.incrementDimension();
+        }
     }
 
     /**

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -1415,6 +1415,10 @@ export default class Ol3Viewer extends EventSubscriber {
         this.player_info.forwards = forwards;
         this.player_info.delay = delay;
         this.image_config.is_movie_playing = true;
+
+        // Don't want to show spinner while playing movie...
+        this.viewer.enableSpinner(false);
+
         // start immediately
         this.player_info.handle = setTimeout(() => {
             this.player_info.waiting_on_delay = false;
@@ -1434,6 +1438,7 @@ export default class Ol3Viewer extends EventSubscriber {
         this.player_info.forwards = null;
         this.player_info.handle = null;
         this.image_config.is_movie_playing = false;
+        this.viewer.enableSpinner(true);
     }
 
     /**

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -652,7 +652,7 @@ class Viewer extends OlObject {
         }
 
         // listen for any tile loading errors...
-        listen(
+        this.tileLoadErrorListener = listen(
             this.getImageLayer().getSource(), "tileloaderror",
             function(event) {
                 if (this.eventbus_) {
@@ -1806,6 +1806,9 @@ class Viewer extends OlObject {
             if (typeof(this.onViewRotationListener) !== 'undefined' &&
                 this.onViewRotationListener)
                     unlistenByKey(this.onViewRotationListener);
+            if (typeof(this.tileLoadErrorListener) !== 'undefined' &&
+                this.tileLoadErrorListener)
+                    unlistenByKey(this.tileLoadErrorListener);
 
             this.viewer_.dispose();
         }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -2322,7 +2322,6 @@ class Viewer extends OlObject {
     getViewParameters() {
         if (this.viewer_ === null || this.getImage() === null) return null;
         var viewProps = this.viewer_.getView().getProperties()
-        console.log(viewProps)
         return {
             "z": this.getDimensionIndex('z'),
             "t": this.getDimensionIndex('t'),

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -216,6 +216,13 @@ class Viewer extends OlObject {
         this.enable_shape_popup = true;
 
         /**
+         * this flag determines whether a spinner is shown when loading image data
+         * Defauls to true
+         * @type {boolean}
+         */
+        this.spinner_enabled = true;
+
+        /**
          * the 'viewer state', i.e. the controls and interactions that were added
          * the items in the map have the following layout
          * <pre>
@@ -2282,10 +2289,22 @@ class Viewer extends OlObject {
     }
 
     /**
+     * Sets the spinner_enabled flag
+     */
+    enableSpinner(enabled) {
+        this.spinner_enabled = enabled;
+        if (!enabled) {
+            this.hideSpinner();
+        }
+    }
+
+    /**
      * Shows a spinner indicating the map is loading data
      */
     showSpinner() {
-        this.viewer_.getTargetElement().classList.add('map_spinner');
+        if (this.spinner_enabled) {
+            this.viewer_.getTargetElement().classList.add('map_spinner');
+        }
     }
 
     /**

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,13 +651,11 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
-        // listen (once) for rendercomplete to remove the map_spinner
-        const renderCompleteListener = listen(
+        // listen for rendercomplete to remove the map_spinner
+        this.renderCompleteListener = listen(
             this.viewer_, "rendercomplete",
             function(event) {
-                this.viewer_.getTargetElement().classList.remove('map_spinner');
-                // stop listening
-                unlistenByKey(renderCompleteListener);
+                this.hideSpinner();
             }, this);
 
         // listen for any tile loading errors...
@@ -1818,7 +1816,9 @@ class Viewer extends OlObject {
             if (typeof(this.tileLoadErrorListener) !== 'undefined' &&
                 this.tileLoadErrorListener)
                     unlistenByKey(this.tileLoadErrorListener);
-
+            if (this.renderCompleteListener) {
+                unlistenByKey(this.renderCompleteListener);
+            }
             this.viewer_.dispose();
         }
 
@@ -2278,6 +2278,20 @@ class Viewer extends OlObject {
     }
 
     /**
+     * Shows a spinner indicating the map is loading data
+     */
+    showSpinner() {
+        this.viewer_.getTargetElement().classList.add('map_spinner');
+    }
+
+    /**
+     * Hides the spinner
+     */
+    hideSpinner() {
+        this.viewer_.getTargetElement().classList.remove('map_spinner');
+    }
+
+    /**
      * Triggers an explicit rerendering of the image (tile) layer
      *
      * @param {boolean} clearCache empties the tile cache if true
@@ -2301,6 +2315,7 @@ class Viewer extends OlObject {
             } else {
                 imageSource.cache_version_++;
             }
+            this.showSpinner();
             imageSource.changed();
         } catch(canHappen) {}
     }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,6 +651,15 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
+        // listen (once) for rendercomplete to remove the map_spinner
+        const renderCompleteListener = listen(
+            this.viewer_, "rendercomplete",
+            function(event) {
+                this.viewer_.getTargetElement().classList.remove('map_spinner');
+                // stop listening
+                unlistenByKey(renderCompleteListener);
+            }, this);
+
         // listen for any tile loading errors...
         this.tileLoadErrorListener = listen(
             this.getImageLayer().getSource(), "tileloaderror",

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -656,6 +656,9 @@ class Viewer extends OlObject {
             this.viewer_, "rendercomplete",
             function(event) {
                 this.hideSpinner();
+                if (this.eventbus_) {
+                    sendEventNotification(this, "RENDER_COMPLETE");
+                }
             }, this);
 
         // listen for any tile loading errors...

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -505,6 +505,7 @@ class Viewer extends OlObject {
             image: this.id_,
             width: dims['width'],
             height: dims['height'],
+            size_t: dims.t,
             plane: initialPlane,
             time: initialTime,
             channels: channels,

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -651,6 +651,15 @@ class Viewer extends OlObject {
             }.bind(this), 100)
         }
 
+        // listen for any tile loading errors...
+        listen(
+            this.getImageLayer().getSource(), "tileloaderror",
+            function(event) {
+                if (this.eventbus_) {
+                    sendEventNotification(this, "TILE_LOAD_ERROR");
+                }
+            }, this);
+
         // listens to resolution changes
         this.onViewResolutionListener =
         listen( // register a resolution handler for zoom display

--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -182,12 +182,13 @@ const OmeroImage = function(options) {
     /**
      * should we use tiled retrieval methods?
      * for now use them only for truly tiled/pyramidal sources
-     * and images that exceed {@link UNTILED_RETRIEVAL_LIMIT}
+     * and single-T images that exceed {@link UNTILED_RETRIEVAL_LIMIT}
+     * (Want to avoid async tile loading while movie is playing)
      * @type {boolean}
      * @private
      */
     this.use_tiled_retrieval_ = this.tiled_ ||
-        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT;
+        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT && this._time == 1;
 
     /**
      * for untiled retrieval the tile size equals the entire image extent

--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -109,6 +109,15 @@ const OmeroImage = function(options) {
         console.error("Image height must be a strictly positive integer");
 
     /**
+     * the image sizeT
+     * @type {number}
+     * @private
+     */
+    this.size_t_ = opts.size_t || 1;
+    if (typeof this.size_t_ !== 'number' || this.size_t_ <= 0)
+        console.error("Image sizeT must be a strictly positive integer");
+
+    /**
      * the plane (z) index
      * @type {number}
      * @private
@@ -188,8 +197,9 @@ const OmeroImage = function(options) {
      * @private
      */
     this.use_tiled_retrieval_ = this.tiled_ ||
-        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT && this._time == 1;
+        this.width_ * this.height_ > UNTILED_RETRIEVAL_LIMIT && this.size_t_ == 1;
 
+    console.log("this.use_tiled_retrieval_", this.use_tiled_retrieval_, this.size_t_);
     /**
      * for untiled retrieval the tile size equals the entire image extent
      * for tiled we use the default tile size


### PR DESCRIPTION
This replaces (builds on) #464 and #456 and also supports movie playing waiting on image loading.

These PRs are combined to avoid conflicts, since the functionality is all related. Also makes it easier to deploy.

 - Tile loading errors are reported with message (as already tested in #464)
 - A spinner is shown while tiles/planes are loaded (as already tested in #464)
 - For "large" movies (between 2k x 2k and 3k x 3k) load whole planes instead of tiles (not tested yet, see #456)
 - When playing a movie, we wait at least 250 millisecs (default delay between frames) but we wait longer if we are still waiting for the image to render from a previous update.

Questions:
 - When we are playing a movie, do we want to show a spinner? If the rate is limited by rendering speed, then the spinner will **always** be shown. Even if rendering is quite fast, we will still see the spinner a lot of the time.
 - Do we want to change the default delay between frames? 250 millisecs is quite short.
 - What criteria do we use for deciding to load tiles? (see discussion in comment below)

To test:
 - Movies should be rendered as a single plane, unless they are really BIG (over 3k * 3k)
 - Play movie, stop/start lots. Check that we don't get in a bad state. 
 - Movie should stop playing when it gets to the end. Clicking start again should start it from the beginning.