### PR TITLE
Minimal add tags to ROI functionality

### DIFF
--- a/plugin/omero_iviewer/urls.py
+++ b/plugin/omero_iviewer/urls.py
@@ -39,6 +39,8 @@ urlpatterns = [
             name='omero_iviewer_get_intensity'),
     re_path(r'^shape_stats/?$', views.shape_stats,
             name='omero_iviewer_shape_stats'),
+    re_path(r'^link_annotations/?$', views.link_annotations,
+            name='omero_iviewer_link_annotations'),
     # optional z or t range e.g. iid/0-10/2-5/
     re_path(r'^rois_by_plane/(?P<image_id>[0-9]+)/'
             r'(?P<the_z>[0-9]+)(?:-(?P<z_end>[0-9]+))?/'

--- a/src/regions/regions-list.html
+++ b/src/regions/regions-list.html
@@ -64,6 +64,12 @@
                         </span>
                         <a href="#">Show Area/Length</a>
                     </li>
+                    <li click.delegate="showColumn('roi_tags')">
+                        <span class="show_roi_tags">
+                            ${active_column === 'roi_tags' ? '&#10003;' : '&nbsp;'}
+                        </span>
+                        <a href="#">Show ROI Tags</a>
+                    </li>
                 </ul>
             </div>
             <div class="regions-table-col roi-toggle">
@@ -100,6 +106,10 @@
                     Length (${regions_info.image_info.image_pixels_size.symbol_x ||
                             'px'})
                 </div>
+            <div class="regions-table-col"
+                show.bind="active_column === 'roi_tags'">
+                ROI Tags
+            </div>
         </div>
 
         <div class="disabled-color loading-text"
@@ -183,6 +193,17 @@
                              show.bind="active_column === 'measurements'"
                              title="${shape.Length && shape.Length > 0 ? shape.Length : ''}">
                                 ${shape.Length && shape.Length > 0 ? shape.Length : ''}
+                        </div>
+                        <div class="regions-table-col roi-tags"
+                             show.bind="active_column === 'roi_tags'">
+                            <input style="width: 40px" focus.trigger="loadRois(roi_id)" keyup.trigger="handleAddTag($event, roi_id)" placeholder="Add Tag ID" type="text"/>
+                            <span show.bind="roi_tags_loaded">
+                                <span if.bind="roi_tags[roi_id]">
+                                    <template repeat.for="t of roi_tags[roi_id]">
+                                        <div title="Tag: ${t.id}" style="border: solid #ddd 1px; background: #eee; border-radius: 5px; font-size:10px; padding: 2px; display:inline-block">${t.textValue}</div>
+                                    </template>
+                                </span>
+                            </span>
                         </div>
                     </div>
                 </template>


### PR DESCRIPTION
See https://forum.image.sc/t/tag-an-individual-roi-shape/105166/3

Initial investigation towards answering the question "how long would it take" to implement ROI Tagging in iviewer...

This is a BARE MINIMUM viable working prototype:

 - You need to save ROIs first, and you also need to have created Tags already and know the Tag IDs, as the most challenging part of a full solution is to load and select the Tags.
 - If you choose the `Show ROI Tags` column of the ROI table, it will load existing Tags on the ROIs - see screenshot. NB: only loads Tags for up to 500 ROIs just now. To support more we would probably need to batch request. 
 - If you mouse-over you can see the ID of each Tag in the tooltip. Otherwise you'll have to copy Tag IDs from the Tag page of webclient.
 - If you type a valid Tag ID you want to add in the input field and hit Enter, it will be added to the ROI and displayed.
 - No functionality for removing Tags yet, but wouldn't be hard to add.

<img width="383" alt="Screenshot 2024-11-21 at 12 40 49" src="https://github.com/user-attachments/assets/5eca6bb4-6b46-4b9d-8413-f84d79bc3e14">

This work took about 3 hours - maybe a bit more as it took me a while to remember how Aurelia framework works!