### PR TITLE
Only add channel to tile request string if active

### DIFF
--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -280,22 +280,20 @@ const OmeroImage = function(options) {
 
             // maps parameter (incl. inverted)
             var maps = [];
-            // add channel param
-            url += 'c=';
+            var channels = [];
+
             var channelsLength = this.channels_info_.length;
             for (var c=0; c<channelsLength;c++) {
+                let ch = "";
                 var channelInfo = this.channels_info_[c];
+
+                // We ONLY include active channels in URL parameters to reduce query length
                 if (!channelInfo['active']) continue;
 
-                if (url[url.length - 1] !== '=') {
-                    // add a comma to separate channels
-                    url += ',';
-                }
-
                 // amend url with channel info
-                url += (!channelInfo['active'] ? "-" : "") + (c + 1);
-                url += "|" + channelInfo['start'] + ":" + channelInfo['end'];
-                url += "$" + channelInfo['color']; // color info
+                ch += (!channelInfo['active'] ? "-" : "") + (c + 1);
+                ch += "|" + channelInfo['start'] + ":" + channelInfo['end'];
+                ch += "$" + channelInfo['color']; // color info
 
                 var m = {};
                 m["inverted"] = { "enabled" :
@@ -320,8 +318,10 @@ const OmeroImage = function(options) {
                             m["quantization"]["coefficient"] = channelInfo['coefficient'];
                         }
                 }
+                channels.push(ch);
                 maps.push(m);
             }
+            url += "c=" + channels.join(",");
             url += "&maps=" + JSON.stringify(maps);
             url += '&m=' + this.image_model_;
             url += '&p=' + this.image_projection_;

--- a/src/viewers/viewer/source/Image.js
+++ b/src/viewers/viewer/source/Image.js
@@ -285,7 +285,12 @@ const OmeroImage = function(options) {
             var channelsLength = this.channels_info_.length;
             for (var c=0; c<channelsLength;c++) {
                 var channelInfo = this.channels_info_[c];
-                if (c != 0) url += ',';
+                if (!channelInfo['active']) continue;
+
+                if (url[url.length - 1] !== '=') {
+                    // add a comma to separate channels
+                    url += ',';
+                }
 
                 // amend url with channel info
                 url += (!channelInfo['active'] ? "-" : "") + (c + 1);
@@ -293,29 +298,27 @@ const OmeroImage = function(options) {
                 url += "$" + channelInfo['color']; // color info
 
                 var m = {};
-                if (channelInfo['active']) {
-                    m["inverted"] = { "enabled" :
-                        typeof channelInfo['inverted'] === 'boolean' &&
-                            channelInfo['inverted']
-                    }
+                m["inverted"] = { "enabled" :
+                    typeof channelInfo['inverted'] === 'boolean' &&
+                        channelInfo['inverted']
+                }
 
-                    // Only need to include family if different from default
-                    var family = channelInfo['family'];
-                    var family_not_default = (family !== "linear" ||
-                                              (family === "linear" && this.saved_channels_info_[c]["family"] !== "linear"));
-                    if (typeof family === 'string' &&
-                        family !== "" &&
-                        family_not_default &&
-                        typeof channelInfo['coefficient'] === 'number' &&
-                        !isNaN(channelInfo['coefficient'])) {
-                            m["quantization"] = {
-                                "family": family,
-                            };
-                            // Only need coefficient if family is not 'linear' or 'logarithmic'
-                            if (family !== 'linear' && family !== 'logarithmic') {
-                                m["quantization"]["coefficient"] = channelInfo['coefficient'];
-                            }
-                    }
+                // Only need to include family if different from default
+                var family = channelInfo['family'];
+                var family_not_default = (family !== "linear" ||
+                                            (family === "linear" && this.saved_channels_info_[c]["family"] !== "linear"));
+                if (typeof family === 'string' &&
+                    family !== "" &&
+                    family_not_default &&
+                    typeof channelInfo['coefficient'] === 'number' &&
+                    !isNaN(channelInfo['coefficient'])) {
+                        m["quantization"] = {
+                            "family": family,
+                        };
+                        // Only need coefficient if family is not 'linear' or 'logarithmic'
+                        if (family !== 'linear' && family !== 'logarithmic') {
+                            m["quantization"]["coefficient"] = channelInfo['coefficient'];
+                        }
                 }
                 maps.push(m);
             }


### PR DESCRIPTION
Fixes https://github.com/ome/omero-iviewer/issues/542

We previously reduced the length of query strings in ome/omero-web#201, but given images with even more channels (148 channel example in issue above), we need to reduce the length further by only including active channels.

To test, import an image (such as the sample image from issue) and check that the URLs for tiles only include active channels.

This has been imported at https://merge-ci.openmicroscopy.org/web/webclient/img_detail/1378/?dataset=871

Without this PR, the image loading fails:

 
<img width="1228" height="789" alt="Screenshot 2026-07-29 at 18 34 18" src="https://github.com/user-attachments/assets/cae5dbf1-f57e-46c3-a7d5-e59547dfdaae" />


The URL for loading the image tile is 

```
https://merge-ci.openmicroscopy.org/web/webgateway/render_image/1378/0/0/?c=1|0:14221$FF0000,2|0:2251$00FF00,3|0:9582$0000FF,-4|0:990$FFE000,-5|0:1129$00E0E0,-6|0:4299$FF00E0,-7|0:465$FFCC00,-8|0:566$00FFEE,-9|0:361$FF00EE,-10|0:829$CCFF00,-11|0:9344$0CA6F2,-12|0:1058$F20C87,-13|0:16687$68F20C,-14|0:2174$0C49F2,-15|0:1193$F20C2B,-16|0:4000$0CF20C,-17|0:12174$2B0CF2,-18|0:12976$F2490C,-19|0:405$0CF268,-20|0:2836$870CF2,-21|0:1666$E6A117,-22|0:1629$17E6BC,-23|0:7562$D817E6,-24|0:2398$D8E617,-25|0:9615$17BCE6,-26|0:18084$E617A1,-27|0:4037$85E617,-28|0:2557$176AE6,-29|0:1575$E6174E,-30|0:1582$32E617,-31|0:623$2121D9,-32|0:1015$D93921,-33|0:33654$21D952,-34|0:352$6A21D9,-35|0:1003$D98321,-36|0:1395$21D99B,-37|0:3528$B421D9,-38|0:1774$D9CC21,-39|0:5628$21CCD9,-40|0:1977$D921B4,-41|0:1564$96CC29,-42|0:1393$2980CC,-43|0:8149$CC296A,-44|0:195$54CC29,-45|0:1677$293FCC,-46|0:147$CC2929,-47|0:1163$29CC3F,-48|0:2422$5429CC,-49|0:5954$CC6A29,-50|0:628$29CC80,-51|0:414$8F30BF,-52|0:3952$BFA330,-53|0:391$30BFB6,-54|0:1313$BF30B6,-55|0:2554$A3BF30,-56|0:2040$308FBF,-57|0:2117$BF307C,-58|0:1182$69BF30,-59|0:4086$3056BF,-60|0:1592$BF3043,-61|0:4038$36B336,-62|0:5303$4636B3,-63|0:1146$B35736,-64|0:3071$36B368,-65|0:8628$7836B3,-66|0:1300$B38936,-67|0:6083$36B39A,-68|0:16942$AA36B3,-69|0:431$AAB336,-70|0:1241$369AB3,-71|0:13087$A63A82,-72|0:3177$73A63A,-73|0:1794$3A65A6,-74|0:4256$A63A57,-75|0:1245$48A63A,-76|0:1234$3A3AA6,-77|2:5504$A6483A,-78|0:1393$3AA657,-79|0:1579$653AA6,-80|0:1329$A6733A,-81|0:1634$3D997A,-82|0:1334$873D99,-83|0:320$99933D,-84|0:3136$3D9399,-85|0:1581$993D87,-86|0:3494$7A993D,-87|0:1925$3D6E99,-88|0:4765$993D62,-89|0:4914$56993D,-90|0:3846$3D4999,-91|0:3916$8C3F3F,-92|0:13909$3F8C49,-93|0:1977$543F8C,-94|0:6656$8C5E3F,-95|0:4390$3F8C68,-96|0:587$733F8C,-97|0:7977$8C7D3F,-98|0:394$3F8C87,-99|0:1788$8C3F87,-100|1:14836$7D8C3F,-101|0:922$406A80,-102|0:679$804062,-103|0:5720$598040,-104|0:654$405180,-105|0:2315$804048,-106|0:10271$408040,-107|0:408$484080,-108|0:1191$805140,-109|0:2424$408059,-110|0:664$624080,-111|0:3917$73623F,-112|0:4214$3F7368,-113|0:2011$6F3F73,-114|0:4770$6F733F,-115|0:2825$3F6873,-116|0:1339$733F62,-117|0:2343$5B733F,-118|0:1857$3F5473,-119|0:3317$733F4D,-120|0:991$46733F,-121|0:5497$3D3D66,-122|0:8689$66433D,-123|0:766$3D6648,-124|0:4075$4E3D66,-125|0:860$66533D,-126|4:2213$3D6658,-127|0:8845$5E3D66,-128|0:3224$66633D,-129|0:5093$3D6366,-130|0:18167$663D5E,-131|0:4256$4F593A,-132|0:980$3A4B59,-133|0:11543$593A47,-134|0:1764$42593A,-135|0:5103$3A3E59,-136|26:4659$593A3A,-137|0:802$3A593E,-138|4:4299$423A59,-139|0:6106$59473A,-140|0:652$3A594B,-141|0:3523$45364D,-142|0:9250$4D4836,-143|0:699$364D4B,-144|0:4327$4D364B,-145|0:963$484D36,-146|0:2853$36454D,-147|0:2955$4D3642,-148|0:1640$3F4D36,-149|0:5906$363C4D,-150|0:386$4D3639,-151|0:8842$304030,-152|0:2804$323040,-153|0:1973$403430,-154|0:1806$304036,-155|0:736$383040,-156|0:2099$403A30,-157|0:4719$30403D,-158|0:15962$3F3040,-159|0:2803$3F4030,-160|0:2160$303D40,-161|0:7200$332930,-162|0:1356$2E3329,-163|0:2429$292D33,-164|0:62870$33292C,-165|0:3296$2A3329,-166|0:6599$292933,-167|0:2272$332A29,-168|0:1769$29332C,-169|0:5316$2D2933,-170|0:4833$332E29,-171|0:1407$212624,-172|0:5235$252126,-173|0:2001$262621,-174|0:2820$212626,-175|0:4457$262125,-176|0:2767$242621,-177|0:25279$212426,-178|0:2594$262123,-179|0:10737$222621,-180|0:3795$212126,-181|0:3059$1A1717,-182|0:11316$171A17,-183|0:7733$18171A,-184|0:1039$1A1817&maps=[{%22inverted%22:{%22enabled%22:false}},{%22inverted%22:{%22enabled%22:false}},{%22inverted%22:{%22enabled%22:false}},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]&m=g&p=normal&q=0.9
```
And the response is:
```
Request Line is too large (4111 > 4094)
```