### PR TITLE
Image id and roi id initial params

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ This may first remove other ``image_configs`` before creating a new one and load
 
     // src/app/context.js
 
-    let image_config = new ImageConfig(this, image_id, parent_id, parent_type);
+    let image_config = new ImageConfig(this, image_id, roi_id, shape_id, parent_id, parent_type);
     // store the image config in the map and make it the selected one
     this.image_configs.set(image_config.id, image_config);
     this.selectConfig(image_config.id);

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -52,7 +52,7 @@ To enable the "open with" feature:
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
 If you want to redirect ``/iviewer/`` URLs to instead use ``/webclient/img_detail/ID`` so
-that the viewer configured at ``omero.web.viewer.view`` is used then use the 
+that a different viewer configured at ``omero.web.viewer.view`` is used then use the 
 config below.
 This will redirect ``/iviewer/?images=12,34`` to ``/webclient/img_detail/12/?images=12,34``,
 ``/iviewer/?roi=56`` to ``/webclient/img_detail/IMAGE_ID/?roi=56`` (same for shape)

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -51,6 +51,13 @@ To enable the "open with" feature:
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
+If you want to redirect /iviewer/?images=123 or roi=456 to /webclient/img_detail/123/ so
+that the viewer configured at ``omero.web.viewer.view`` is used:
+
+::
+
+    $ omero config set omero.web.iviewer.redirect_iviewer True
+
 Now restart OMERO.web as normal.
 
 

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -51,8 +51,13 @@ To enable the "open with" feature:
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
-If you want to redirect /iviewer/?images=123 or roi=456 to /webclient/img_detail/123/ so
-that the viewer configured at ``omero.web.viewer.view`` is used:
+If you want to redirect ``/iviewer/`` URLs to instead use ``/webclient/img_detail/ID`` so
+that the viewer configured at ``omero.web.viewer.view`` is used then use the 
+config below.
+This will redirect ``/iviewer/?images=12,34`` to ``/webclient/img_detail/12/?images=12,34``,
+``/iviewer/?roi=56`` to ``/webclient/img_detail/IMAGE_ID/?roi=56`` (same for shape)
+and ``/iviewer/?well=78`` to ``/webclient/img_detail/IMAGE_ID/?images=ID1,ID2,...``
+where ID1, ID2, etc are the images in the well.
 
 ::
 

--- a/plugin/omero_iviewer/iviewer_settings.py
+++ b/plugin/omero_iviewer/iviewer_settings.py
@@ -65,6 +65,13 @@ IVIEWER_SETTINGS_MAPPING = {
          ("Disables spectrum color picker. Forces users to use preset options."
           "Must define a color palette for this setting to work.")],
 
+    "omero.web.iviewer.redirect_iviewer":
+        ["REDIRECT_IVIEWER",
+         False,
+         bool,
+         ("If True, we redirect /iviewer/?... to /webclient/img_detail/123/ so"
+         " that the viewer configured at omero.web.viewer.view is used.")],
+
     "omero.web.iviewer.enable_mirror":
         ["ENABLE_MIRROR",
          False,

--- a/plugin/omero_iviewer/iviewer_settings.py
+++ b/plugin/omero_iviewer/iviewer_settings.py
@@ -70,7 +70,7 @@ IVIEWER_SETTINGS_MAPPING = {
          False,
          bool,
          ("If True, we redirect /iviewer/?... to /webclient/img_detail/123/ so"
-         " that the viewer configured at omero.web.viewer.view is used.")],
+         " that a different viewer configured at omero.web.viewer.view is used.")],
 
     "omero.web.iviewer.enable_mirror":
         ["ENABLE_MIRROR",

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.http import JsonResponse, Http404
 from django.conf import settings
 from django.urls import reverse, NoReverseMatch
@@ -78,6 +78,28 @@ def index(request, iid=None, conn=None, **kwargs):
     for key in request.GET:
         if request.GET[key]:
             params[str(key).upper()] = str(request.GET[key])
+
+    # If URL is /iviewer/?... rather than /webclient/img_detail/123/
+    # we want to redirect to the latter, to support omero.web.viewer.view config
+    if iid is None:
+        # we want to redirect to /webclient/img_detail/123/
+        if params.get("ROI") is not None:
+            roi = conn.getQueryService().get('Roi', int(params.get("ROI")), conn.SERVICE_OPTS)
+            image_id = roi.image.id.val
+        elif params.get("SHAPE") is not None:
+            image_id, roi_id = get_image_roi_id_for_shape(conn, params.get("SHAPE"))
+        elif params.get("IMAGES") is not None:
+            image_id = int(params.get("IMAGES").split(',')[0])
+
+        if image_id is not None:
+            redirect_url = reverse('web_image_viewer', kwargs={'iid': image_id})
+            # add all query params to redirect url
+            query_string = '&'.join([f"{key}={value}" for key, value in request.GET.items()])
+            if query_string:
+                redirect_url = f"{redirect_url}?{query_string}"
+            return redirect(redirect_url)
+        else:
+            raise Http404(f'Could not find Image, ROI, or Shape for given id(s)')
 
     # set interpolation default
     server_settings = request.session.get('server_settings', {})

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -83,6 +83,8 @@ def index(request, iid=None, conn=None, **kwargs):
     # If URL is /iviewer/?... rather than /webclient/img_detail/123/
     # we want to redirect to the latter, to support omero.web.viewer.view config
     if iid is None and REDIRECT_IVIEWER:
+        image_id = None
+        query_string = '&'.join([f"{key}={value}" for key, value in request.GET.items()])
         # we want to redirect to /webclient/img_detail/123/
         if params.get("ROI") is not None:
             roi = conn.getQueryService().get('Roi', int(params.get("ROI")), conn.SERVICE_OPTS)
@@ -91,18 +93,24 @@ def index(request, iid=None, conn=None, **kwargs):
             image_id, roi_id = get_image_roi_id_for_shape(conn, params.get("SHAPE"))
         elif params.get("IMAGES") is not None:
             image_id = int(params.get("IMAGES").split(',')[0])
+        elif params.get("WELL") is not None:
+            well = conn.getObject("Well", int(params.get("WELL")))
+            if well is not None:
+                image_ids = [well_sample.getImage().id for well_sample in well.listChildren()]
+                if len(image_ids) > 0:
+                    image_id = image_ids[0]
+                    query_string = f"images={','.join(map(str, image_ids))}"
 
         if image_id is not None:
             redirect_url = reverse('web_image_viewer', kwargs={'iid': image_id})
             # add all query params to redirect url
             # e.g. /webclient/img_detail/123/?images=123,456 will open both images
             # and /webclient/img_detail/123/?roi=456 will open the image with the roi highlighted
-            query_string = '&'.join([f"{key}={value}" for key, value in request.GET.items()])
             if query_string:
                 redirect_url = f"{redirect_url}?{query_string}"
             return redirect(redirect_url)
         else:
-            raise Http404(f'Could not find Image, ROI, or Shape for given id(s)')
+            raise Http404(f'Could not find Image, Well, ROI, or Shape for given id(s)')
 
     # set interpolation default
     server_settings = request.session.get('server_settings', {})

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -54,6 +54,7 @@ MAX_ACTIVE_CHANNELS = getattr(iviewer_settings, 'MAX_ACTIVE_CHANNELS')
 ROI_COLOR_PALETTE = getattr(iviewer_settings, 'ROI_COLOR_PALETTE')
 SHOW_PALETTE_ONLY = getattr(iviewer_settings, 'SHOW_PALETTE_ONLY')
 ENABLE_MIRROR = getattr(iviewer_settings, 'ENABLE_MIRROR')
+REDIRECT_IVIEWER = getattr(iviewer_settings, 'REDIRECT_IVIEWER')
 
 PROJECTIONS = {
     'normal': -1,
@@ -81,7 +82,7 @@ def index(request, iid=None, conn=None, **kwargs):
 
     # If URL is /iviewer/?... rather than /webclient/img_detail/123/
     # we want to redirect to the latter, to support omero.web.viewer.view config
-    if iid is None:
+    if iid is None and REDIRECT_IVIEWER:
         # we want to redirect to /webclient/img_detail/123/
         if params.get("ROI") is not None:
             roi = conn.getQueryService().get('Roi', int(params.get("ROI")), conn.SERVICE_OPTS)
@@ -94,6 +95,8 @@ def index(request, iid=None, conn=None, **kwargs):
         if image_id is not None:
             redirect_url = reverse('web_image_viewer', kwargs={'iid': image_id})
             # add all query params to redirect url
+            # e.g. /webclient/img_detail/123/?images=123,456 will open both images
+            # and /webclient/img_detail/123/?roi=456 will open the image with the roi highlighted
             query_string = '&'.join([f"{key}={value}" for key, value in request.GET.items()])
             if query_string:
                 redirect_url = f"{redirect_url}?{query_string}"

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -383,28 +383,49 @@ export default class Context {
      * @memberof Context
      */
     openWithInitialParams() {
+        console.log("openWithInitialParams", this.initParams);
         // do we have any image ids or roi ids?
-        let initial_ids;
-        let initial_type;   // INITIAL_TYPES int
-        if (this.initParams[REQUEST_PARAMS.IMAGES]) {
-            initial_ids = this.initParams[REQUEST_PARAMS.IMAGES];
-            initial_type = INITIAL_TYPES.IMAGES;
-        } else if (this.initParams[REQUEST_PARAMS.ROI]) {
-            // also support ?roi=1
-            initial_ids = this.initParams[REQUEST_PARAMS.ROI];
-            initial_type = INITIAL_TYPES.ROIS;
-        } else if (this.initParams[REQUEST_PARAMS.SHAPE]) {
-            initial_ids = this.initParams[REQUEST_PARAMS.SHAPE];
-            initial_type = INITIAL_TYPES.SHAPES;
-        }
-        if (initial_ids) {
-            this.initial_ids = initial_ids.split(',')
-                .map(id => parseInt(id))
-                .filter(id => !isNaN(id))
+        // let initial_ids;
+        // let initial_type;   // INITIAL_TYPES int
 
-            if (this.initial_ids.length > 0)
-                this.initial_type = initial_type;
+        const parseIds = (dtype) => {
+            let value = this.initParams[dtype];
+            let ids = value.split(',')
+                .map(id => parseInt(id))
+                .filter(id => !isNaN(id));
+            if (ids.length > 0) {
+                this.initial_ids = ids;
+            }
+            return ids;
         }
+
+        let image_ids = [], roi_ids = [], shape_ids = [];
+
+        // this.initial_type will be set to the type of the last param that is successfully parsed,
+        // but that's ok because we only use it to determine the parent type for the image config, 
+        if (this.initParams[REQUEST_PARAMS.SHAPE]) {
+            shape_ids = parseIds(REQUEST_PARAMS.SHAPE);
+            if (shape_ids.length > 0) {
+                this.initial_type = INITIAL_TYPES.SHAPES;
+            }
+        }
+        if (this.initParams[REQUEST_PARAMS.ROI]) {
+            roi_ids = parseIds(REQUEST_PARAMS.ROI);
+            if (roi_ids.length > 0) {
+                this.initial_type = INITIAL_TYPES.ROIS;
+            }
+        }
+        if (this.initParams[REQUEST_PARAMS.IMAGES]) {
+            image_ids = parseIds(REQUEST_PARAMS.IMAGES);
+            if (image_ids.length > 0) {
+                this.initial_type = INITIAL_TYPES.IMAGES;
+            }
+        }
+
+        console.log("image ids: " + image_ids);
+        console.log("roi ids: " + roi_ids);
+        console.log("shape ids: " + shape_ids);
+
 
         // do we have a dataset id?
         let initial_dataset_id =
@@ -418,7 +439,7 @@ export default class Context {
             initial_well_id = null;
 
         // add image config if we have image ids OR roi id OR shape id
-        if ([INITIAL_TYPES.IMAGES, INITIAL_TYPES.ROIS, INITIAL_TYPES.SHAPES].indexOf(this.initial_type) > -1) {
+        if (image_ids.length > 0 || roi_ids.length > 0 || shape_ids.length > 0) {
             let parent_id = initial_dataset_id || initial_well_id;
             let parent_type;
             if (parent_id) {
@@ -428,7 +449,8 @@ export default class Context {
                     parent_type = INITIAL_TYPES.WELL
                 }
             }
-            this.addImageConfig(this.initial_ids[0], this.initial_type, parent_id, parent_type);
+            // one of these should be valid, others may be undefined if length is 0
+            this.addImageConfig(image_ids[0], roi_ids[0], shape_ids[0], parent_id, parent_type);
         } else {
             // we could either have a well or just a dataset
             if (initial_well_id) { // well takes precedence
@@ -726,13 +748,13 @@ export default class Context {
      * Creates and adds an ImageConfig instance by handing it an id of an image
      * stored on the server, as well as making it the selected/active image config.
      *
-     * @param {number} obj_id the image or roi id
-     * @param {number} obj_type e.g. INITIAL_TYPES.IMAGES or ROIS
+     * @param {number} image_id the image id
+     * @param {number} roi_id the roi id
+     * @param {number} shape_id the shape id
      * @param {number} parent_id an optional parent id
      * @param {number} parent_type an optional parent type  (e.g. dataset or well)
      */
-    addImageConfig(obj_id, obj_type, parent_id, parent_type) {
-        if (typeof obj_id !== 'number' || obj_id < 0) return;
+    addImageConfig(image_id, roi_id, shape_id, parent_id, parent_type) {
 
         // we do not keep the other configs around unless we are in MDI mode.
         if (!this.useMDI) {
@@ -748,7 +770,7 @@ export default class Context {
         }
 
         let image_config =
-            new ImageConfig(this, obj_id, obj_type, parent_id, parent_type);
+            new ImageConfig(this, image_id, roi_id, shape_id, parent_id, parent_type);
         // store the image config in the map and make it the selected one
         this.image_configs.set(image_config.id, image_config);
         this.selectConfig(image_config.id);
@@ -806,7 +828,7 @@ export default class Context {
                 let oldPosition = Object.assign({}, replace_image_config.position);
                 let oldSize = Object.assign({}, replace_image_config.size);
                 this.removeImageConfig(replace_image_config, true);
-                this.addImageConfig(obj_id, initial_type, parent_id, parent_type);
+                this.addImageConfig(obj_id, undefined, undefined, parent_id, parent_type);
                 // Get the newly created image config
                 let selImgConf = this.getSelectedImageConfig();
                 if (selImgConf !== null) {
@@ -814,7 +836,7 @@ export default class Context {
                     selImgConf.size = oldSize;
                 }
             } else {
-                this.addImageConfig(obj_id, initial_type, parent_id, parent_type);
+                this.addImageConfig(obj_id, undefined, undefined, parent_id, parent_type);
             }
         };
 

--- a/src/app/context.js
+++ b/src/app/context.js
@@ -383,10 +383,7 @@ export default class Context {
      * @memberof Context
      */
     openWithInitialParams() {
-        console.log("openWithInitialParams", this.initParams);
         // do we have any image ids or roi ids?
-        // let initial_ids;
-        // let initial_type;   // INITIAL_TYPES int
 
         const parseIds = (dtype) => {
             let value = this.initParams[dtype];
@@ -401,7 +398,7 @@ export default class Context {
 
         let image_ids = [], roi_ids = [], shape_ids = [];
 
-        // this.initial_type will be set to the type of the last param that is successfully parsed,
+        // this.initial_type and this.initial_ids will be set to the type of the last param that is successfully parsed,
         // but that's ok because we only use it to determine the parent type for the image config, 
         if (this.initParams[REQUEST_PARAMS.SHAPE]) {
             shape_ids = parseIds(REQUEST_PARAMS.SHAPE);
@@ -421,11 +418,6 @@ export default class Context {
                 this.initial_type = INITIAL_TYPES.IMAGES;
             }
         }
-
-        console.log("image ids: " + image_ids);
-        console.log("roi ids: " + roi_ids);
-        console.log("shape ids: " + shape_ids);
-
 
         // do we have a dataset id?
         let initial_dataset_id =

--- a/src/app/thumbnail-slider.js
+++ b/src/app/thumbnail-slider.js
@@ -240,7 +240,7 @@ export default class ThumbnailSlider extends EventSubscriber {
                 this.context.initial_type === INITIAL_TYPES.ROIS ||
                 this.context.initial_type === INITIAL_TYPES.SHAPES) &&
             this.context.initial_ids.length === 1 &&
-            this.image_config.image_info.parent_id !== 'number') {
+            typeof this.image_config.image_info.parent_id !== 'number') {
             // have we had all the data already
             if (this.image_config.image_info.ready) {
                 // too bad, no dataset id

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -106,12 +106,13 @@ export default class ImageConfig extends History {
     /**
      * @constructor
      * @param {Context} context the application context
-     * @param {number} obj_id the id of the obj (image, roi)
-     * @param {number} obj_type the type of obj. e.g. INITIAL_TYPES.IMAGES or ROIS
+     * @param {number} image_id the image id to be queried. If undefined then use shape or roi id to query for image data
+     * @param {number} roi_id the roi id to be queried
+     * @param {number} shape_id the shape id to be queried
      * @param {number} parent_id an optional parent id
      * @param {number} parent_type an optional parent type  (e.g. INITIAL_TYPES.DATASET or WELL)
      */
-    constructor(context, obj_id, obj_type, parent_id, parent_type) {
+    constructor(context, image_id, roi_id, shape_id, parent_id, parent_type) {
         super(); // for history
         this.context = context;
         // for now this should suffice, especially given js 1 threaded nature
@@ -119,7 +120,7 @@ export default class ImageConfig extends History {
         // go create the data objects for an image and its associated region
         this.image_info =
             new ImageInfo(
-                this.context, this.id, obj_id, obj_type, parent_id, parent_type);
+                this.context, this.id, image_id, roi_id, shape_id, parent_id, parent_type);
         this.regions_info = new RegionsInfo(this.image_info);
     }
 

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -248,17 +248,18 @@ export default class ImageInfo {
      * @constructor
      * @param {Context} context the application context
      * @param {number} config_id the config id we belong to
-     * @param {number} obj_id the object id to be queried
-     * @param {number} obj_type the type of obj. e.g. INITIAL_TYPES.IMAGES or ROIS
+     * @param {number} image_id the image id to be queried. If undefined then use shape or roi id to query for image data
+     * @param {number} roi_id the roi id to be queried
+     * @param {number} shape_id the shape id to be queried
      * @param {number} parent_id an optional parent id
      * @param {number} parent_type an optional parent type (e.g. INITIAL_TYPES.DATASET or WELL)
      */
-    constructor(context, config_id, obj_id, obj_type, parent_id, parent_type) {
+    constructor(context, config_id, image_id, roi_id, shape_id, parent_id, parent_type) {
         this.context = context;
         this.config_id = config_id;
-        this.image_id = obj_type == INITIAL_TYPES.IMAGES ? obj_id : undefined;
-        this.initial_roi_id = obj_type == INITIAL_TYPES.ROIS ? obj_id : undefined;
-        this.initial_shape_id = obj_type == INITIAL_TYPES.SHAPES ? obj_id : undefined;
+        this.image_id = image_id;
+        this.initial_roi_id = roi_id;
+        this.initial_shape_id = shape_id;
         if (typeof parent_id === 'number') {
             this.parent_id = parent_id;
             if (typeof parent_type === 'number' &&

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -315,9 +315,9 @@ export default class ImageInfo {
             success : (response) => {
                 if (!this.image_id) {
                     this.image_id = response.id;
-                    this.web_url = this.context.server + this.context.getPrefixedURI(WEBCLIENT) +
-                        '/?show=image-' + this.image_id;
                 }
+                this.web_url = this.context.server + this.context.getPrefixedURI(WEBCLIENT) +
+                    '/?show=image-' + this.image_id;
 
                 // validate response
                 // check for Exceptions and show error dialog.

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -267,9 +267,6 @@ export default class ImageInfo {
                 parent_type <= INITIAL_TYPES.WELL)
                     this.parent_type = parent_type;
         }
-        this.web_url = this.context.server +
-        this.context.getPrefixedURI(WEBCLIENT) +
-        '/?show=image-' + this.image_id;
     }
 
     /**
@@ -318,6 +315,8 @@ export default class ImageInfo {
             success : (response) => {
                 if (!this.image_id) {
                     this.image_id = response.id;
+                    this.web_url = this.context.server + this.context.getPrefixedURI(WEBCLIENT) +
+                        '/?show=image-' + this.image_id;
                 }
 
                 // validate response


### PR DESCRIPTION

When linking from e.g. OMERO.tables or anywhere that we have ONLY a Roi/Shape ID, we use e.g. `/iviewer/?roi=789` or `/iviewer/?shape=456`.

However, this doesn't use `webclient/img_detail/123/` URL so it ignores any setting we have for `omero.web.viewer.view` to use a different viewer (such as idr-gallery) for handling images.

In this PR, when iviewer loads we check if the `image ID` has been passed in the URL (which tells us whether we're at e.g. `webclient/img_detail/IMAGE_ID/`) and if we're NOT at that URL, then we lookup the image ID (via ROI or SHAPE) and then redirect to `/img_detail/123/?shape=456`.

Also, we now handle Image ID AND Roi/Shape IDs, so that `webclient/img_detail/123/?shape=456` will load the image *and then* select the Shape. Previously we *only* handled Image ID *or* Shape ID but not both.

The only time when you might not want the redirect behaviour is if you have some other viewer set at `omero.web.viewer.view` (e.g. Pathviewer) but you still want iviewer to be available at `/iviewer/?images=123`. So, we only redirect if 

```
$ omero config set omero.web.iviewer.redirect_iviewer True
```

This is added to the README.

To test:

 - The config above has already been set on merge-ci OMERO.web job
 - Find or create & Save a Shape in iviewer
 - Click on the link icon (top right of ROI panel in iviewer) and copy the link. E.g. /iviewer/?shape=456
 - Paste it in the URL and you should get redirected to /webclient/img_detail/IMAGEID/?shape=456
 - Also, selecting multiple images in the webclient and Open With > iviewer which gives /iviewer/?images=7,8,9 should also redirect to webclient/img_details/7/?images=7,8,9 and open the multiple images
 - Select a Well in webclient and in the right panel Open with > iviewer. This will redirect to show all the images in the well as in previous test above