### PR TITLE
Use POST data for saveImgRdef params

### DIFF
--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -330,17 +330,18 @@ export default class ImageConfig extends History {
         let url =
             this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
             "/saveImgRDef/" +
-            image_info.image_id + '/?m=' + image_info.model[0] +
+            image_info.image_id + '/';
+        let data = "m=" + image_info.model[0] +
             "&p=" + image_info.projection +
             "&t=" + (image_info.dimensions.t+1) +
             "&z=" + (image_info.dimensions.z+1) +
             "&q=0.9&ia=0";
-        url = Misc.appendChannelsAndMapsToQueryString(image_info.channels, url);
+        data = Misc.appendChannelsAndMapsToQueryString(image_info.channels, data);
 
         if (typeof error !== 'function')
             error = (error) => console.error(error);
         $.ajax({
-            'url': url, 'method': 'POST',
+            'url': url, 'method': 'POST', 'data': data,
             'success': success, 'error': error
         });
     }


### PR DESCRIPTION
Fixes #545.

NB: this requires https://github.com/ome/omero-web/pull/683
Once that is in and released, we need to bump `install_requires=['omero-web>=5.7.0'],` for iviewer.

To test, as for https://github.com/ome/omero-web/pull/683
 - save rdef changes to an image with LOTs of channels (e.g. > 50) e.g. image from https://zenodo.org/records/20824472?token=eyJhbGciOiJIUzUxMiJ9.eyJpZCI6ImZhZTBkMWNkLWQxZWItNDUyOC1hM2FhLTc1NjQzMzNmMmQ2MiIsImRhdGEiOnt9LCJyYW5kb20iOiI5NGFhZTE3NTlkMWY2ZDY0MWJlNmQzYmQ4M2E5NWViZCJ9.ekmmLZ2Hi6PYVwBqRsw8r9_ZhIKRUf0qdQZDghcSWln1PmrXTR0xSFrPzM4zsbNHW0KiRGr77PB3Nj-PNJCAow
