### PR TITLE
Query timestamps from all planes when C or Z dimensions are not filled

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -565,7 +565,15 @@ def delta_t_data(request, image_id, conn=None, **kwargs):
             # Remove restriction on c0 z0 to catch all timestamps
             params = omero.sys.ParametersI()
             params.addLong('pid', image.getPixelsId())
-            query = "from PlaneInfo as Info where pixels.id=:pid"
+            query = """
+                from PlaneInfo Info where Info.pixels.id=:pid
+                and Info.id in (
+                    select min(subInfo.id)
+                    from PlaneInfo subInfo
+                    where subInfo.pixels.id=:pid
+                    group by subInfo.theT
+                )
+            """
             info_list = conn.getQueryService().findAllByQuery(
                 query, params, conn.SERVICE_OPTS)
 

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -566,8 +566,7 @@ def delta_t_data(request, image_id, conn=None, **kwargs):
             params = omero.sys.ParametersI()
             params.addLong('pid', image.getPixelsId())
             query = """
-                from PlaneInfo Info where Info.pixels.id=:pid
-                and Info.id in (
+                from PlaneInfo Info where Info.id in (
                     select min(subInfo.id)
                     from PlaneInfo subInfo
                     where subInfo.pixels.id=:pid


### PR DESCRIPTION
Hello,
we found a bug on the timestamps display. We have data where the channel at index 0 was acquired only for the first and last frames.

Because the query to get timestamps was restricted to Z=0 and C=0, most timestamps were missing: we only got a list of two (instead of ~400).
-> Consequently, the last timepoint was assigned to the frame n°2, while all other frames had NaN values for timestamps.

To fix it, I added a condition that if the number of timestamps returned from the query is smaller than the number of frames, we do a second query. As such, it will impact performance (and results) only for images requiring it. 

Return one arbitrary plane per theT. It does not ensure that it's the lowest theC/theZ, but seems acceptable for those edge cases.
``` hql
FROM PlaneInfo Info WHERE Info.pixels.id = :pid 
AND Info.id IN (
    SELECT min(subInfo.id) FROM PlaneInfo subInfo
    WHERE subInfo.pixels.id = :pid GROUP BY subInfo.theT
)
```

(ensuring here that the minimum possible theC/theZ combination is returned increases the complexity of the query by a lot, because `min(theC)` is not always the same plane as `min(theZ)`)