### PR TITLE
Fix where interpolate_pixels server config is read from

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -81,8 +81,9 @@ def index(request, iid=None, conn=None, **kwargs):
 
     # set interpolation default
     server_settings = request.session.get('server_settings', {})
-    params['INTERPOLATE'] = server_settings.get('interpolate_pixels', True)
+    viewer_settings = server_settings.get('viewer', {})
 
+    params['INTERPOLATE'] = viewer_settings.get('interpolate_pixels', True)
     # we add the (possibly prefixed) uris
     params['WEBGATEWAY'] = reverse('webgateway')
     params['WEBCLIENT'] = reverse('webindex')


### PR DESCRIPTION
I realized that iviewer was not able to read the `interpolate_pixels` configuration.

As it was read, `interpolate_pixels` should be part of the client settings
→ `omero.client.interpolate_pixels`

But if I print the server_settings after setting that property, it only appears under ["viewer"]["interpolate_pixels"] and has the default value `True`

However if I change the configuration to:
→ `omero.client.viewer.interpolate_pixels`  (as listed in the [config glossary](https://omero.readthedocs.io/en/stable/sysadmins/config.html#omero-client-viewer-interpolate-pixels))
then it reads the configuration properly.

So unless there was a way to read the configuration property, this is the fix to read the viewer `interpolate_pixels` from the server settings.