### PR TITLE
Img data error handling

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1365,6 +1365,10 @@ thumbnail-slider img {
     overflow-y: hidden;
 }
 
+.modal-dialog pre {
+    max-height: 200px;
+}
+
 .text-weight-bold {
    font-weight: 700;
  }

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from os.path import splitext
 from collections import defaultdict
 from struct import unpack
+import traceback
 
 from omeroweb.api.api_settings import API_MAX_LIMIT
 from omeroweb.decorators import login_required

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -499,19 +499,19 @@ def image_data(request, image_id, conn=None, **kwargs):
         # Add extra parameters with units data
         # Note ['pixel_size']['x'] will have size in MICROMETER
         px = image.getPrimaryPixels().getPhysicalSizeX()
-        if (px is not None):
+        if (px is not None and 'pixel_size' in rv):
             size = image.getPixelSizeX(True)
             value = format_pixel_size_with_units(size)
             rv['pixel_size']['unit_x'] = value[0]
             rv['pixel_size']['symbol_x'] = value[1]
         py = image.getPrimaryPixels().getPhysicalSizeY()
-        if (py is not None):
+        if (py is not None and 'pixel_size' in rv):
             size = image.getPixelSizeY(True)
             value = format_pixel_size_with_units(size)
             rv['pixel_size']['unit_y'] = value[0]
             rv['pixel_size']['symbol_y'] = value[1]
         pz = image.getPrimaryPixels().getPhysicalSizeZ()
-        if (pz is not None):
+        if (pz is not None and 'pixel_size' in rv):
             size = image.getPixelSizeZ(True)
             value = format_pixel_size_with_units(size)
             rv['pixel_size']['unit_z'] = value[0]
@@ -531,8 +531,8 @@ def image_data(request, image_id, conn=None, **kwargs):
             rv['families'].append(fam.getValue())
 
         return JsonResponse(rv)
-    except Exception as image_data_retrieval_exception:
-        return JsonResponse({'error': repr(image_data_retrieval_exception)})
+    except Exception:
+        return JsonResponse({'error': traceback.format_exc()})
 
 
 @login_required()

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -19,6 +19,7 @@
 import {noView} from 'aurelia-framework';
 import Misc from '../utils/misc';
 import Ui from '../utils/ui';
+var escapeHtml = require('escape-html')
 import {
     APP_TITLE, CHANNEL_SETTINGS_MODE, INITIAL_TYPES, IVIEWER,
     PROJECTION, REQUEST_PARAMS, WEBCLIENT, WEBGATEWAY
@@ -318,6 +319,13 @@ export default class ImageInfo {
                     this.image_id = response.id;
                 }
 
+                // validate response
+                // check for Exceptions and show error dialog.
+                const valid = this.validateImageInfo(response);
+                if (!valid) {
+                    return;
+                }
+
                 // read initial request params
                 this.initializeImageInfo(response, refresh);
                 // check for a parent id (if not well)
@@ -358,6 +366,39 @@ export default class ImageInfo {
                 Ui.showModalMessage(errMsg, 'OK');
             }
         });
+    }
+
+    /**
+     * Checks that the imgData JSON response is valid, no exceptions etc.
+     *
+     * @private
+     * @param {Object} response the response object
+     * @memberof ImageInfo
+     * @return {Boolean} True if data is valid. Also shows dialogs with errors
+     */
+    validateImageInfo(response) {
+
+        if (response.ConcurrencyException) {
+            Ui.showModalMessage(`<p>Image is not currently viewable</p>
+                <pre>ConcurrencyException</pre>
+                <small>A pyramid of zoom levels is not available. Generation may be in progress if this is enabled on your server.</small>`, "OK");
+            return false;
+        }
+
+        if (response.error || response.Exception) {
+            const msg = response.error || response.Exception;
+            Ui.showModalMessage(`<p>Error loading Image data</p>
+                <pre>${escapeHtml(msg)}</pre>`, "OK");
+            return false;
+        }
+
+        if (response.channels == undefined || response.channels.length === 0) {
+            Ui.showModalMessage(`<p>No channel data loaded</p>
+                <pre>${escapeHtml(JSON.stringify(response, null, 4))}</pre>`, "OK");
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Fixes #473 

This improves the error handling for loading image metadata.
Previously we only handled `404 Image not found`, but if any JSON data was returned, even with exceptions, then these were ignored and the viewer would silently fail.

I have handled the possible Errors etc that are reported by the python error handling at various stages, such as ConcurrencyException and other catch-all exceptions:

![Screenshot 2024-04-24 at 16 51 31](https://github.com/ome/omero-iviewer/assets/900055/598e4232-1097-41b9-87a4-e44be0c0fcf7)

![Screenshot 2024-04-24 at 16 52 33](https://github.com/ome/omero-iviewer/assets/900055/f1559422-2fbd-4b5b-9fdb-51d349521bbf)

To test, you need to generate or find broken images (or missing pyramids etc).

Most of the testing I've done has been by artificially adding errors at particular points in the python code.
