### PR TITLE
Keyboard select roi

### DIFF
--- a/src/app/context.js
+++ b/src/app/context.js
@@ -593,22 +593,22 @@ export default class Context {
                 if (typeof keyHandlers === 'undefined' ||
                     event.target.nodeName.toUpperCase() === 'INPUT') return;
 
-                // we allow the browser's default action and event
-                // bubbling unless one handler returns false
-                let allowDefaultAndPropagation = true;
+                // sort to put "global" last - give other groups (tabs) a chance to handle first
+                let keys = Object.keys(keyHandlers).sort((x, y) => x === 'global' ? 1 : -1);
                 try {
-                    for (let a in keyHandlers) {
+                    for (let a of keys) {
                         let action = keyHandlers[a];
                         if (action['ctrl'] && !event[command]) continue;
-                        if (!((action['action'])(event)))
-                            allowDefaultAndPropagation = false;
+                        let result = (action['action'])(event);
+                        // we allow the browser's default action and event
+                        // bubbling unless one handler returns false
+                        if (result === false) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            return false;
+                        }
                     }
                 } catch(ignored) {}
-                if (!allowDefaultAndPropagation) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    return false;
-                }
             };
     }
 

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -62,7 +62,9 @@ export default class RegionsEdit extends EventSubscriber {
         { key: 'V', func: this.pasteShapes },                     // ctrl - v
         { key: 'Delete', func: this.deleteShapes, ctrl: false},   // DELETE
         { key: 'Del', func: this.deleteShapes, ctrl: false},      // DEL IE
-        { key: 'Backspace', func: this.deleteShapes, ctrl: false} // DEL MAC
+        { key: 'Backspace', func: this.deleteShapes, ctrl: false}, // DEL MAC
+        { key: 'ArrowDown', func: this.nextShape, ctrl: false},
+        { key: 'ArrowUp', func: this.prevShape, ctrl: false},
     ];
 
     /**
@@ -973,5 +975,49 @@ export default class RegionsEdit extends EventSubscriber {
      */
     deleteShapes() {
         this.regions_info.deleteShapes();
+    }
+
+    /**
+     * Selects the previous shape
+     *
+     * @memberof RegionsEdit
+     */
+    prevShape() {
+        return this.incrementShape(-1);
+    }
+
+    /**
+     * Selects the next shape
+     *
+     * @memberof RegionsEdit
+     */
+    nextShape() {
+        return this.incrementShape(1);
+    }
+
+    /**
+     * Selects the next or previous shape depending on the increment
+     *
+     * @memberof RegionsEdit
+     */
+    incrementShape(increment) {
+        if (!this.regions_info.ready) return;
+        if (this.regions_info.selected_shapes.length == 0) {
+            // No ROIs selected. No action taken. Allow event to bubble up...
+            return true;
+        }
+        let currentIds = this.regions_info.selected_shapes;
+        let lastSelected = currentIds[currentIds.length - 1];
+        let currentIndex = this.regions_info.getAllShapeIds().indexOf(lastSelected);
+        let count = this.regions_info.getAllShapeIds().length;
+        let nextIndex = (currentIndex + increment + count) % count;
+        let nextId = this.regions_info.getAllShapeIds()[nextIndex];
+        this.context.publish(
+           REGIONS_SET_PROPERTY, {
+               config_id: this.regions_info.image_info.config_id,
+               property: 'selected',
+               shapes : [nextId], clear: true,
+               value : true, center : true});
+        return false;
     }
 }

--- a/src/regions/regions-edit.js
+++ b/src/regions/regions-edit.js
@@ -982,8 +982,8 @@ export default class RegionsEdit extends EventSubscriber {
      *
      * @memberof RegionsEdit
      */
-    prevShape() {
-        return this.incrementShape(-1);
+    prevShape(event) {
+        return this.incrementShape(event, -1);
     }
 
     /**
@@ -991,8 +991,8 @@ export default class RegionsEdit extends EventSubscriber {
      *
      * @memberof RegionsEdit
      */
-    nextShape() {
-        return this.incrementShape(1);
+    nextShape(event) {
+        return this.incrementShape(event, 1);
     }
 
     /**
@@ -1000,7 +1000,11 @@ export default class RegionsEdit extends EventSubscriber {
      *
      * @memberof RegionsEdit
      */
-    incrementShape(increment) {
+    incrementShape(event, increment) {
+        // Z/T slider handle has focus and will handle the event; we ignore it
+        if (event?.target?.className.includes("ui-slider-handle")) {
+            return;
+        }
         if (!this.regions_info.ready) return;
         if (this.regions_info.selected_shapes.length == 0) {
             // No ROIs selected. No action taken. Allow event to bubble up...

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -316,18 +316,25 @@ export default class Ui {
                     (event) => {
                         let command =
                             Misc.isApple() ? 'metaKey' : 'ctrlKey';
+                            // if the "group" (tab) is set and we're NOT on that tab,
+                            // return true to allow other handlers to handle the event...
                             if (context.selected_config === null ||
                                 (group !== 'global' &&
                                 context.selected_tab !== group) ||
                                 ((typeof action.ctrl !== 'boolean' ||
                                   action.ctrl) && !event[command])) return true;
                             try {
-                                action.func.apply(scope, action.args);
+                                // pass the event as first argument, followed by any additional args provided in the action object
+                                // return the result, allows stopPropagation if false
+                                return action.func.apply(scope, [event].concat(action.args));
                             } catch(err) {
                                 console.error("Key Handler failed: " + err);
                             }
-                            return false;
-                }, group, action.ctrl));
+                    },
+                    group,
+                    action.ctrl
+                )
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes #561 

To test:

 - Select an ROI and use Up/Down Arrow keys to select prev/next ROI
 - If the ROIs tab is not selected, or NO ROIs are selected, the Up/Down arrows will instead cause the Image to Pan as usual
 - Left/Right keys still do only image panning


Video below shows:
 - Use of Arrow keys for panning
 - Drawing ROIs: since NO ROIs are selected, Arrow keys continue to work for panning while drawing ROIs
 - ROIs saved and ROI selected: Now, Up/Down Arrows change ROI selection (and image pans to selected ROIs)



https://github.com/user-attachments/assets/bf73b15e-9ae8-4479-8c9c-d9110414ecbc

