### PR TITLE
Use POST data for imgRdef save

### DIFF
--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -118,7 +118,7 @@ setup(name="omero-iviewer",
       url="https://github.com/ome/omero-iviewer/",
       download_url='https://github.com/ome/omero-iviewer/archive/v%s.tar.gz' % version,  # NOQA
       keywords=['OMERO.web', 'plugin'],
-      install_requires=['omero-web>=5.7.0'],
+      install_requires=['omero-web>=5.33.0'],
       python_requires='>=3',
       include_package_data=True,
       zip_safe=False,

--- a/src/model/image_config.js
+++ b/src/model/image_config.js
@@ -329,18 +329,19 @@ export default class ImageConfig extends History {
         let image_info = this.image_info;
         let url =
             this.context.server + this.context.getPrefixedURI(WEBGATEWAY) +
-            "/saveImgRDef/" +
-            image_info.image_id + '/?m=' + image_info.model[0] +
+            `/saveImgRDef/${image_info.image_id}/`;
+        let query = 'm=' + image_info.model[0] +
             "&p=" + image_info.projection +
             "&t=" + (image_info.dimensions.t+1) +
             "&z=" + (image_info.dimensions.z+1) +
             "&q=0.9&ia=0";
-        url = Misc.appendChannelsAndMapsToQueryString(image_info.channels, url);
+        query = Misc.appendChannelsAndMapsToQueryString(image_info.channels, query);
 
         if (typeof error !== 'function')
             error = (error) => console.error(error);
         $.ajax({
             'url': url, 'method': 'POST',
+            'data': query, 'dataType': 'json',
             'success': success, 'error': error
         });
     }


### PR DESCRIPTION
Fixes #545.

This relies on https://github.com/ome/omero-web/pull/683/ (released in https://github.com/ome/omero-web/releases/tag/v5.33.0) for the `views.py` endpoint POST handling and adds the equivalent JavaScript changes for iviewer.

To test, follow instructions in https://github.com/ome/omero-web/pull/683/ and test Save settings in iviewer.
Sample image available at [zenodo](https://zenodo.org/records/20824472?token=eyJhbGciOiJIUzUxMiJ9.eyJpZCI6ImZhZTBkMWNkLWQxZWItNDUyOC1hM2FhLTc1NjQzMzNmMmQ2MiIsImRhdGEiOnt9LCJyYW5kb20iOiI5NGFhZTE3NTlkMWY2ZDY0MWJlNmQzYmQ4M2E5NWViZCJ9.ekmmLZ2Hi6PYVwBqRsw8r9_ZhIKRUf0qdQZDghcSWln1PmrXTR0xSFrPzM4zsbNHW0KiRGr77PB3Nj-PNJCAow) already imported at https://merge-ci.openmicroscopy.org/web/webclient/img_detail/1378/
 - Edit rendering settings - Save (can use dev tools Network tab to "see" that the settings are POST payload (below) and that the URL itself is short (doesn't include the rendering settings)
 - Refresh iviewer page to check that settings have been saved

<img width="1399" height="1160" alt="Screenshot 2026-08-25 at 11 24 03" src="https://github.com/user-attachments/assets/dcba11fa-1029-4a66-ac00-aa73802d5765" />

