### PR TITLE
Add keyboard handling for Left, Right, Up, Down Arrows to pan

### DIFF
--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -489,6 +489,10 @@ export default class Ol3Viewer extends EventSubscriber {
         // Add Key Handlers for panning the view with arrow keys
         const vv = this.viewer.viewer_;
         function panView(dx, dy) {
+            // Ignore Arrows if slider handle has focus
+            if (document.activeElement.classList.contains("ui-slider-handle")) {
+                return;
+            }
             let [cx, cy] = vv.getView().getCenter();
             let [minX, minY, maxX, maxY] = vv.getView().calculateExtent();
             vv.getView().animate({

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -485,6 +485,23 @@ export default class Ol3Viewer extends EventSubscriber {
                      container: this.container
                  });
         delete this.image_config.image_info.tmp_data;
+
+        // Add Key Handlers for panning the view with arrow keys
+        const vv = this.viewer.viewer_;
+        function panView(dx, dy) {
+            let [cx, cy] = vv.getView().getCenter();
+            let [minX, minY, maxX, maxY] = vv.getView().calculateExtent();
+            vv.getView().animate({
+              center: [cx + (maxX - minX) * dx, cy + (maxY - minY) * dy],
+              duration: 1000,
+            });
+        }
+        Ui.registerKeyHandlers(this.context,
+            [{key: 'ArrowLeft', func: () => panView(-0.9, 0), ctrl: false},
+             {key: 'ArrowRight', func: () => panView(0.9, 0), ctrl: false},
+             {key: 'ArrowUp', func: () => panView(0, 0.9), ctrl: false},
+             {key: 'ArrowDown', func: () => panView(0, -0.9), ctrl: false}],
+            "global", this);
         
         // hide controls for mdi when more than 1 image configs
         if (this.context.useMDI && this.context.image_configs.size > 1)


### PR DESCRIPTION
As discussed with Carlos, cc @pwalczysko 

To test:
 - Use Left, Right, Up, Down keys to pan viewport in iviewer
 - Check that we DON'T pan when using the Arrow Keys for other purposes, e.g:
   - Focus a Z/T slider and use Arrows to increment
   - When editing Comment text boxes etc
   - Any other usages you can think of??