### PR TITLE
Fix settings.md link to master branch. Move iviewer redirect settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ https://omero-guides.readthedocs.io/en/latest/iviewer/docs/index.html
 Settings
 ========
 
-See the `OMERO.iviewer settings <https://github.com/ome/omero-iviewer/blob/settings_docs/docs/settings.md>`_
+See the `OMERO.iviewer settings <https://github.com/ome/omero-iviewer/blob/master/docs/settings.md>`_
 for details on how to configure various settings.
 
 Known issues

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -71,3 +71,19 @@ settings if you want to increase the limit.
     $ omero config set omero.web.iviewer.roi_page_size 1000
 
     $ omero config set omero.web.api.max_limit 1000
+
+
+Redirect iviewer URLs
+---------------------
+
+If you want to redirect ``/iviewer/`` URLs to instead use ``/webclient/img_detail/ID`` so
+that a different viewer configured at ``omero.web.viewer.view`` is used then use the 
+config below.
+This will redirect ``/iviewer/?images=12,34`` to ``/webclient/img_detail/12/?images=12,34``,
+``/iviewer/?roi=56`` to ``/webclient/img_detail/IMAGE_ID/?roi=56`` (same for shape)
+and ``/iviewer/?well=78`` to ``/webclient/img_detail/IMAGE_ID/?images=ID1,ID2,...``
+where ID1, ID2, etc are the images in the well.
+
+::
+
+    $ omero config set omero.web.iviewer.redirect_iviewer True

--- a/plugin/omero_iviewer/README.rst
+++ b/plugin/omero_iviewer/README.rst
@@ -51,19 +51,14 @@ To enable the "open with" feature:
       {"supported_objects":["images", "dataset", "well"],
        "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
-If you want to redirect ``/iviewer/`` URLs to instead use ``/webclient/img_detail/ID`` so
-that a different viewer configured at ``omero.web.viewer.view`` is used then use the 
-config below.
-This will redirect ``/iviewer/?images=12,34`` to ``/webclient/img_detail/12/?images=12,34``,
-``/iviewer/?roi=56`` to ``/webclient/img_detail/IMAGE_ID/?roi=56`` (same for shape)
-and ``/iviewer/?well=78`` to ``/webclient/img_detail/IMAGE_ID/?images=ID1,ID2,...``
-where ID1, ID2, etc are the images in the well.
-
-::
-
-    $ omero config set omero.web.iviewer.redirect_iviewer True
-
 Now restart OMERO.web as normal.
+
+
+Settings
+========
+
+See the `OMERO.iviewer settings <https://github.com/ome/omero-iviewer/blob/master/docs/settings.md>`_
+for details on how to configure other settings.
 
 
 Usage


### PR DESCRIPTION
I realised the link under https://github.com/ome/omero-iviewer#settings is not working.

Also added the same link on the `plugin/omero_iviewer/README.rst` page after install instructions and moved the `iviewer redirect` info from here into the settings page (since I'd forgotten about the settings page when I added that).

