### PR TITLE
Add grid overlay feature with configurable cell size and labels

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1643,3 +1643,330 @@ thumbnail-slider img {
     padding: 0px;
     font-weight: bold;
 }
+/* ========================================
+   Grid Control Panel
+   ======================================== */
+.grid-control-panel {
+    position: absolute;
+    top: 8px;
+    left: 240px;  /* Position to the right of zoom control */
+    z-index: 1000;
+    background-color: white;
+    border-radius: 2px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    padding: 2px;
+    min-width: 30px;
+}
+
+/* Grid Header - Button Row */
+.grid-header {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.grid-toggle-btn {
+    flex: 1;
+    background-color: white;
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: normal;
+    color: #333;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.grid-toggle-btn:hover {
+    background-color: #f0f0f0;
+    border-color: #007bff;
+    color: #007bff;
+}
+
+/* Collapse Button */
+.grid-collapse-btn {
+    background-color: white;
+    border: 1px solid #ccc;
+    padding: 4px 6px;
+    cursor: pointer;
+    border-radius: 4px;
+    font-size: 10px;
+    color: #666;
+    transition: all 0.2s ease;
+    min-width: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.grid-collapse-btn:hover {
+    background-color: #f0f0f0;
+    border-color: #007bff;
+    color: #007bff;
+}
+
+.grid-collapse-btn:active {
+    transform: scale(0.95);
+}
+
+.grid-controls {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #ddd;
+    animation: slideDown 0.2s ease;
+    min-width: 220px;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        max-height: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        max-height: 500px;
+        transform: translateY(0);
+    }
+}
+
+.grid-control-item {
+    margin-bottom: 12px;
+}
+
+.grid-control-item:last-child {
+    margin-bottom: 0;
+}
+
+.grid-control-item label {
+    display: block;
+    font-size: 11px;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 4px;
+}
+
+/* Grid Input Group */
+.grid-input-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.grid-number-input {
+    width: 70px;
+    padding: 4px 6px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    font-size: 11px;
+    text-align: center;
+    font-weight: bold;
+}
+
+.grid-number-input:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 2px rgba(0,123,255,0.1);
+}
+
+.grid-number-input::-webkit-inner-spin-button,
+.grid-number-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.grid-number-input {
+    -moz-appearance: textfield;
+}
+
+.grid-slider {
+    flex: 1;
+    height: 4px;
+    border-radius: 2px;
+    background: #ddd;
+    outline: none;
+    cursor: pointer;
+    -webkit-appearance: none;
+}
+
+.grid-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #007bff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.grid-slider::-webkit-slider-thumb:hover {
+    background: #0056b3;
+    transform: scale(1.1);
+}
+
+.grid-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #007bff;
+    cursor: pointer;
+    border: none;
+    transition: all 0.2s ease;
+}
+
+.grid-slider::-moz-range-thumb:hover {
+    background: #0056b3;
+    transform: scale(1.1);
+}
+
+.grid-size-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    color: #666;
+    margin-top: 2px;
+    padding: 0 5px;
+}
+
+.grid-size-labels span {
+    font-weight: bold;
+}
+
+.grid-control-item input[type="checkbox"] {
+    margin-right: 6px;
+    cursor: pointer;
+    width: 14px;
+    height: 14px;
+    vertical-align: middle;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .grid-control-panel {
+        min-width: 180px;
+        top: 5px;
+        left: 200px;
+    }
+    
+    .grid-toggle-btn {
+        font-size: 10px;
+        padding: 3px 6px;
+    }
+    
+    .grid-control-item label {
+        font-size: 10px;
+    }
+}
+/* ========================================
+   Disable Grid Interaction (Allow clicks through)
+   ======================================== */
+.grid-overlay-layer,
+.grid-label-layer {
+    pointer-events: none !important;
+}
+
+.grid-overlay-layer canvas,
+.grid-label-layer canvas {
+    pointer-events: none !important;
+}
+
+/* Ensure viewer remains interactive */
+.viewer {
+    pointer-events: auto;
+}
+
+.viewer-container {
+    pointer-events: auto;
+}
+
+/* Ensure control panel IS clickable */
+.grid-control-panel {
+    pointer-events: auto !important;
+}
+
+.grid-control-panel * {
+    pointer-events: auto !important;
+}
+
+.grid-preset-buttons {
+    display: flex;
+    gap: 5px;
+}
+
+.grid-preset-btn {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s;
+}
+
+.grid-preset-btn:hover {
+    background: #f0f0f0;
+}
+
+.grid-preset-btn.active {
+    background: #007bff;
+    color: white;
+    border-color: #007bff;
+}
+
+/* Grid Input Group */
+.grid-input-group {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.grid-number-input {
+    width: 80px;
+    padding: 5px 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 13px;
+    text-align: center;
+    font-weight: bold;
+}
+
+.grid-number-input:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 2px rgba(0,123,255,0.1);
+}
+
+/* Remove spinner arrows in number input */
+.grid-number-input::-webkit-inner-spin-button,
+.grid-number-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.grid-number-input {
+    -moz-appearance: textfield;
+}
+
+.grid-slider {
+    flex: 1;
+}
+
+/* Size labels below slider */
+.grid-size-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: #666;
+    margin-top: 2px;
+    padding: 0 5px;
+}
+
+.grid-size-labels span {
+    font-weight: bold;
+}

--- a/css/app.css
+++ b/css/app.css
@@ -1646,16 +1646,16 @@ thumbnail-slider img {
 /* ========================================
    Grid Control Panel
    ======================================== */
-.grid-control-panel {
-    position: absolute;
-    top: 8px;
-    left: 240px;  /* Position to the right of zoom control */
-    z-index: 1000;
-    background-color: white;
-    border-radius: 2px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-    padding: 2px;
-    min-width: 30px;
+.ol-grid {
+    top: .5em;
+    left: 14.5em;
+}
+/* Hide the grid collapse button by default, show it when the grid control is enabled */
+.ol-control .grid-collapse-btn {
+    display: none;
+}
+.ol-control.enabled .grid-collapse-btn {
+    display: block;
 }
 
 /* Grid Header - Button Row */
@@ -1686,20 +1686,6 @@ thumbnail-slider img {
 }
 
 /* Collapse Button */
-.grid-collapse-btn {
-    background-color: white;
-    border: 1px solid #ccc;
-    padding: 4px 6px;
-    cursor: pointer;
-    border-radius: 4px;
-    font-size: 10px;
-    color: #666;
-    transition: all 0.2s ease;
-    min-width: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
 
 .grid-collapse-btn:hover {
     background-color: #f0f0f0;
@@ -1707,16 +1693,33 @@ thumbnail-slider img {
     color: #007bff;
 }
 
-.grid-collapse-btn:active {
-    transform: scale(0.95);
+.ol-control .grid-collapse-btn {
+    width: 30px;
+    height: 30px;
+    font-size: 14px;
+    left: -1px;  /* collapse left border */
+    position: relative;
+}
+/* rotate to toggle up/down arrow */
+.panel-open .grid-collapse-btn {
+    transform: rotate(180deg);
 }
 
 .grid-controls {
-    margin-top: 8px;
-    padding-top: 8px;
-    border-top: 1px solid #ddd;
+    position: absolute;
+    top: 35px;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
     animation: slideDown 0.2s ease;
     min-width: 220px;
+    background-color: white;
+    display: none;
+}
+
+.panel-open.enabled .grid-controls {
+    display: block;
 }
 
 @keyframes slideDown {
@@ -1974,6 +1977,27 @@ thumbnail-slider img {
     display: flex;
     gap: 4px;
 }
+.grid-linewidth-group {
+    input[type="radio"] {
+        display: none;
+    }
+}
+.grid-linewidth-group label {
+    flex: 1;
+    padding: 4px 0;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background: white;
+    font-size: 11px;
+    text-align: center;
+    cursor: pointer;
+}
+.grid-linewidth-group label:has(input:checked) {
+    border-color: #007bff;
+    color: #007bff;
+    background: #eaf3ff;
+}
+
 .grid-lw-btn {
     flex: 1;
     padding: 4px 0;

--- a/css/app.css
+++ b/css/app.css
@@ -1658,13 +1658,6 @@ thumbnail-slider img {
     display: block;
 }
 
-/* Grid Header - Button Row */
-.grid-header {
-    display: flex;
-    gap: 4px;
-    align-items: center;
-}
-
 .grid-toggle-btn {
     flex: 1;
     background-color: white;
@@ -1826,19 +1819,6 @@ thumbnail-slider img {
     transform: scale(1.1);
 }
 
-.grid-size-labels {
-    display: flex;
-    justify-content: space-between;
-    font-size: 9px;
-    color: #666;
-    margin-top: 2px;
-    padding: 0 5px;
-}
-
-.grid-size-labels span {
-    font-weight: bold;
-}
-
 .grid-control-item input[type="checkbox"] {
     margin-right: 6px;
     cursor: pointer;
@@ -1960,19 +1940,6 @@ thumbnail-slider img {
     flex: 1;
 }
 
-/* Size labels below slider */
-.grid-size-labels {
-    display: flex;
-    justify-content: space-between;
-    font-size: 10px;
-    color: #666;
-    margin-top: 2px;
-    padding: 0 5px;
-}
-
-.grid-size-labels span {
-    font-weight: bold;
-}
 .grid-linewidth-group {
     display: flex;
     gap: 4px;
@@ -1993,21 +1960,6 @@ thumbnail-slider img {
     cursor: pointer;
 }
 .grid-linewidth-group label:has(input:checked) {
-    border-color: #007bff;
-    color: #007bff;
-    background: #eaf3ff;
-}
-
-.grid-lw-btn {
-    flex: 1;
-    padding: 4px 0;
-    border: 1px solid #ddd;
-    border-radius: 3px;
-    background: white;
-    font-size: 11px;
-    cursor: pointer;
-}
-.grid-lw-btn.active {
     border-color: #007bff;
     color: #007bff;
     background: #eaf3ff;

--- a/css/app.css
+++ b/css/app.css
@@ -1945,7 +1945,6 @@ thumbnail-slider img {
     gap: 4px;
 }
 .grid-linewidth-group input[type="radio"] {
-    input[type="radio"] {
         display: none;
     }
 }

--- a/css/app.css
+++ b/css/app.css
@@ -1970,3 +1970,21 @@ thumbnail-slider img {
 .grid-size-labels span {
     font-weight: bold;
 }
+.grid-linewidth-group {
+    display: flex;
+    gap: 4px;
+}
+.grid-lw-btn {
+    flex: 1;
+    padding: 4px 0;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background: white;
+    font-size: 11px;
+    cursor: pointer;
+}
+.grid-lw-btn.active {
+    border-color: #007bff;
+    color: #007bff;
+    background: #eaf3ff;
+}

--- a/css/app.css
+++ b/css/app.css
@@ -1946,7 +1946,6 @@ thumbnail-slider img {
 }
 .grid-linewidth-group input[type="radio"] {
         display: none;
-    }
 }
 .grid-linewidth-group label {
     flex: 1;

--- a/css/app.css
+++ b/css/app.css
@@ -1944,7 +1944,7 @@ thumbnail-slider img {
     display: flex;
     gap: 4px;
 }
-.grid-linewidth-group {
+.grid-linewidth-group input[type="radio"] {
     input[type="radio"] {
         display: none;
     }

--- a/css/app.css
+++ b/css/app.css
@@ -1945,7 +1945,7 @@ thumbnail-slider img {
     gap: 4px;
 }
 .grid-linewidth-group input[type="radio"] {
-        display: none;
+    display: none;
 }
 .grid-linewidth-group label {
     flex: 1;

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -94,7 +94,7 @@ export default class ImageConfig extends History {
      * @memberof ImageConfig
      * @type {Object}
      */
-    size = {width: '435px', height: '435px'};
+    size = {width: '500px', height: '500px'};
 
     /**
      * show histogram flag

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -40,23 +40,62 @@
         </dimension-slider>
 
         <div class="viewer">
+              <!-- Grid Control Panel -->
+              <div class="grid-control-panel" if.bind="gridOverlay">
+                  <div class="grid-header">
+                      <button class="grid-toggle-btn" 
+                              click.delegate="toggleGrid()"
+                              title="Show/Hide Grid">
+                          ${gridEnabled ? '✓ ' : ''}📐 Grid
+                      </button>
+                      
+                      <button class="grid-collapse-btn" 
+                              if.bind="gridEnabled"
+                              click.delegate="toggleGridPanel()"
+                              title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
+                          ${gridPanelExpanded ? '▼' : '▲'}
+                      </button>
+                  </div>
+                  
+                  <div class="grid-controls" 
+                       if.bind="gridEnabled && gridPanelExpanded">
+                      <div class="grid-control-item">
+                          <label>Cell Size (px)</label>
+                          <div class="grid-input-group">
+                              <input type="number" 
+                                     value.bind="gridCellSize" 
+                                     min="5000" 
+                                     max="10000" 
+                                     step="500"
+                                     change.delegate="updateGridCellSize()"
+                                     class="grid-number-input">
+                              <input type="range" 
+                                     value.bind="gridCellSize" 
+                                     min="5000" 
+                                     max="10000" 
+                                     step="500"
+                                     change.delegate="updateGridCellSize()"
+                                     class="grid-slider">
+                          </div>
+                          <div class="grid-size-labels">
+                              <span>Medium</span>
+                              <span>Large</span>
+                              <span>Very Large</span>
+                          </div>
+                      </div>
+                      
+                      <div class="grid-control-item">
+                          <label>
+                              <input type="checkbox" 
+                                     checked.bind="gridShowLabels"
+                                     change.delegate="toggleGridLabels()">
+                              Show Labels (A1, B2...)
+                          </label>
+                      </div>
+                  </div>
+              </div>
+              
               <div id.bind="container" class="viewer-container map_spinner"></div>
         </div>
-    </div>
-
-    <div class="${image_config.image_info.dimensions.max_t > 1 ?
-                    'center-row2' : 'center-row2-hidden'}
-                ${image_config.is_movie_playing ? 'cursor_spinner' : ''}
-                ${image_config.image_info.dimensions.max_z > 1 ?
-                    'show-zSlider' : ''}">
-            <dimension-slider
-                if.bind="image_config.image_info.dimensions.max_t > 1"
-                image_config.bind="image_config"
-                dim="t"
-                player_info.bind="player_info"
-                class="time-slider"
-            >
-            </dimension-slider>
-    </div>
     <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>
 </template>

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -27,8 +27,8 @@
                 ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}"
             drop.delegate="handleDrop($event)"
             dragover.delegate="handleDragover($event)"
-            dragleave.delegate="handleDragleave($event)"
-            >
+            dragleave.delegate="handleDragleave($event)">
+
         <dimension-slider
             if.bind="image_config.image_info.dimensions.max_z > 1"
             image_config.bind="image_config"
@@ -40,62 +40,81 @@
         </dimension-slider>
 
         <div class="viewer">
-              <!-- Grid Control Panel -->
-              <div class="grid-control-panel" if.bind="gridOverlay">
-                  <div class="grid-header">
-                      <button class="grid-toggle-btn" 
-                              click.delegate="toggleGrid()"
-                              title="Show/Hide Grid">
-                          ${gridEnabled ? '✓ ' : ''}📐 Grid
-                      </button>
-                      
-                      <button class="grid-collapse-btn" 
-                              if.bind="gridEnabled"
-                              click.delegate="toggleGridPanel()"
-                              title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
-                          ${gridPanelExpanded ? '▼' : '▲'}
-                      </button>
-                  </div>
-                  
-                  <div class="grid-controls" 
-                       if.bind="gridEnabled && gridPanelExpanded">
-                      <div class="grid-control-item">
-                          <label>Cell Size (px)</label>
-                          <div class="grid-input-group">
-                              <input type="number" 
-                                     value.bind="gridCellSize" 
-                                     min="5000" 
-                                     max="10000" 
-                                     step="500"
-                                     change.delegate="updateGridCellSize()"
-                                     class="grid-number-input">
-                              <input type="range" 
-                                     value.bind="gridCellSize" 
-                                     min="5000" 
-                                     max="10000" 
-                                     step="500"
-                                     change.delegate="updateGridCellSize()"
-                                     class="grid-slider">
-                          </div>
-                          <div class="grid-size-labels">
-                              <span>Medium</span>
-                              <span>Large</span>
-                              <span>Very Large</span>
-                          </div>
-                      </div>
-                      
-                      <div class="grid-control-item">
-                          <label>
-                              <input type="checkbox" 
-                                     checked.bind="gridShowLabels"
-                                     change.delegate="toggleGridLabels()">
-                              Show Labels (A1, B2...)
-                          </label>
-                      </div>
-                  </div>
-              </div>
-              
-              <div id.bind="container" class="viewer-container map_spinner"></div>
+
+            <!-- Grid Control Panel -->
+            <div class="grid-control-panel" if.bind="gridOverlay">
+
+                <div class="grid-header">
+                    <button class="grid-toggle-btn ${gridEnabled ? 'active' : ''}"
+                            click.delegate="toggleGrid()"
+                            title="${gridEnabled ? 'Hide Grid' : 'Show Grid'}"
+                            style="width: 24px; height: 24px; padding: 1px; display: flex; align-items: center; justify-content: center; background: transparent; border: 1px solid #ccc; cursor: pointer;">
+                        <svg class="grid-icon" viewBox="0 0 16 16" fill="none"
+                                stroke="currentColor" stroke-width="1.5" aria-hidden="true"
+                                style="width: 100%; height: 100%; display: block;">
+                            <line x1="5.33"  y1="0"   x2="5.33"  y2="16"/>
+                            <line x1="10.66" y1="0"   x2="10.66" y2="16"/>
+                            <line x1="0"     y1="5.33"  x2="16"  y2="5.33"/>
+                            <line x1="0"     y1="10.66" x2="16"  y2="10.66"/>
+                        </svg>
+                    </button>
+
+                    <button class="grid-collapse-btn"
+                            if.bind="gridEnabled"
+                            click.delegate="toggleGridPanel()"
+                            title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
+                        ${gridPanelExpanded ? '▼' : '▲'}
+                    </button>
+                </div>
+
+                <div class="grid-controls"
+                     if.bind="gridEnabled && gridPanelExpanded">
+
+                    <div class="grid-control-item">
+                        <label>Cell Size (px)</label>
+                        <div class="grid-input-group">
+                            <input type="number"
+                                   value.bind="gridCellSize"
+                                   min="5000" max="10000" step="500"
+                                   change.delegate="updateGridCellSize()"
+                                   class="grid-number-input">
+                            <input type="range"
+                                   value.bind="gridCellSize"
+                                   min="5000" max="10000" step="500"
+                                   change.delegate="updateGridCellSize()"
+                                   class="grid-slider">
+                        </div>
+                    </div>
+
+                    <div class="grid-control-item">
+                        <label>Line Width</label>
+                        <div class="grid-linewidth-group">
+                            <button class="grid-lw-btn ${gridLineWidth == 1 ? 'active' : ''}"
+                                    click.delegate="setGridLineWidth(1)">1 px</button>
+                            <button class="grid-lw-btn ${gridLineWidth == 2 ? 'active' : ''}"
+                                    click.delegate="setGridLineWidth(2)">2 px</button>
+                            <button class="grid-lw-btn ${gridLineWidth == 5 ? 'active' : ''}"
+                                    click.delegate="setGridLineWidth(5)">5 px</button>
+                        </div>
+                    </div>
+
+                    <div class="grid-control-item">
+                        <label>
+                            <input type="checkbox"
+                                   checked.bind="gridShowLabels"
+                                   change.delegate="toggleGridLabels()">
+                            Show Labels (A1, B2...)
+                        </label>
+                    </div>
+
+                </div>
+            </div>
+
+            <div id.bind="container" class="viewer-container map_spinner"></div>
+
         </div>
-    <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>
+
+        <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>
+
+    </div>
 </template>

--- a/src/viewers/ol3-viewer.html
+++ b/src/viewers/ol3-viewer.html
@@ -27,8 +27,8 @@
                 ${image_config.image_info.dimensions.max_z > 1 ? 'show-zSlider' : ''}"
             drop.delegate="handleDrop($event)"
             dragover.delegate="handleDragover($event)"
-            dragleave.delegate="handleDragleave($event)">
-
+            dragleave.delegate="handleDragleave($event)"
+            >
         <dimension-slider
             if.bind="image_config.image_info.dimensions.max_z > 1"
             image_config.bind="image_config"
@@ -40,81 +40,23 @@
         </dimension-slider>
 
         <div class="viewer">
-
-            <!-- Grid Control Panel -->
-            <div class="grid-control-panel" if.bind="gridOverlay">
-
-                <div class="grid-header">
-                    <button class="grid-toggle-btn ${gridEnabled ? 'active' : ''}"
-                            click.delegate="toggleGrid()"
-                            title="${gridEnabled ? 'Hide Grid' : 'Show Grid'}"
-                            style="width: 24px; height: 24px; padding: 1px; display: flex; align-items: center; justify-content: center; background: transparent; border: 1px solid #ccc; cursor: pointer;">
-                        <svg class="grid-icon" viewBox="0 0 16 16" fill="none"
-                                stroke="currentColor" stroke-width="1.5" aria-hidden="true"
-                                style="width: 100%; height: 100%; display: block;">
-                            <line x1="5.33"  y1="0"   x2="5.33"  y2="16"/>
-                            <line x1="10.66" y1="0"   x2="10.66" y2="16"/>
-                            <line x1="0"     y1="5.33"  x2="16"  y2="5.33"/>
-                            <line x1="0"     y1="10.66" x2="16"  y2="10.66"/>
-                        </svg>
-                    </button>
-
-                    <button class="grid-collapse-btn"
-                            if.bind="gridEnabled"
-                            click.delegate="toggleGridPanel()"
-                            title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
-                        ${gridPanelExpanded ? '▼' : '▲'}
-                    </button>
-                </div>
-
-                <div class="grid-controls"
-                     if.bind="gridEnabled && gridPanelExpanded">
-
-                    <div class="grid-control-item">
-                        <label>Cell Size (px)</label>
-                        <div class="grid-input-group">
-                            <input type="number"
-                                   value.bind="gridCellSize"
-                                   min="5000" max="10000" step="500"
-                                   change.delegate="updateGridCellSize()"
-                                   class="grid-number-input">
-                            <input type="range"
-                                   value.bind="gridCellSize"
-                                   min="5000" max="10000" step="500"
-                                   change.delegate="updateGridCellSize()"
-                                   class="grid-slider">
-                        </div>
-                    </div>
-
-                    <div class="grid-control-item">
-                        <label>Line Width</label>
-                        <div class="grid-linewidth-group">
-                            <button class="grid-lw-btn ${gridLineWidth == 1 ? 'active' : ''}"
-                                    click.delegate="setGridLineWidth(1)">1 px</button>
-                            <button class="grid-lw-btn ${gridLineWidth == 2 ? 'active' : ''}"
-                                    click.delegate="setGridLineWidth(2)">2 px</button>
-                            <button class="grid-lw-btn ${gridLineWidth == 5 ? 'active' : ''}"
-                                    click.delegate="setGridLineWidth(5)">5 px</button>
-                        </div>
-                    </div>
-
-                    <div class="grid-control-item">
-                        <label>
-                            <input type="checkbox"
-                                   checked.bind="gridShowLabels"
-                                   change.delegate="toggleGridLabels()">
-                            Show Labels (A1, B2...)
-                        </label>
-                    </div>
-
-                </div>
-            </div>
-
-            <div id.bind="container" class="viewer-container map_spinner"></div>
-
+              <div id.bind="container" class="viewer-container map_spinner"></div>
         </div>
-
-        <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>
-
     </div>
+
+    <div class="${image_config.image_info.dimensions.max_t > 1 ?
+                    'center-row2' : 'center-row2-hidden'}
+                ${image_config.is_movie_playing ? 'cursor_spinner' : ''}
+                ${image_config.image_info.dimensions.max_z > 1 ?
+                    'show-zSlider' : ''}">
+            <dimension-slider
+                if.bind="image_config.image_info.dimensions.max_t > 1"
+                image_config.bind="image_config"
+                dim="t"
+                player_info.bind="player_info"
+                class="time-slider"
+            >
+            </dimension-slider>
+    </div>
+    <viewer-context-menu image_config.bind="image_config"></viewer-context-menu>
 </template>

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -23,6 +23,7 @@ import {Converters} from '../utils/converters';
 import Ui from '../utils/ui';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import Viewer from './viewer/Viewer';
+import {GridOverlay} from './viewer/grid-overlay';
 import Ol3ViewerLinkedEvents from './ol3-viewer-linked-events';
 import * as FileSaver from '../../node_modules/file-saver';
 import {draggable} from 'jquery-ui/ui/widgets/draggable';
@@ -76,6 +77,33 @@ export default class Ol3Viewer extends EventSubscriber {
      */
     image_info_ready_observer = null;
 
+    /**
+     * Set cell size to preset value
+     * @memberof Ol3Viewer
+     */
+    setCellSize(size) {
+        this.gridCellSize = size;
+        this.updateGridCellSize();
+    }
+    
+    /**
+     * grid overlay instance
+     * @memberof Ol3Viewer
+     * @type {GridOverlay}
+     */
+    gridOverlay = null;
+    gridEnabled = false;
+    gridLineWidth = 5;
+    gridCellSize = 5000;
+    gridShowLabels = true;
+    /**
+     * Toggle grid settings panel visibility
+     * @memberof Ol3Viewer
+     */
+    toggleGridPanel() {
+        this.gridPanelExpanded = !this.gridPanelExpanded;
+        console.log('Grid panel expanded:', this.gridPanelExpanded);
+    }    
     /**
      * watches for selection changes
      * @memberof Ol3Viewer
@@ -404,6 +432,14 @@ export default class Ol3Viewer extends EventSubscriber {
                             () => this.storeShapes(
                                 {"config_id": this.image_config.id}));
                 });
+
+        // Inicializar grid overlay
+        setTimeout(() => {
+            if (this.viewer && this.viewer.viewer_) {
+                this.gridOverlay = new GridOverlay(this.viewer);
+                console.log('GridOverlay inicializado');
+            }
+        }, 1500);
     }
 
     /**
@@ -1761,4 +1797,59 @@ export default class Ol3Viewer extends EventSubscriber {
         // We don't use dragenter/leave events as they are too fickle
         $(".viewer-mdi").removeClass("drag_enter");
     }
+    /**
+     * Toggle grid overlay
+     * @memberof Ol3Viewer
+     */
+    toggleGrid() {
+        if (!this.gridOverlay && this.viewer && this.viewer.viewer_) {
+            this.gridOverlay = new GridOverlay(this.viewer);
+            console.log('GridOverlay initialized on demand');
+        }
+        
+        if (this.gridOverlay) {
+            if (!this.gridOverlay.isEnabled()) {
+                // Show grid with configured cell size
+                this.gridOverlay.showGrid(5, this.gridCellSize, this.gridShowLabels);
+            } else {
+                // Hide grid
+                this.gridOverlay.hideGrid();
+            }
+            this.gridEnabled = this.gridOverlay.isEnabled();
+        }
+    }
+        /**
+         * Update grid line width
+         * @memberof Ol3Viewer
+         */
+        updateGridLineWidth() {
+            if (this.gridOverlay && this.gridEnabled) {
+                this.gridOverlay.updateLineWidth(parseInt(this.gridLineWidth));
+            }
+        }
+
+        /**
+         * Update grid cell size
+         * @memberof Ol3Viewer
+         */
+        updateGridCellSize() {
+        if (this.gridOverlay && this.gridEnabled) {
+            // Ensure value is within range
+            if (this.gridCellSize < 5000) this.gridCellSize = 5000;
+            if (this.gridCellSize > 10000) this.gridCellSize = 10000;
+            
+            // Update grid with new size
+            this.gridOverlay.updateCellSize(parseInt(this.gridCellSize));
+            }
+        }
+
+        /**
+         * Toggle grid labels
+         * @memberof Ol3Viewer
+         */
+        toggleGridLabels() {
+            if (this.gridOverlay && this.gridEnabled) {
+                this.gridOverlay.toggleLabels();
+            }
+        }
 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -393,6 +393,9 @@ export default class Ol3Viewer extends EventSubscriber {
             this.getContainer().find('.ol-control').on(
                 'mousedown',
                 () => this.context.selectConfig(this.image_config.id))
+            // Started grid overlay
+            this.gridOverlay = new GridOverlay(this.viewer);
+            console.log('GridOverlay Started');
         };
         // listen via the observer for image ready changes
         this.image_info_ready_observer =
@@ -432,14 +435,6 @@ export default class Ol3Viewer extends EventSubscriber {
                             () => this.storeShapes(
                                 {"config_id": this.image_config.id}));
                 });
-
-        // Inicializar grid overlay
-        setTimeout(() => {
-            if (this.viewer && this.viewer.viewer_) {
-                this.gridOverlay = new GridOverlay(this.viewer);
-                console.log('GridOverlay inicializado');
-            }
-        }, 1500);
     }
 
     /**
@@ -1810,7 +1805,7 @@ export default class Ol3Viewer extends EventSubscriber {
         if (this.gridOverlay) {
             if (!this.gridOverlay.isEnabled()) {
                 // Show grid with configured cell size
-                this.gridOverlay.showGrid(5, this.gridCellSize, this.gridShowLabels);
+                this.gridOverlay.showGrid(this.gridCellSize, this.gridShowLabels);
             } else {
                 // Hide grid
                 this.gridOverlay.hideGrid();
@@ -1818,38 +1813,33 @@ export default class Ol3Viewer extends EventSubscriber {
             this.gridEnabled = this.gridOverlay.isEnabled();
         }
     }
-        /**
-         * Update grid line width
-         * @memberof Ol3Viewer
-         */
-        updateGridLineWidth() {
-            if (this.gridOverlay && this.gridEnabled) {
-                this.gridOverlay.updateLineWidth(parseInt(this.gridLineWidth));
-            }
-        }
-
-        /**
-         * Update grid cell size
-         * @memberof Ol3Viewer
-         */
-        updateGridCellSize() {
+    /**
+     * Update grid line width
+     * @memberof Ol3Viewer
+     */
+    updateGridLineWidth() {
         if (this.gridOverlay && this.gridEnabled) {
-            // Ensure value is within range
+            this.gridOverlay.updateLineWidth(parseInt(this.gridLineWidth));
+        }
+    }
+    /**
+     * Update grid cell size
+     * @memberof Ol3Viewer
+     */
+    updateGridCellSize() {
+        if (this.gridOverlay && this.gridEnabled) {
             if (this.gridCellSize < 5000) this.gridCellSize = 5000;
             if (this.gridCellSize > 10000) this.gridCellSize = 10000;
-            
-            // Update grid with new size
             this.gridOverlay.updateCellSize(parseInt(this.gridCellSize));
-            }
         }
-
-        /**
-         * Toggle grid labels
-         * @memberof Ol3Viewer
-         */
-        toggleGridLabels() {
-            if (this.gridOverlay && this.gridEnabled) {
-                this.gridOverlay.toggleLabels();
-            }
+    }
+    /**
+     * Toggle grid labels
+     * @memberof Ol3Viewer
+     */
+    toggleGridLabels() {
+        if (this.gridOverlay && this.gridEnabled) {
+            this.gridOverlay.toggleLabels();
         }
+    }
 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -93,9 +93,10 @@ export default class Ol3Viewer extends EventSubscriber {
      */
     gridOverlay = null;
     gridEnabled = false;
-    gridLineWidth = 5;
+    gridLineWidth = 2;
     gridCellSize = 5000;
     gridShowLabels = true;
+    gridPanelExpanded = false;
     /**
      * Toggle grid settings panel visibility
      * @memberof Ol3Viewer
@@ -387,6 +388,13 @@ export default class Ol3Viewer extends EventSubscriber {
                             if (newValue) {
                                 this.initRegions();
                                 delete this.image_config.regions_info.tmp_data;
+                                // Re-align the grid with the layers of recreated regions
+                                if (this.gridOverlay && this.gridOverlay.isEnabled()) {
+                                    this.gridOverlay.showGrid(
+                                        parseInt(this.gridLineWidth, 10),
+                                        parseInt(this.gridCellSize, 10),
+                                        this.gridShowLabels);
+                                }
                             }
                     });
             // mdi needs to switch image config when using controls
@@ -1805,7 +1813,7 @@ export default class Ol3Viewer extends EventSubscriber {
         if (this.gridOverlay) {
             if (!this.gridOverlay.isEnabled()) {
                 // Show grid with configured cell size
-                this.gridOverlay.showGrid(this.gridCellSize, this.gridShowLabels);
+                this.gridOverlay.showGrid(this.gridLineWidth, this.gridCellSize, this.gridShowLabels);
             } else {
                 // Hide grid
                 this.gridOverlay.hideGrid();
@@ -1841,5 +1849,9 @@ export default class Ol3Viewer extends EventSubscriber {
         if (this.gridOverlay && this.gridEnabled) {
             this.gridOverlay.toggleLabels();
         }
+    }
+    setGridLineWidth(width) {
+        this.gridLineWidth = width;
+        this.updateGridLineWidth();
     }
 }

--- a/src/viewers/ol3-viewer.js
+++ b/src/viewers/ol3-viewer.js
@@ -23,7 +23,6 @@ import {Converters} from '../utils/converters';
 import Ui from '../utils/ui';
 import {inject, customElement, bindable, BindingEngine} from 'aurelia-framework';
 import Viewer from './viewer/Viewer';
-import {GridOverlay} from './viewer/grid-overlay';
 import Ol3ViewerLinkedEvents from './ol3-viewer-linked-events';
 import * as FileSaver from '../../node_modules/file-saver';
 import {draggable} from 'jquery-ui/ui/widgets/draggable';
@@ -77,34 +76,6 @@ export default class Ol3Viewer extends EventSubscriber {
      */
     image_info_ready_observer = null;
 
-    /**
-     * Set cell size to preset value
-     * @memberof Ol3Viewer
-     */
-    setCellSize(size) {
-        this.gridCellSize = size;
-        this.updateGridCellSize();
-    }
-    
-    /**
-     * grid overlay instance
-     * @memberof Ol3Viewer
-     * @type {GridOverlay}
-     */
-    gridOverlay = null;
-    gridEnabled = false;
-    gridLineWidth = 2;
-    gridCellSize = 5000;
-    gridShowLabels = true;
-    gridPanelExpanded = false;
-    /**
-     * Toggle grid settings panel visibility
-     * @memberof Ol3Viewer
-     */
-    toggleGridPanel() {
-        this.gridPanelExpanded = !this.gridPanelExpanded;
-        console.log('Grid panel expanded:', this.gridPanelExpanded);
-    }    
     /**
      * watches for selection changes
      * @memberof Ol3Viewer
@@ -388,22 +359,12 @@ export default class Ol3Viewer extends EventSubscriber {
                             if (newValue) {
                                 this.initRegions();
                                 delete this.image_config.regions_info.tmp_data;
-                                // Re-align the grid with the layers of recreated regions
-                                if (this.gridOverlay && this.gridOverlay.isEnabled()) {
-                                    this.gridOverlay.showGrid(
-                                        parseInt(this.gridLineWidth, 10),
-                                        parseInt(this.gridCellSize, 10),
-                                        this.gridShowLabels);
-                                }
                             }
                     });
             // mdi needs to switch image config when using controls
             this.getContainer().find('.ol-control').on(
                 'mousedown',
                 () => this.context.selectConfig(this.image_config.id))
-            // Started grid overlay
-            this.gridOverlay = new GridOverlay(this.viewer);
-            console.log('GridOverlay Started');
         };
         // listen via the observer for image ready changes
         this.image_info_ready_observer =
@@ -1799,59 +1760,5 @@ export default class Ol3Viewer extends EventSubscriber {
     handleDragleave(event) {
         // We don't use dragenter/leave events as they are too fickle
         $(".viewer-mdi").removeClass("drag_enter");
-    }
-    /**
-     * Toggle grid overlay
-     * @memberof Ol3Viewer
-     */
-    toggleGrid() {
-        if (!this.gridOverlay && this.viewer && this.viewer.viewer_) {
-            this.gridOverlay = new GridOverlay(this.viewer);
-            console.log('GridOverlay initialized on demand');
-        }
-        
-        if (this.gridOverlay) {
-            if (!this.gridOverlay.isEnabled()) {
-                // Show grid with configured cell size
-                this.gridOverlay.showGrid(this.gridLineWidth, this.gridCellSize, this.gridShowLabels);
-            } else {
-                // Hide grid
-                this.gridOverlay.hideGrid();
-            }
-            this.gridEnabled = this.gridOverlay.isEnabled();
-        }
-    }
-    /**
-     * Update grid line width
-     * @memberof Ol3Viewer
-     */
-    updateGridLineWidth() {
-        if (this.gridOverlay && this.gridEnabled) {
-            this.gridOverlay.updateLineWidth(parseInt(this.gridLineWidth));
-        }
-    }
-    /**
-     * Update grid cell size
-     * @memberof Ol3Viewer
-     */
-    updateGridCellSize() {
-        if (this.gridOverlay && this.gridEnabled) {
-            if (this.gridCellSize < 5000) this.gridCellSize = 5000;
-            if (this.gridCellSize > 10000) this.gridCellSize = 10000;
-            this.gridOverlay.updateCellSize(parseInt(this.gridCellSize));
-        }
-    }
-    /**
-     * Toggle grid labels
-     * @memberof Ol3Viewer
-     */
-    toggleGridLabels() {
-        if (this.gridOverlay && this.gridEnabled) {
-            this.gridOverlay.toggleLabels();
-        }
-    }
-    setGridLineWidth(width) {
-        this.gridLineWidth = width;
-        this.updateGridLineWidth();
     }
 }

--- a/src/viewers/viewer/Viewer.js
+++ b/src/viewers/viewer/Viewer.js
@@ -67,6 +67,7 @@ import OmeroImage from './source/Image';
 import Regions from './source/Regions';
 import Mask from './geom/Mask';
 import Mirror from './controls/Mirror';
+import Grid from './controls/Grid';
 import { REQUEST_PARAMS } from '../../utils/constants';
 
 /**
@@ -624,6 +625,9 @@ class Viewer extends OlObject {
                 flipY: initialFlipY
             })
         }
+
+        // link the grid control to the viewer if requested
+        this.addControl('grid');
         
         // tweak source element for fullscreen to include dim sliders (iviewer only)
         var targetId = this.getTargetId();

--- a/src/viewers/viewer/controls/Grid.js
+++ b/src/viewers/viewer/controls/Grid.js
@@ -1,0 +1,289 @@
+import {listen} from 'ol/events';
+import EventType from 'ol/events/EventType';
+import Control from 'ol/control/Control';
+import Feature from 'ol/Feature';
+import LineString from 'ol/geom/LineString';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Style from 'ol/style/Style';
+import Stroke from 'ol/style/Stroke';
+import Fill from 'ol/style/Fill';
+import Text from 'ol/style/Text';
+import {CLASS_UNSELECTABLE, CLASS_CONTROL } from 'ol/css';
+import DragPan from 'ol/interaction/DragPan';
+
+export class Grid extends Control {
+    /**
+     * @constructor
+     */
+    constructor(opt_options) {
+        const options = opt_options || {};
+
+        const element = document.createElement('div');
+        super({
+            element: element,
+            target: options.target
+        });
+
+        const cssClasses = 'ol-grid ' + CLASS_CONTROL;
+
+        // defaults
+        this.config = {
+            cellSize: 5000,
+            lineWidth: 2,
+            labelSize: 20,
+            showLabels: false
+        }
+
+        // Create button elements
+        element.className = cssClasses;
+        const buttonGroup = document.createElement('div');
+        buttonGroup.className = 'btn-group btn-group-sm';
+        buttonGroup.innerHTML = this.getControlsHtml();
+        buttonGroup.children[0].addEventListener('click', (event) => {
+            this.toggleGrid();
+        });
+        buttonGroup.children[1].addEventListener('click', (event) => {
+            this.toggleGridPanel();
+        });
+        element.appendChild(buttonGroup);
+
+
+
+        // listen for input events on children of the element (e.g., sliders, checkboxes)
+        element.addEventListener('input', (event) => {
+            const target = event.target;
+            switch (target.type) {
+                case 'radio':
+                    // handle radio input for line width
+                    this.config.lineWidth = parseInt(target.value, 10);
+                    this.refreshGrid();  // re-render grid with new line width
+                    break;
+                case 'range':
+                    this.config.cellSize = parseInt(target.value, 10);
+                    target.previousElementSibling.value = target.value;
+                    this.refreshGrid();  // re-render grid with new cell size
+                    break;
+                case 'number':
+                    this.config.cellSize = parseInt(target.value, 10);
+                    target.nextElementSibling.value = target.value;
+                    this.refreshGrid();  // re-render grid with new cell size
+                    break;
+                case 'checkbox':
+                    this.config.showLabels = target.checked;
+                    this.refreshGrid();
+                    break;
+            }
+        });
+
+        // Map setter override to initialize on map setup
+        this.setMap_ = this.setMap;
+        this.setMap = (map) => {
+            this.setMap_(map);
+            if (map != null) this.init();
+        };
+        this.element = element;
+    }
+
+    numberToLetter(num) {
+        let letter = '';
+        while (num >= 0) {
+            letter = String.fromCharCode(65 + (num % 26)) + letter;
+            num = Math.floor(num / 26) - 1;
+        }
+        return letter;
+    }
+
+    /**
+     * Adds buttons and panel
+     * @private
+     */
+    getControlsHtml() {
+        let gridEnabled = false;
+        let gridPanelExpanded = false;
+        let gridLineWidth = 2;
+        return `<button class="btn btn-default glyphicon grid-toggle-btn ${gridEnabled ? 'active' : ''}"
+                        title="${gridEnabled ? 'Hide Grid' : 'Show Grid'}"
+                        style="width:30px; height:30px; top:0; padding: 1px; display: flex; align-items: center; justify-content: center; background: transparent; border: 1px solid #ccc; cursor: pointer;">
+                    <svg class="grid-icon" viewBox="0 0 16 16" fill="none"
+                            stroke="currentColor" stroke-width="1.5" aria-hidden="true"
+                            style="width: 16px; height: 16px; display: block;">
+                        <line x1="5.33"  y1="0"   x2="5.33"  y2="16"/>
+                        <line x1="10.66" y1="0"   x2="10.66" y2="16"/>
+                        <line x1="0"     y1="5.33"  x2="16"  y2="5.33"/>
+                        <line x1="0"     y1="10.66" x2="16"  y2="10.66"/>
+                    </svg>
+                </button>
+                <button class="grid-collapse-btn"
+                        title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
+                    ▲
+                </button>
+
+                <div class="grid-controls">
+                    <div class="grid-control-item">
+                        <label>Cell Size (px)</label>
+                        <div class="grid-input-group">
+                            <input type="number"
+                                value="${this.config.cellSize}"
+                                min="5000" max="10000" step="500"
+                                class="grid-number-input">
+                            <input type="range"
+                                value="${this.config.cellSize}"
+                                min="5000" max="10000" step="500"
+                                class="grid-slider">
+                        </div>
+                    </div>
+
+                    <div class="grid-control-item">
+                        <label>Line Width</label>
+                        <div class="grid-linewidth-group">
+                            <label><input type="radio" name="gridLineWidth" value="1">1 px</label>
+                            <label><input type="radio" name="gridLineWidth" value="2" checked>2 px</label>
+                            <label><input type="radio" name="gridLineWidth" value="3">3 px</label>
+                        </div>
+                    </div>
+
+                    <div class="grid-control-item">
+                        <label>
+                            <input type="checkbox" style="margin-top: 0">
+                            Show Labels (A1, B2...)
+                        </label>
+                    </div>
+
+                </div>`;
+    }
+
+    /**
+     * Initialization on map setup
+     */
+    init(opts) {
+        this.map = this.getMap()
+    }
+
+    toggleGridPanel() {
+        this.element.classList.toggle('panel-open');
+    }
+
+    toggleGrid(axis) {
+        if (this.gridLayer) {
+            this.map.removeLayer(this.gridLayer);
+            this.gridLayer = null;
+        }
+        this.element.classList.toggle('enabled');
+
+        if (this.element.classList.contains('enabled')) {
+            this.refreshGrid();
+        }
+    }
+
+    refreshGrid() {
+        if (this.gridLayer) {
+            this.map.removeLayer(this.gridLayer);
+            this.gridLayer = null;
+        }
+
+        // Resolve parameters (coerce to numbers; fall back to config defaults)
+        const cellSize = this.config.cellSize;
+        const lineWidth = this.config.lineWidth;
+        const labelSize = this.config.labelSize;
+        const showLabels = this.config.showLabels;
+
+        // Guard: abort if cell size is invalid (prevents infinite loop / freeze)
+        if (!cellSize || !isFinite(cellSize) || cellSize <= 0) {
+            console.error('Invalid cell size, aborting grid render:', cellSize);
+            return;
+        }
+
+        // find image layer to get image dimensions
+        let imgLayer = this.map.getLayers().item(0);
+        let src = imgLayer.getSource();
+        const width = src.getWidth();
+        const height = src.getHeight();
+
+        const features = [];
+
+        // Vertical lines (inverted Y axis used by OMERO: [x, -y])
+        for (let x = 0; x <= width; x += cellSize) {
+            const f = new Feature({
+                geometry: new LineString([[x, -height], [x, 0]]),
+                gridType: 'line'
+            });
+            f.set('non-interactive', true);
+            features.push(f);
+        }
+        // Horizontal lines
+        for (let y = 0; y <= height; y += cellSize) {
+            const f = new Feature({
+                geometry: new LineString([[0, -y], [width, -y]]),
+                gridType: 'line'
+            });
+            f.set('non-interactive', true);
+            features.push(f);
+        }
+
+        // Labels (A1, B2, ...)
+        if (showLabels) {
+            const cols = Math.ceil(width / cellSize);
+            const rows = Math.ceil(height / cellSize);
+            for (let row = 0; row < rows; row++) {
+                for (let col = 0; col < cols; col++) {
+                    const label = this.numberToLetter(col) + (row + 1);
+                    const cx = col * cellSize + cellSize / 2;
+                    const cy = -(row * cellSize + cellSize / 2);
+                    const f = new Feature({
+                        geometry: new Point([cx, cy]),
+                        gridType: 'label',
+                        label: label
+                    });
+                    f.set('non-interactive', true);
+                    features.push(f);
+                }
+            }
+        }
+
+        const lineStyle = new Style({
+            stroke: new Stroke({
+                color: 'rgba(255, 0, 0, 0.9)',
+                width: lineWidth,
+                lineCap: 'square'
+            })
+        });
+
+        const source = new VectorSource({ features: features, wrapX: false });
+
+        this.gridLayer = new VectorLayer({
+            source: source,
+            updateWhileAnimating: true,
+            updateWhileInteracting: true,
+            // NB: deliberately NO className (see class comment)
+            style: (feature) => {
+                if (feature.get('gridType') === 'label') {
+                    return new Style({
+                        text: new Text({
+                            text: feature.get('label'),
+                            font: `bold ${labelSize}px Arial`,
+                            fill: new Fill({ color: 'rgba(255, 255, 255, 0.9)' }),
+                            stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.8)', width: 3 }),
+                            overflow: true
+                        })
+                    });
+                }
+                return lineStyle;
+            }
+        });
+        this.gridLayer.set('selectable', false);
+        this.gridLayer.set('grid-layer', true);
+        this.gridLayer.set('name', 'grid-overlay');
+
+        // Insert at position 1 (just above the base image, below the ROI/regions
+        // layers). iviewer's drawing assumes the regions layer is the topmost one,
+        // so the grid must NOT be appended at the end or it captures the draw.
+        // insertAt() is the correct Collection API (fires events; unlike a direct
+        // getArray().splice(), which broke the enable/disable toggle).
+        this.map.getLayers().insertAt(1, this.gridLayer);
+        this.map.render();
+    }
+}
+
+export default Grid;

--- a/src/viewers/viewer/controls/Grid.js
+++ b/src/viewers/viewer/controls/Grid.js
@@ -1,5 +1,4 @@
-import {listen} from 'ol/events';
-import EventType from 'ol/events/EventType';
+
 import Control from 'ol/control/Control';
 import Feature from 'ol/Feature';
 import LineString from 'ol/geom/LineString';
@@ -10,8 +9,7 @@ import Style from 'ol/style/Style';
 import Stroke from 'ol/style/Stroke';
 import Fill from 'ol/style/Fill';
 import Text from 'ol/style/Text';
-import {CLASS_UNSELECTABLE, CLASS_CONTROL } from 'ol/css';
-import DragPan from 'ol/interaction/DragPan';
+import { CLASS_CONTROL } from 'ol/css';
 
 export class Grid extends Control {
     /**
@@ -49,8 +47,6 @@ export class Grid extends Control {
         });
         element.appendChild(buttonGroup);
 
-
-
         // listen for input events on children of the element (e.g., sliders, checkboxes)
         element.addEventListener('input', (event) => {
             const target = event.target;
@@ -86,6 +82,11 @@ export class Grid extends Control {
         this.element = element;
     }
 
+    /**
+     * Converts a number to a letter (0 -> A, 1 -> B, ..., 25 -> Z, 26 -> AA, etc.)
+     * @param {number} num The number to convert
+     * @returns {string} The corresponding letter(s)
+     */
     numberToLetter(num) {
         let letter = '';
         while (num >= 0) {
@@ -100,11 +101,9 @@ export class Grid extends Control {
      * @private
      */
     getControlsHtml() {
-        let gridEnabled = false;
-        let gridPanelExpanded = false;
-        let gridLineWidth = 2;
-        return `<button class="btn btn-default glyphicon grid-toggle-btn ${gridEnabled ? 'active' : ''}"
-                        title="${gridEnabled ? 'Hide Grid' : 'Show Grid'}"
+        // random number to ensure unique radio button names for when multiple image viewers are open
+        let randomNumber = Math.floor(Math.random() * 1000);
+        return `<button class="btn btn-default glyphicon grid-toggle-btn" title="Show Grid"
                         style="width:30px; height:30px; top:0; padding: 1px; display: flex; align-items: center; justify-content: center; background: transparent; border: 1px solid #ccc; cursor: pointer;">
                     <svg class="grid-icon" viewBox="0 0 16 16" fill="none"
                             stroke="currentColor" stroke-width="1.5" aria-hidden="true"
@@ -115,8 +114,7 @@ export class Grid extends Control {
                         <line x1="0"     y1="10.66" x2="16"  y2="10.66"/>
                     </svg>
                 </button>
-                <button class="grid-collapse-btn"
-                        title="${gridPanelExpanded ? 'Hide Settings' : 'Show Settings'}">
+                <button class="grid-collapse-btn" title="Show Settings">
                     ▲
                 </button>
 
@@ -138,9 +136,9 @@ export class Grid extends Control {
                     <div class="grid-control-item">
                         <label>Line Width</label>
                         <div class="grid-linewidth-group">
-                            <label><input type="radio" name="gridLineWidth" value="1">1 px</label>
-                            <label><input type="radio" name="gridLineWidth" value="2" checked>2 px</label>
-                            <label><input type="radio" name="gridLineWidth" value="3">3 px</label>
+                            <label><input type="radio" name="gridLineWidth${randomNumber}" value="1">1 px</label>
+                            <label><input type="radio" name="gridLineWidth${randomNumber}" value="2" checked>2 px</label>
+                            <label><input type="radio" name="gridLineWidth${randomNumber}" value="5">5 px</label>
                         </div>
                     </div>
 
@@ -150,7 +148,6 @@ export class Grid extends Control {
                             Show Labels (A1, B2...)
                         </label>
                     </div>
-
                 </div>`;
     }
 
@@ -161,11 +158,17 @@ export class Grid extends Control {
         this.map = this.getMap()
     }
 
+    /**
+     * Toggles the visibility of the grid settings panel
+     */
     toggleGridPanel() {
         this.element.classList.toggle('panel-open');
     }
 
-    toggleGrid(axis) {
+    /**
+     * Toggles the grid overlay on the map
+     */
+    toggleGrid() {
         if (this.gridLayer) {
             this.map.removeLayer(this.gridLayer);
             this.gridLayer = null;
@@ -177,6 +180,9 @@ export class Grid extends Control {
         }
     }
 
+    /**
+     * Recreates the grid overlay based on current configuration
+     */
     refreshGrid() {
         if (this.gridLayer) {
             this.map.removeLayer(this.gridLayer);

--- a/src/viewers/viewer/globals.js
+++ b/src/viewers/viewer/globals.js
@@ -36,6 +36,8 @@ import IntensityDisplay from './controls/IntensityDisplay';
 import RotateInteraction from './interaction/Rotate';
 import BoxSelect from './interaction/BoxSelect';
 import Mirror from './controls/Mirror';
+import Grid from './controls/Grid';
+
 
 /**
  * Default lineCap setting for default stroke
@@ -324,6 +326,12 @@ export const AVAILABLE_VIEWER_CONTROLS = {
         "options": {},
         "defaults": true,
         "enabled" : false,
+        "links" : []},
+    "grid" :
+        {"clazz" : Grid,
+        "options": {},
+        "defaults": true,
+        "enabled" : true,
         "links" : []}
 };
 

--- a/src/viewers/viewer/grid-overlay.js
+++ b/src/viewers/viewer/grid-overlay.js
@@ -56,30 +56,12 @@ export class GridOverlay {
             let cellSize, lineWidth, labelSize;
             
             // Cell size: use custom value or fallback to auto-calculation
-        if (customCellSize) {
-            cellSize = customCellSize;  // ← USE THE VALUE PROVIDED
-        } else {
-            // Fallback: auto-calculate only if not provided
-            if (Math.max(width, height) > 50000) {
-                cellSize = Math.floor(Math.min(width, height) / 6);
-            } else if (Math.max(width, height) > 10000) {
-                cellSize = Math.floor(Math.min(width, height) / 10);
-            } else {
-                cellSize = Math.floor(Math.min(width, height) / 12);
-            }
-        }
-        
-        // Line width: always 5px
+        cellSize = customCellSize;
+            // Line width: always 5px
         lineWidth = customLineWidth || 5;
         
-        // Label size: based on image size
-        if (Math.max(width, height) > 50000) {
-            labelSize = customLabelSize || 20;
-        } else if (Math.max(width, height) > 10000) {
-            labelSize = customLabelSize || 20;
-        } else {
-            labelSize = customLabelSize || 20;
-        }
+            // Label size: based on image size
+        labelSize = customLabelSize || 20;
 
             this.config.cellSize = cellSize;
             this.config.lineWidth = lineWidth;

--- a/src/viewers/viewer/grid-overlay.js
+++ b/src/viewers/viewer/grid-overlay.js
@@ -1,0 +1,362 @@
+//
+// Copyright (C) 2024 University of Dundee & Open Microscopy Environment.
+// All rights reserved.
+//
+
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import LineString from 'ol/geom/LineString';
+import Point from 'ol/geom/Point';
+import {Style, Stroke, Fill, Text} from 'ol/style';
+
+/**
+ * Grid Overlay - Optimized for NDPI images in OMERO with labels
+ */
+export class GridOverlay {
+    constructor(viewer) {
+        this.viewer = viewer;
+        this.gridLayer = null;
+        this.labelLayer = null;
+        this.enabled = false;
+        
+        // Default configuration
+        this.config = {
+            cellSize: null,
+            lineWidth: null,
+            gridColor: 'rgba(255, 0, 0, 0.9)',
+            showLabels: true,
+            labelSize: 30
+        };
+    }
+
+    /**
+     * Show grid with quadrant labels
+     */
+    showGrid(customLineWidth = null, customCellSize = null, showLabels = true, customLabelSize = null) {
+        if (this.gridLayer) {
+            this.hideGrid();
+        }
+
+        try {
+            const imageInfo = this.viewer.image_info_;
+            if (!imageInfo || !imageInfo.size) {
+                console.error('Could not get image information');
+                return;
+            }
+            
+            const width = imageInfo.size.width;
+            const height = imageInfo.size.height;
+
+            console.log('=== GRID OVERLAY DEBUG ===');
+            console.log('Image dimensions:', width, 'x', height);
+            console.log('Requested cell size:', customCellSize);
+
+            // Calculate parameters if not specified
+            let cellSize, lineWidth, labelSize;
+            
+            // Cell size: use custom value or fallback to auto-calculation
+        if (customCellSize) {
+            cellSize = customCellSize;  // ← USE THE VALUE PROVIDED
+        } else {
+            // Fallback: auto-calculate only if not provided
+            if (Math.max(width, height) > 50000) {
+                cellSize = Math.floor(Math.min(width, height) / 6);
+            } else if (Math.max(width, height) > 10000) {
+                cellSize = Math.floor(Math.min(width, height) / 10);
+            } else {
+                cellSize = Math.floor(Math.min(width, height) / 12);
+            }
+        }
+        
+        // Line width: always 5px
+        lineWidth = customLineWidth || 5;
+        
+        // Label size: based on image size
+        if (Math.max(width, height) > 50000) {
+            labelSize = customLabelSize || 20;
+        } else if (Math.max(width, height) > 10000) {
+            labelSize = customLabelSize || 20;
+        } else {
+            labelSize = customLabelSize || 20;
+        }
+
+            this.config.cellSize = cellSize;
+            this.config.lineWidth = lineWidth;
+            this.config.labelSize = labelSize;
+            this.config.showLabels = showLabels;
+
+            console.log('Cell size:', cellSize, 'px');
+            console.log('Line width:', lineWidth, 'px');
+            console.log('Label size:', labelSize, 'px');
+
+            // Create line features
+            const gridFeatures = [];
+
+            // Vertical lines
+            for (let x = 0; x <= width; x += cellSize) {
+                const line = new LineString([
+                    [x, -height],
+                    [x, 0]
+                ]);
+                const feature = new Feature({
+                    geometry: line,
+                    type: 'grid-vertical'
+                });
+                // Mark feature as non-interactive
+                feature.set('non-interactive', true);
+                feature.setId('grid-line-v-' + x); // Unique ID
+                gridFeatures.push(feature);
+            }
+
+            // Horizontal lines
+            for (let y = 0; y <= height; y += cellSize) {
+                const line = new LineString([
+                    [0, -y],
+                    [width, -y]
+                ]);
+                const feature = new Feature({
+                    geometry: line,
+                    type: 'grid-horizontal'
+                });
+                // Mark feature as non-interactive
+                feature.set('non-interactive', true);
+                feature.setId('grid-line-h-' + y); // Unique ID
+                gridFeatures.push(feature);
+            }
+
+            // Create grid layer
+            const gridSource = new VectorSource({ 
+                features: gridFeatures,
+                wrapX: false
+            });
+
+            this.gridLayer = new VectorLayer({
+                source: gridSource,
+                style: new Style({
+                    stroke: new Stroke({
+                        color: this.config.gridColor,
+                        width: lineWidth,
+                        lineCap: 'square'
+                    })
+                }),
+                zIndex: 9999,
+                updateWhileAnimating: true,
+                updateWhileInteracting: false,
+                className: 'grid-overlay-layer',
+                properties: {
+                    'non-interactive': true,
+                    'grid-layer': true
+                }
+            });
+            
+            // Mark layer as non-selectable and non-interactive
+            this.gridLayer.set('selectable', false);
+            this.gridLayer.set('grid-layer', true);
+            this.gridLayer.set('name', 'grid-overlay');
+
+            // Create quadrant labels
+            if (showLabels) {
+                const labelFeatures = [];
+                const cols = Math.ceil(width / cellSize);
+                const rows = Math.ceil(height / cellSize);
+
+                for (let row = 0; row < rows; row++) {
+                    for (let col = 0; col < cols; col++) {
+                        const colLabel = this.numberToLetter(col);
+                        const rowLabel = row + 1;
+                        const label = `${colLabel}${rowLabel}`;
+
+                        const x = col * cellSize + cellSize / 2;
+                        const y = -(row * cellSize + cellSize / 2);
+
+                        const point = new Point([x, y]);
+                        const feature = new Feature({
+                            geometry: point,
+                            label: label,
+                            type: 'grid-label'
+                        });
+                        
+                        // CRITICAL: Mark feature as non-interactive
+                        feature.set('non-interactive', true);
+                        feature.setId('grid-label-' + colLabel + rowLabel);
+                        labelFeatures.push(feature);
+                    }
+                }
+
+                const labelSource = new VectorSource({ 
+                    features: labelFeatures,
+                    wrapX: false
+                });
+
+                this.labelLayer = new VectorLayer({
+                    source: labelSource,
+                    style: (feature) => {
+                        return new Style({
+                            text: new Text({
+                                text: feature.get('label'),
+                                font: `bold ${labelSize}px Arial`,
+                                fill: new Fill({ color: 'rgba(255, 255, 255, 0.9)' }),
+                                stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.8)', width: 3 }),
+                                offsetX: 0,
+                                offsetY: 0
+                            })
+                        });
+                    },
+                    zIndex: 10000,
+                    updateWhileAnimating: true,
+                    updateWhileInteracting: false,  // CRITICAL
+                    className: 'grid-label-layer',
+                    properties: {
+                        'non-interactive': true,
+                        'grid-layer': true
+                    }
+                });
+                
+                // CRITICAL: Mark layer as completely non-selectable
+                this.labelLayer.set('selectable', false);
+                this.labelLayer.set('grid-layer', true);
+                this.labelLayer.set('name', 'grid-labels');
+                this.labelLayer.set('interactive', false);
+            }
+
+            // Add layers to map
+            const map = this.viewer.viewer_;
+            map.addLayer(this.gridLayer);
+            if (this.labelLayer) {
+                map.addLayer(this.labelLayer);
+            }
+
+            // Don't put them at the end - insert before interactive layers
+            const allLayers = map.getLayers().getArray();
+            [this.gridLayer, this.labelLayer].forEach(layer => {
+                if (layer) {
+                    const idx = allLayers.indexOf(layer);
+                    if (idx !== -1) {
+                        allLayers.splice(idx, 1);
+                        // Insert at position 1 (after base image, before ROI layers)
+                        allLayers.splice(1, 0, layer);
+                    }
+                }
+            });
+
+            this.enabled = true;
+            console.log(' Grid overlay added (fully non-interactive mode)');
+            console.log('Grid layer selectable:', this.gridLayer.get('selectable'));
+            if (this.labelLayer) {
+                console.log('Label layer selectable:', this.labelLayer.get('selectable'));
+            }
+            console.log('=========================');
+
+        } catch (error) {
+            console.error(' Error showing grid:', error);
+        }
+    }
+
+    /**
+     * Convert number to letter (0=A, 1=B, 25=Z, 26=AA, etc.)
+     */
+    numberToLetter(num) {
+        let letter = '';
+        while (num >= 0) {
+            letter = String.fromCharCode(65 + (num % 26)) + letter;
+            num = Math.floor(num / 26) - 1;
+        }
+        return letter;
+    }
+
+    /**
+     * Hide grid
+     */
+    hideGrid() {
+        const map = this.viewer.viewer_;
+        
+        if (this.gridLayer) {
+            try {
+                // Clear the source first
+                const source = this.gridLayer.getSource();
+                if (source) {
+                    source.clear();
+                }
+                
+                // Remove layer from map
+                map.removeLayer(this.gridLayer);
+                this.gridLayer = null;
+                
+                console.log(' Grid layer removed');
+            } catch (error) {
+                console.error('Error hiding grid:', error);
+            }
+        }
+        
+        if (this.labelLayer) {
+            try {
+                // Clear the source first
+                const source = this.labelLayer.getSource();
+                if (source) {
+                    source.clear();
+                }
+                
+                // Remove layer from map
+                map.removeLayer(this.labelLayer);
+                this.labelLayer = null;
+                
+                console.log(' Label layer removed');
+            } catch (error) {
+                console.error('Error hiding labels:', error);
+            }
+        }
+        
+        this.enabled = false;
+        
+        // Force map to re-render
+        map.render();
+        
+        console.log(' Grid overlay removed completely');
+    }
+
+    /**
+     * Toggle grid on/off
+     */
+    toggle() {
+        if (this.enabled) {
+            this.hideGrid();
+        } else {
+            this.showGrid();
+        }
+    }
+
+    /**
+     * Update line width
+     */
+    updateLineWidth(newWidth) {
+        if (this.enabled) {
+            this.showGrid(newWidth, this.config.cellSize, this.config.showLabels);
+        }
+    }
+
+    /**
+     * Update cell size
+     */
+    updateCellSize(newSize) {
+        if (this.enabled) {
+            this.showGrid(this.config.lineWidth, newSize, this.config.showLabels);
+        }
+    }
+
+    /**
+     * Toggle labels
+     */
+    toggleLabels() {
+        if (this.enabled) {
+            this.showGrid(this.config.lineWidth, this.config.cellSize, !this.config.showLabels);
+        }
+    }
+
+    /**
+     * Check if enabled
+     */
+    isEnabled() {
+        return this.enabled;
+    }
+}

--- a/src/viewers/viewer/grid-overlay.js
+++ b/src/viewers/viewer/grid-overlay.js
@@ -11,228 +11,156 @@ import Point from 'ol/geom/Point';
 import {Style, Stroke, Fill, Text} from 'ol/style';
 
 /**
- * Grid Overlay - Optimized for NDPI images in OMERO with labels
+ * Grid Overlay - Optimized for NDPI images in OMERO with labels.
  */
 export class GridOverlay {
     constructor(viewer) {
         this.viewer = viewer;
         this.gridLayer = null;
-        this.labelLayer = null;
         this.enabled = false;
-        
+
         // Default configuration
         this.config = {
-            cellSize: null,
-            lineWidth: null,
+            cellSize: 5000,
+            lineWidth: 2,
             gridColor: 'rgba(255, 0, 0, 0.9)',
             showLabels: true,
-            labelSize: 30
+            labelSize: 20
         };
     }
 
     /**
-     * Show grid with quadrant labels
+     * Show grid with quadrant labels.
+     *
+     * @param {number} customLineWidth line width in px (optional)
+     * @param {number} customCellSize  cell size in px (optional)
+     * @param {boolean} showLabels     whether to draw A1/B2 labels
+     * @param {number} customLabelSize label font size in px (optional)
      */
-    showGrid(customLineWidth = null, customCellSize = null, showLabels = true, customLabelSize = null) {
-        if (this.gridLayer) {
-            this.hideGrid();
+    showGrid(customLineWidth = null, customCellSize = null,
+             showLabels = true, customLabelSize = null) {
+
+        // Resolve parameters (coerce to numbers; fall back to config defaults)
+        const cellSize = parseInt(customCellSize, 10) || this.config.cellSize;
+        const lineWidth = parseInt(customLineWidth, 10) || this.config.lineWidth;
+        const labelSize = parseInt(customLabelSize, 10) || this.config.labelSize;
+
+        // Guard: abort if cell size is invalid (prevents infinite loop / freeze)
+        if (!cellSize || !isFinite(cellSize) || cellSize <= 0) {
+            console.error('Invalid cell size, aborting grid render:', cellSize);
+            return;
         }
 
-        try {
-            const imageInfo = this.viewer.image_info_;
-            if (!imageInfo || !imageInfo.size) {
-                console.error('Could not get image information');
-                return;
-            }
-            
-            const width = imageInfo.size.width;
-            const height = imageInfo.size.height;
+        this.config.cellSize = cellSize;
+        this.config.lineWidth = lineWidth;
+        this.config.labelSize = labelSize;
+        this.config.showLabels = showLabels;
 
-            console.log('=== GRID OVERLAY DEBUG ===');
-            console.log('Image dimensions:', width, 'x', height);
-            console.log('Requested cell size:', customCellSize);
+        // Remove any previous layer first
+        this.hideGrid();
 
-            // Calculate parameters if not specified
-            let cellSize, lineWidth, labelSize;
-            
-            // Cell size: use custom value or fallback to auto-calculation
-        cellSize = customCellSize;
-            // Line width: always 5px
-        lineWidth = customLineWidth || 5;
-        
-            // Label size: based on image size
-        labelSize = customLabelSize || 20;
-
-            this.config.cellSize = cellSize;
-            this.config.lineWidth = lineWidth;
-            this.config.labelSize = labelSize;
-            this.config.showLabels = showLabels;
-
-            console.log('Cell size:', cellSize, 'px');
-            console.log('Line width:', lineWidth, 'px');
-            console.log('Label size:', labelSize, 'px');
-
-            // Create line features
-            const gridFeatures = [];
-
-            // Vertical lines
-            for (let x = 0; x <= width; x += cellSize) {
-                const line = new LineString([
-                    [x, -height],
-                    [x, 0]
-                ]);
-                const feature = new Feature({
-                    geometry: line,
-                    type: 'grid-vertical'
-                });
-                // Mark feature as non-interactive
-                feature.set('non-interactive', true);
-                feature.setId('grid-line-v-' + x); // Unique ID
-                gridFeatures.push(feature);
-            }
-
-            // Horizontal lines
-            for (let y = 0; y <= height; y += cellSize) {
-                const line = new LineString([
-                    [0, -y],
-                    [width, -y]
-                ]);
-                const feature = new Feature({
-                    geometry: line,
-                    type: 'grid-horizontal'
-                });
-                // Mark feature as non-interactive
-                feature.set('non-interactive', true);
-                feature.setId('grid-line-h-' + y); // Unique ID
-                gridFeatures.push(feature);
-            }
-
-            // Create grid layer
-            const gridSource = new VectorSource({ 
-                features: gridFeatures,
-                wrapX: false
-            });
-
-            this.gridLayer = new VectorLayer({
-                source: gridSource,
-                style: new Style({
-                    stroke: new Stroke({
-                        color: this.config.gridColor,
-                        width: lineWidth,
-                        lineCap: 'square'
-                    })
-                }),
-                zIndex: 9999,
-                updateWhileAnimating: true,
-                updateWhileInteracting: false,
-                className: 'grid-overlay-layer',
-                properties: {
-                    'non-interactive': true,
-                    'grid-layer': true
-                }
-            });
-            
-            // Mark layer as non-selectable and non-interactive
-            this.gridLayer.set('selectable', false);
-            this.gridLayer.set('grid-layer', true);
-            this.gridLayer.set('name', 'grid-overlay');
-
-            // Create quadrant labels
-            if (showLabels) {
-                const labelFeatures = [];
-                const cols = Math.ceil(width / cellSize);
-                const rows = Math.ceil(height / cellSize);
-
-                for (let row = 0; row < rows; row++) {
-                    for (let col = 0; col < cols; col++) {
-                        const colLabel = this.numberToLetter(col);
-                        const rowLabel = row + 1;
-                        const label = `${colLabel}${rowLabel}`;
-
-                        const x = col * cellSize + cellSize / 2;
-                        const y = -(row * cellSize + cellSize / 2);
-
-                        const point = new Point([x, y]);
-                        const feature = new Feature({
-                            geometry: point,
-                            label: label,
-                            type: 'grid-label'
-                        });
-                        
-                        // CRITICAL: Mark feature as non-interactive
-                        feature.set('non-interactive', true);
-                        feature.setId('grid-label-' + colLabel + rowLabel);
-                        labelFeatures.push(feature);
-                    }
-                }
-
-                const labelSource = new VectorSource({ 
-                    features: labelFeatures,
-                    wrapX: false
-                });
-
-                this.labelLayer = new VectorLayer({
-                    source: labelSource,
-                    style: (feature) => {
-                        return new Style({
-                            text: new Text({
-                                text: feature.get('label'),
-                                font: `bold ${labelSize}px Arial`,
-                                fill: new Fill({ color: 'rgba(255, 255, 255, 0.9)' }),
-                                stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.8)', width: 3 }),
-                                offsetX: 0,
-                                offsetY: 0
-                            })
-                        });
-                    },
-                    zIndex: 10000,
-                    updateWhileAnimating: true,
-                    updateWhileInteracting: false,  // CRITICAL
-                    className: 'grid-label-layer',
-                    properties: {
-                        'non-interactive': true,
-                        'grid-layer': true
-                    }
-                });
-                
-                // CRITICAL: Mark layer as completely non-selectable
-                this.labelLayer.set('selectable', false);
-                this.labelLayer.set('grid-layer', true);
-                this.labelLayer.set('name', 'grid-labels');
-                this.labelLayer.set('interactive', false);
-            }
-
-            // Add layers to map
-            const map = this.viewer.viewer_;
-            map.addLayer(this.gridLayer);
-            if (this.labelLayer) {
-                map.addLayer(this.labelLayer);
-            }
-
-            // Don't put them at the end - insert before interactive layers
-            const allLayers = map.getLayers().getArray();
-            [this.gridLayer, this.labelLayer].forEach(layer => {
-                if (layer) {
-                    const idx = allLayers.indexOf(layer);
-                    if (idx !== -1) {
-                        allLayers.splice(idx, 1);
-                        // Insert at position 1 (after base image, before ROI layers)
-                        allLayers.splice(1, 0, layer);
-                    }
-                }
-            });
-
-            this.enabled = true;
-            console.log(' Grid overlay added (fully non-interactive mode)');
-            console.log('Grid layer selectable:', this.gridLayer.get('selectable'));
-            if (this.labelLayer) {
-                console.log('Label layer selectable:', this.labelLayer.get('selectable'));
-            }
-            console.log('=========================');
-
-        } catch (error) {
-            console.error(' Error showing grid:', error);
+        const map = this.viewer.viewer_;
+        const imageInfo = this.viewer.image_info_;
+        if (!map || !imageInfo || !imageInfo.size) {
+            console.error('Could not get map / image information');
+            return;
         }
+
+        const width = imageInfo.size.width;
+        const height = imageInfo.size.height;
+
+        console.log('=== GRID OVERLAY ===');
+        console.log('Image dimensions:', width, 'x', height);
+        console.log('Cell size:', cellSize, 'px | Line width:', lineWidth,
+                    'px | Label size:', labelSize, 'px');
+
+        const features = [];
+
+        // Vertical lines (inverted Y axis used by OMERO: [x, -y])
+        for (let x = 0; x <= width; x += cellSize) {
+            const f = new Feature({
+                geometry: new LineString([[x, -height], [x, 0]]),
+                gridType: 'line'
+            });
+            f.set('non-interactive', true);
+            features.push(f);
+        }
+        // Horizontal lines
+        for (let y = 0; y <= height; y += cellSize) {
+            const f = new Feature({
+                geometry: new LineString([[0, -y], [width, -y]]),
+                gridType: 'line'
+            });
+            f.set('non-interactive', true);
+            features.push(f);
+        }
+
+        // Labels (A1, B2, ...)
+        if (showLabels) {
+            const cols = Math.ceil(width / cellSize);
+            const rows = Math.ceil(height / cellSize);
+            for (let row = 0; row < rows; row++) {
+                for (let col = 0; col < cols; col++) {
+                    const label = this.numberToLetter(col) + (row + 1);
+                    const cx = col * cellSize + cellSize / 2;
+                    const cy = -(row * cellSize + cellSize / 2);
+                    const f = new Feature({
+                        geometry: new Point([cx, cy]),
+                        gridType: 'label',
+                        label: label
+                    });
+                    f.set('non-interactive', true);
+                    features.push(f);
+                }
+            }
+        }
+
+        const lineStyle = new Style({
+            stroke: new Stroke({
+                color: this.config.gridColor,
+                width: lineWidth,
+                lineCap: 'square'
+            })
+        });
+
+        const source = new VectorSource({ features: features, wrapX: false });
+
+        this.gridLayer = new VectorLayer({
+            source: source,
+            updateWhileAnimating: true,
+            updateWhileInteracting: true,
+            // NB: deliberately NO className (see class comment)
+            style: (feature) => {
+                if (feature.get('gridType') === 'label') {
+                    return new Style({
+                        text: new Text({
+                            text: feature.get('label'),
+                            font: `bold ${labelSize}px Arial`,
+                            fill: new Fill({ color: 'rgba(255, 255, 255, 0.9)' }),
+                            stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.8)', width: 3 }),
+                            overflow: true
+                        })
+                    });
+                }
+                return lineStyle;
+            }
+        });
+        this.gridLayer.set('selectable', false);
+        this.gridLayer.set('grid-layer', true);
+        this.gridLayer.set('name', 'grid-overlay');
+
+        // Insert at position 1 (just above the base image, below the ROI/regions
+        // layers). iviewer's drawing assumes the regions layer is the topmost one,
+        // so the grid must NOT be appended at the end or it captures the draw.
+        // insertAt() is the correct Collection API (fires events; unlike a direct
+        // getArray().splice(), which broke the enable/disable toggle).
+        map.getLayers().insertAt(1, this.gridLayer);
+        map.render();
+
+        this.enabled = true;
+        console.log('Grid overlay enabled (feature-based, no className). Features:',
+                    features.length);
+        console.log('====================');
     }
 
     /**
@@ -252,49 +180,18 @@ export class GridOverlay {
      */
     hideGrid() {
         const map = this.viewer.viewer_;
-        
         if (this.gridLayer) {
             try {
-                // Clear the source first
                 const source = this.gridLayer.getSource();
-                if (source) {
-                    source.clear();
-                }
-                
-                // Remove layer from map
-                map.removeLayer(this.gridLayer);
-                this.gridLayer = null;
-                
-                console.log(' Grid layer removed');
+                if (source) source.clear();
+                if (map) map.removeLayer(this.gridLayer);
             } catch (error) {
                 console.error('Error hiding grid:', error);
             }
+            this.gridLayer = null;
         }
-        
-        if (this.labelLayer) {
-            try {
-                // Clear the source first
-                const source = this.labelLayer.getSource();
-                if (source) {
-                    source.clear();
-                }
-                
-                // Remove layer from map
-                map.removeLayer(this.labelLayer);
-                this.labelLayer = null;
-                
-                console.log(' Label layer removed');
-            } catch (error) {
-                console.error('Error hiding labels:', error);
-            }
-        }
-        
         this.enabled = false;
-        
-        // Force map to re-render
-        map.render();
-        
-        console.log(' Grid overlay removed completely');
+        if (map) map.render();
     }
 
     /**
@@ -331,7 +228,8 @@ export class GridOverlay {
      */
     toggleLabels() {
         if (this.enabled) {
-            this.showGrid(this.config.lineWidth, this.config.cellSize, !this.config.showLabels);
+            this.showGrid(this.config.lineWidth, this.config.cellSize,
+                          !this.config.showLabels);
         }
     }
 


### PR DESCRIPTION
Hi, We welcome your comments and would like to add the following
- Created GridOverlay class for rendering grid lines and labels
- Added grid control panel with collapse/expand functionality
- Configurable cell size (5000-10000px) with slider and number input
- quadrant labels (A1, B2, etc.)
- Non-interactive grid layers (allows ROI tools to work)