### PR TITLE
Use the release/v1 branch for the PyPA action publishing to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./plugin
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: plugin/dist
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/456