### PR TITLE
Z projection disabled tooltip

### DIFF
--- a/src/controls/dimension-slider.html
+++ b/src/controls/dimension-slider.html
@@ -37,7 +37,7 @@
         </span>
         <span class="dim-projection
                      ${getZProjectionDisabled(player_info.handle, player_info.forwards) ? 'disabled-color' : ''}"
-              title="${getZProjectionDisabled(player_info.handle, player_info.forwards) ? 'Projection disabled' :
+              title="${getZProjectionDisabled(player_info.handle, player_info.forwards) ? getZProjectionTooltip() :
                             image_config.image_info.projection === INTMAX ?
                                 'Turn off projection' : 'Turn on projection'}"
               css="${image_config.image_info.projection === INTMAX ?

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -527,6 +527,26 @@ export default class DimensionSlider {
         return (handle !== null && forwards || tiled || stack_size > proj_limit);
     }
 
+    getZProjectionTooltip(handle, forwards) {
+        let dims = this.image_config.image_info.dimensions;
+        let tiled = (dims.max_x * dims.max_y) > UNTILED_RETRIEVAL_LIMIT;
+        let bytes_per_pixel = Math.ceil(Math.log2(this.image_config.image_info.range[1]) / 8.0);
+        let size_c = this.image_config.image_info.channels.length;
+        let stack_size = dims.max_x * dims.max_y * dims.max_z * bytes_per_pixel * size_c;
+        let proj_limit = this.context.max_projection_bytes;
+
+        let tooltip = "Projection Disabled: ";
+        if (handle !== null && forwards) {
+            tooltip += " Movie playing";
+        } else if (tiled) {
+            tooltip += " Image is tiled"
+        } else if (stack_size > proj_limit) {
+            let numFmt = new Intl.NumberFormat();
+            tooltip += " Image stack bytes (" + numFmt.format(stack_size) + ") greater than " + numFmt.format(proj_limit);
+        }
+        return tooltip;
+    }
+
     /**
      * Any change in Z/T or projection will cause ROIs to reload if we are
      * paginating ROIs by Z/T plane.

--- a/src/controls/dimension-slider.js
+++ b/src/controls/dimension-slider.js
@@ -535,14 +535,14 @@ export default class DimensionSlider {
         let stack_size = dims.max_x * dims.max_y * dims.max_z * bytes_per_pixel * size_c;
         let proj_limit = this.context.max_projection_bytes;
 
+        let numFmt = new Intl.NumberFormat();
         let tooltip = "Projection Disabled: ";
         if (handle !== null && forwards) {
             tooltip += " Movie playing";
         } else if (tiled) {
-            tooltip += " Image is tiled"
+            tooltip += " Image sizeX x sizeY is greater than " + numFmt.format(UNTILED_RETRIEVAL_LIMIT);
         } else if (stack_size > proj_limit) {
-            let numFmt = new Intl.NumberFormat();
-            tooltip += " Image stack bytes (" + numFmt.format(stack_size) + ") greater than " + numFmt.format(proj_limit);
+            tooltip += " Image bytes (" + bytes_per_pixel + " bytes per pixel x sizeX x sizeY x sizeC = " + numFmt.format(stack_size) + ") is greater than " + numFmt.format(proj_limit);
         }
         return tooltip;
     }


### PR DESCRIPTION
See https://forum.image.sc/t/z-projections-disabled/95042/7

Discussion above shows that we don't give any feedback about why projection is disabled. Users can't tell if the max projection bytes config is being taken into account or if projection is disabled for some other reason.

This adds a useful tooltip to provide info on why projection is disabled (movie is playing or image is tiled or image bytes greater than projection:

![Screenshot 2024-04-18 at 12 22 11](https://github.com/ome/omero-iviewer/assets/900055/a0f59522-77a2-4497-b40a-5ffd419f352d)
