### PR TITLE
Fix roi link permissions

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -481,7 +481,8 @@ def roi_image_data(request, obj_type, obj_id, conn=None, **kwargs):
     """ Get image_data for image linked to ROI """
     image_id = None
     if obj_type == 'roi':
-        roi = conn.getQueryService().get('Roi', int(obj_id))
+        roi = conn.getQueryService().get('Roi', int(obj_id),
+                                         conn.SERVICE_OPTS)
         if roi:
             image_id = roi.image.id.val
     elif obj_type == 'shape':


### PR DESCRIPTION
Fixes issue reported at https://forum.image.sc/t/rois-link-in-omero-table-not-working/119676/4 where we failed to use a "cross-group" query, so a link to ROI in iviewer didn't work if the ROI wasn't in your default group.

To test:
 - As user-3 on merge-ci, login and then enter URL `/web/iviewer/?roi=3819` (that ROI is owned by user-3 but not in their default group)
 - Currently this fails with `Error` dialog in iviewer
 - This should find the correct image and open it in iviewer